### PR TITLE
Feature/GitHub issue creation rule

### DIFF
--- a/.cursor/rules/github-issue-creation.mdc
+++ b/.cursor/rules/github-issue-creation.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description: When creating a new github issue
 globs: 
 alwaysApply: false
 ---


### PR DESCRIPTION
when asking the agent to create an issue, it tend to default to trying to create an issue on sirkitree/prompt_library instead of Lullabot/prompt_library - this rule helps it know right away where it should be trying to create issues.