### PR TITLE
Issue #47: Adding Tugboat config.

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -13,8 +13,8 @@ services:
         - echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
         - apt-get update
         - apt-get install -yq nodejs
-        # Set the webroot to the Gatsby public folder
-        - ln -snf "${TUGBOAT_ROOT}/public" "${DOCROOT}"
+        # Set the webroot to the Eleventy output directory (_site)
+        - ln -snf "${TUGBOAT_ROOT}/_site" "${DOCROOT}"
       update:
         # Install dependencies
         - npm install


### PR DESCRIPTION
This pull request introduces a new Tugboat configuration file to enable PR preview environments, visual diffs, and Lighthouse audits. The configuration sets up an Apache service with commands for initializing, updating, and building a static Gatsby site, and defines key URLs for testing.

### Tugboat configuration for PR previews:
* Added `.tugboat/config.yml` to configure PR preview environments, visual diffs, and Lighthouse audits. This includes:
  - Setting up an Apache service using the `tugboatqa/httpd:latest` image.
  - Commands for initializing the environment (e.g., installing Node.js 18 and setting the webroot to the Gatsby public folder).
  - Commands for updating dependencies (`npm install`) and building the Gatsby site (`npm run build`).
  - Defined key URLs for testing, such as `/`, `/development/prompts/ai-code-review/`, and `/help/`.