### PR TITLE
Issue #63: Fixing contrast of text in dark mode.

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1109,4 +1109,17 @@ pre code {
 .discipline-card.discipline-empty h2 {
     /* Optionally style the title differently */
     opacity: 0.7;
+}
+
+:root.dark-theme h2,
+:root.dark-theme .content-list > div h2,
+:root.dark-theme .content-item h2,
+:root.dark-theme .content-card h2 {
+    color: #ffffff;
+}
+
+:root.dark-theme .description,
+:root.dark-theme .content-type-header .description {
+    color: #e0e7ef;
+    opacity: 1;
 } 


### PR DESCRIPTION
---
name: "Pull Request"
about: "Submit a pull request to Noko-LSM"
---

## Issue Reference
Closes #63

## Description of Changes
This pull request introduces new styling rules for dark theme support in the `assets/css/styles.css` file. The changes ensure proper text color adjustments for headers and descriptions when the dark theme is active.

### Dark Theme Styling Additions:
* Added specific CSS rules under `:root.dark-theme` to style `h2` elements in various contexts (`h2`, `.content-list > div h2`, `.content-item h2`, `.content-card h2`) with a white color (`#ffffff`).
* Updated the `.description` and `.content-type-header .description` elements to use a light color (`#e0e7ef`) with full opacity when the dark theme is enabled.

## Testing Instructions
1. List steps to test the changes
2. Include any setup or configuration required
3. Note any edge cases to consider

## Screenshots (if applicable)
BEFORE
![localhost_8080_development_resources_drupal-and-ddev-links_](https://github.com/user-attachments/assets/8a2d56d2-1d7c-4ad6-96a3-de4f14a07f8c)


AFTER
![localhost_8080_development_resources_drupal-and-ddev-links_ (1)](https://github.com/user-attachments/assets/4dabf6ab-46e0-40fb-a595-180cdabca4c2)



## Checklist for Reviewers
- [ ] Code follows project best practices
- [ ] All tests pass locally
- [ ] Documentation is updated as needed
- [ ] Configuration changes (if any) are exported and committed
- [ ] Update hooks or data migrations are included (if needed)
- [ ] No sensitive data or credentials are committed
- [ ] PR description is clear and complete

## Additional Notes
Add any other information for reviewers here. 