### PR TITLE
fix(templates): Replace Noko-LSM references with prompt library

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: "🐛 Bug report"
-about: "Report a bug to help us improve Noko-LSM"
+about: "Report a bug to help us improve the prompt library"
 title: "[Bug] <short description>"
 labels: [bug]
 ---
@@ -23,7 +23,7 @@ What actually happened?
 ## Environment
 - OS:
 - Browser:
-- Noko-LSM version:
+- Prompt library version:
 - Any relevant configuration (e.g., custom modules, config changes):
 
 ## Screenshots

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 General Question
-    url: https://github.com/lullabot/noko-lsm/discussions
+    url: https://github.com/Lullabot/prompt_library/discussions
     about: Ask a question or start a discussion 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: "✨ Feature request"
-about: "Suggest a new feature or enhancement for Noko-LSM"
+about: "Suggest a new feature or enhancement for the prompt library"
 title: "[Feature] <short description>"
 labels: [enhancement]
 ---

--- a/.github/ISSUE_TEMPLATE/performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/performance_issue.md
@@ -1,6 +1,6 @@
 ---
 name: "🚀 Performance issue"
-about: "Report a performance problem or bottleneck in Noko-LSM"
+about: "Report a performance problem or bottleneck in the prompt library"
 title: "[Performance] <short description>"
 labels: [performance]
 ---
@@ -25,7 +25,7 @@ Describe what actually happened, including any metrics or measurements if availa
 ## Environment
 - OS:
 - Browser:
-- Noko-LSM version:
+- Prompt library version:
 - Data size (if relevant):
 
 ## Proposed Solution

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 name: "Pull Request"
-about: "Submit a pull request to Noko-LSM"
+about: "Submit a pull request to the prompt library"
 ---
 
 ## Issue Reference

--- a/llms.txt
+++ b/llms.txt
@@ -4357,7 +4357,7 @@ size: 961 bytes
 <markdown>
 ---
 name: "Pull Request"
-about: "Submit a pull request to Noko-LSM"
+about: "Submit a pull request to the prompt library"
 ---
 
 ## Issue Reference
@@ -4735,7 +4735,7 @@ size: 757 bytes
 <markdown>
 ---
 name: "✨ Feature request"
-about: "Suggest a new feature or enhancement for Noko-LSM"
+about: "Suggest a new feature or enhancement for the prompt library"
 title: "[Feature] <short description>"
 labels: [enhancement]
 ---
@@ -4771,7 +4771,7 @@ size: 849 bytes
 <markdown>
 ---
 name: "🐛 Bug report"
-about: "Report a bug to help us improve Noko-LSM"
+about: "Report a bug to help us improve the prompt library"
 title: "[Bug] <short description>"
 labels: [bug]
 ---
@@ -4794,7 +4794,7 @@ What actually happened?
 ## Environment
 - OS:
 - Browser:
-- Noko-LSM version:
+- Prompt library version:
 - Any relevant configuration (e.g., custom modules, config changes):
 
 ## Screenshots
@@ -4917,7 +4917,7 @@ size: 1072 bytes
 <markdown>
 ---
 name: "🚀 Performance issue"
-about: "Report a performance problem or bottleneck in Noko-LSM"
+about: "Report a performance problem or bottleneck in the prompt library"
 title: "[Performance] <short description>"
 labels: [performance]
 ---
@@ -4942,7 +4942,7 @@ Describe what actually happened, including any metrics or measurements if availa
 ## Environment
 - OS:
 - Browser:
-- Noko-LSM version:
+- Prompt library version:
 - Data size (if relevant):
 
 ## Proposed Solution
@@ -4969,7 +4969,7 @@ size: 181 bytes
 blank_issues_enabled: false
 contact_links:
   - name: 💬 General Question
-    url: https://github.com/lullabot/noko-lsm/discussions
+    url: https://github.com/Lullabot/prompt_library/discussions
     about: Ask a question or start a discussion 
 </content>
 


### PR DESCRIPTION
## Issue Reference
Fixes #76

## Description of Changes
Updated GitHub issue templates and configuration to replace outdated "Noko-LSM" project references with "prompt library":

- Updated bug_report.md "about" field and environment section
- Updated feature_request.md "about" field  
- Updated performance_issue.md "about" field and environment section
- Updated PULL_REQUEST_TEMPLATE.md "about" field
- Updated config.yml discussion URL to point to correct repository
- Updated corresponding entries in llms.txt file

These changes ensure that GitHub issue templates display the correct project name and link to the appropriate discussion forum.

## Testing Instructions
1. Navigate to GitHub Issues page
2. Click "New Issue" 
3. Select any of the issue templates (Bug report, Feature request, Performance issue)
4. Verify the template descriptions now reference "prompt library" instead of "Noko-LSM"
5. Check that environment sections ask for "Prompt library version:" instead of "Noko-LSM version:"
6. Verify the "General Question" link in config points to the correct discussions forum

## Screenshots
Before: Templates referenced "Noko-LSM" (as shown in issue #76)
After: Templates now correctly reference "prompt library"

## Checklist for Reviewers
- [x] Code follows project best practices
- [x] All tests pass locally (static site generation)
- [x] Documentation is updated as needed (llms.txt file updated)
- [x] Configuration changes properly implemented
- [x] No sensitive data or credentials are committed
- [x] PR description is clear and complete

## Additional Notes
- Verified no remaining "Noko" references exist in the codebase
- All changes are backward compatible
- Changes only affect template descriptions and URLs, no functional impact
