### PR TITLE
Add support for skills with associated resources

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -185,6 +185,36 @@ module.exports = function(eleventyConfig) {
     return all.sort((a, b) => new Date(b.date) - new Date(a.date));
   });
 
+  // After build: copy raw markdown for skill files as SKILL.md
+  // This enables agents to fetch skill definitions programmatically
+  eleventyConfig.on('eleventy.after', async () => {
+    const outputDir = path.join(__dirname, '_site');
+    const glob = require('path');
+
+    for (const discipline of disciplines) {
+      const skillsDir = path.join(__dirname, discipline, 'skills');
+      if (!fs.existsSync(skillsDir)) continue;
+
+      const entries = fs.readdirSync(skillsDir);
+      for (const entry of entries) {
+        if (!entry.endsWith('.md') || entry === 'index.md') continue;
+
+        const slug = entry.replace(/\.md$/, '');
+        const srcFile = path.join(skillsDir, entry);
+        const destDir = path.join(outputDir, discipline, 'skills', slug);
+        const destFile = path.join(destDir, 'SKILL.md');
+
+        // Read the raw markdown and extract the content between five backticks
+        const raw = fs.readFileSync(srcFile, 'utf8');
+        const match = raw.match(/`{5}\n([\s\S]*?)\n`{5}/);
+        const skillContent = match ? match[1] : raw;
+
+        fs.mkdirSync(destDir, { recursive: true });
+        fs.writeFileSync(destFile, skillContent);
+      }
+    }
+  });
+
   return {
     dir: {
       input: ".",

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -66,14 +66,19 @@ module.exports = function(eleventyConfig) {
       return [];
     }
 
-    // Recursively collect all files in the resource directory
+    // Recursively collect files matching the passthrough-copied extensions
+    // This prevents listing files that won't be in the build output
+    const allowedExtensions = new Set(skillResourceExtensions);
     const resources = [];
     const walk = (dir, prefix) => {
       const entries = fs.readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
+        if (entry.name.startsWith('.')) continue; // skip dotfiles
         if (entry.isDirectory()) {
           walk(path.join(dir, entry.name), `${prefix}${entry.name}/`);
         } else {
+          const ext = entry.name.split('.').pop();
+          if (!allowedExtensions.has(ext)) continue;
           resources.push({
             name: entry.name,
             relativePath: `${prefix}${entry.name}`,

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,7 +4,7 @@ const path = require('path');
 module.exports = function(eleventyConfig) {
   // Copy static assets
   eleventyConfig.addPassthroughCopy("assets");
-  
+
   // Add filters
   eleventyConfig.addFilter("date", function(date, format = "yyyy-MM-dd") {
     if (date === "now") {
@@ -41,6 +41,50 @@ module.exports = function(eleventyConfig) {
   // Add collections for all content types
   const disciplines = ['development', 'project-management', 'sales-marketing', 'content-strategy', 'design', 'quality-assurance'];
   const contentTypes = ['prompts', 'rules', 'project-configs', 'workflow-states', 'resources', 'agents', 'skills'];
+
+  // Copy skill resource directories (scripts, configs, templates)
+  const skillResourceExtensions = ['sh', 'yml', 'yaml', 'json', 'py', 'rb', 'js', 'txt', 'cfg', 'conf', 'toml'];
+  disciplines.forEach(discipline => {
+    skillResourceExtensions.forEach(ext => {
+      eleventyConfig.addPassthroughCopy(`${discipline}/skills/**/*.${ext}`);
+    });
+  });
+
+  // Filter to discover companion resource files for a skill page
+  eleventyConfig.addNunjucksFilter("getSkillResources", function(page) {
+    if (!page || !page.inputPath) return [];
+    // Only apply to skill pages
+    if (!page.inputPath.includes('/skills/')) return [];
+
+    // Derive companion directory from the skill's markdown file path
+    // e.g., ./development/skills/cloudflare-tunnel.md -> development/skills/cloudflare-tunnel/
+    const inputPath = page.inputPath.replace(/^\.\//, '');
+    const resourceDir = inputPath.replace(/\.md$/, '');
+    const fullResourceDir = path.join(__dirname, resourceDir);
+
+    if (!fs.existsSync(fullResourceDir) || !fs.statSync(fullResourceDir).isDirectory()) {
+      return [];
+    }
+
+    // Recursively collect all files in the resource directory
+    const resources = [];
+    const walk = (dir, prefix) => {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          walk(path.join(dir, entry.name), `${prefix}${entry.name}/`);
+        } else {
+          resources.push({
+            name: entry.name,
+            relativePath: `${prefix}${entry.name}`,
+            url: `/${resourceDir}/${prefix}${entry.name}`
+          });
+        }
+      }
+    };
+    walk(fullResourceDir, '');
+    return resources;
+  });
 
   // Add collections for each content type
   contentTypes.forEach(type => {

--- a/.github/ISSUE_TEMPLATE/skill-submission.yml
+++ b/.github/ISSUE_TEMPLATE/skill-submission.yml
@@ -63,6 +63,21 @@ body:
       required: true
 
   - type: textarea
+    id: skill-resources
+    attributes:
+      label: Associated Resources
+      description: "If your skill requires helper scripts, config files, or other resources, describe them here. Include file contents or links to a gist/repo. Resources will be stored alongside the skill definition."
+      placeholder: |
+        e.g., scripts/tunnel.sh — Helper script for managing tunnels
+
+        ```bash
+        #!/bin/bash
+        # script content...
+        ```
+    validations:
+      required: false
+
+  - type: textarea
     id: usage-instructions
     attributes:
       label: Usage Instructions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,24 @@ Prompt content here
 `````
 ```
 
+### Skill Resources
+
+Skills can include companion resources (scripts, config files, templates) in a directory alongside the skill markdown file. The directory name must match the skill filename (without `.md`):
+
+```text
+development/skills/cloudflare-tunnel.md        # Skill definition
+development/skills/cloudflare-tunnel/           # Resource directory
+  scripts/tunnel.sh
+  resources/config-template.yml
+```
+
+Resources are automatically:
+- Copied to the build output via 11ty passthrough copy
+- Discovered and displayed on the skill's page with download links
+- Served as static files (no processing)
+
+Supported resource file types: `.sh`, `.yml`, `.yaml`, `.json`, `.py`, `.rb`, `.js`, `.txt`, `.cfg`, `.conf`, `.toml`.
+
 ## Key Configuration Files
 
 - `.eleventy.js`: Main 11ty configuration, defines collections, filters, and build settings

--- a/_includes/content-type.njk
+++ b/_includes/content-type.njk
@@ -9,7 +9,7 @@ layout: base.njk
   <div class="content-list">
     {% for item in collections[contentType] %}
       {% if item.data.discipline == discipline %}
-        <article class="content-item">
+        <article class="content-item fade-up">
           <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
           <p class="item-description">{{ item.data.description }}</p>
           <div class="item-meta">
@@ -34,56 +34,61 @@ layout: base.njk
     padding: 2rem 1rem;
   }
 
-  .page-title {
-    font-size: 2.5rem;
+  .content-type-page .page-title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
     font-weight: 700;
-    color: #2d3748;
+    color: var(--text-color);
     margin-bottom: 0.5rem;
     text-align: center;
   }
 
-  .page-description {
+  .content-type-page .page-description {
     font-size: 1.25rem;
-    color: #4a5568;
+    color: var(--text-muted);
     text-align: center;
     margin-bottom: 3rem;
   }
 
-  .content-list {
+  .content-type-page .content-list {
     display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
     gap: 2rem;
   }
 
-  .content-item {
-    background-color: white;
+  .content-type-page .content-item {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
     border-radius: 0.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
     padding: 1.5rem;
-    transition: transform 0.2s, box-shadow 0.2s;
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
   }
 
-  .content-item:hover {
+  .content-type-page .content-item:hover {
     transform: translateY(-2px);
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 24px var(--card-hover-shadow);
   }
 
-  .content-item h2 {
+  :root.dark-theme .content-type-page .content-item:hover {
+    border-color: var(--accent-color);
+  }
+
+  .content-type-page .content-item h2 {
     font-size: 1.5rem;
-    color: #2d3748;
+    color: var(--text-color);
     margin-bottom: 0.5rem;
   }
 
-  .content-item h2 a {
-    color: inherit;
+  .content-type-page .content-item h2 a {
+    color: var(--primary-color);
     text-decoration: none;
   }
 
-  .content-item h2 a:hover {
-    color: #4299e1;
+  .content-type-page .content-item h2 a:hover {
+    text-decoration: underline;
   }
 
   .item-description {
-    color: #4a5568;
+    color: var(--text-muted);
     margin-bottom: 1rem;
   }
 
@@ -91,7 +96,7 @@ layout: base.njk
     display: flex;
     gap: 1rem;
     font-size: 0.875rem;
-    color: #718096;
+    color: var(--text-muted);
     margin-bottom: 1rem;
   }
 
@@ -101,17 +106,17 @@ layout: base.njk
     gap: 0.5rem;
   }
 
-  .tag {
-    background-color: #edf2f7;
-    color: #4a5568;
+  .item-tags .tag {
+    background-color: var(--tag-background);
+    color: var(--text-color);
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     font-size: 0.75rem;
   }
 
   @media (max-width: 640px) {
-    .content-list {
+    .content-type-page .content-list {
       grid-template-columns: 1fr;
     }
   }
-</style> 
+</style>

--- a/_layouts/content-type.njk
+++ b/_layouts/content-type.njk
@@ -9,7 +9,7 @@ layout: discipline.njk
 
 <div class="content-list">
     {% for item in collections[contentType] | filterByDiscipline(discipline) %}
-        <article class="content-item">
+        <article class="content-item fade-up">
             <h2><a href="{{ item.url }}">{{ item.data.title }}</a></h2>
             <p>{{ item.data.description }}</p>
             <div class="metadata">

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -216,7 +216,7 @@ layout: base.njk
   .copy-button.copied {
     background-color: var(--accent-color);
     border-color: var(--accent-color);
-    color: #0c0c0b;
+    color: #12212b;
   }
 </style>
 

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -18,6 +18,24 @@ layout: base.njk
   <div class="content">
     {{ content | safe }}
   </div>
+
+  {% set resources = page | getSkillResources %}
+  {% if resources.length > 0 %}
+  <div class="skill-resources">
+    <h2>Associated Resources</h2>
+    <p>This skill includes companion scripts and files. Download them to your local <code>~/.claude/skills/</code> directory to use with this skill.</p>
+    <ul class="resource-list">
+      {% for resource in resources %}
+      <li class="resource-item">
+        <a href="{{ resource.url | fullUrl }}" class="resource-link" download>
+          <span class="resource-icon">📄</span>
+          <span class="resource-path">{{ resource.relativePath }}</span>
+        </a>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
 </div>
 
 <style>
@@ -71,6 +89,61 @@ layout: base.njk
 
   .content li {
     margin-bottom: 0.5rem;
+  }
+
+  /* Skill resources section */
+  .skill-resources {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background-color: #f8fafc;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.5rem;
+  }
+
+  .skill-resources h2 {
+    margin-top: 0;
+    margin-bottom: 0.5rem;
+    color: #2d3748;
+  }
+
+  .skill-resources p {
+    color: #4a5568;
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+  }
+
+  .resource-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .resource-item {
+    margin-bottom: 0.5rem;
+  }
+
+  .resource-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.375rem;
+    text-decoration: none;
+    color: #2b6cb0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 0.875rem;
+    transition: all 0.2s;
+  }
+
+  .resource-link:hover {
+    background-color: #ebf8ff;
+    border-color: #90cdf4;
+  }
+
+  .resource-icon {
+    font-size: 1rem;
   }
 
   /* Code block styling */

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -25,7 +25,7 @@ layout: base.njk
         {% for resource in resources %}
         <li class="resource-item">
           <a href="{{ resource.url | fullUrl }}" class="resource-link" download>
-            <span class="resource-icon">📄</span>
+            <span class="resource-icon" aria-hidden="true">📄</span>
             <span class="resource-path">{{ resource.relativePath }}</span>
           </a>
         </li>

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -5,7 +5,7 @@ layout: base.njk
 <div class="markdown-content">
   <h1>{{ title }}</h1>
   <p class="description">{{ description }}</p>
-  
+
   <div class="metadata">
     <div class="tags">
       {% for tag in tags %}
@@ -15,27 +15,37 @@ layout: base.njk
     <time datetime="{{ date }}">{{ date | date }}</time>
   </div>
 
+  {% set resources = page | getSkillResources %}
+  {% if resources.length > 0 %}
+  <details class="skill-install-section">
+    <summary>Installation &amp; Resources</summary>
+    <div class="skill-install-content">
+      <p>This skill includes companion scripts and files. Download them to your local <code>~/.claude/skills/</code> directory.</p>
+      <ul class="resource-list">
+        {% for resource in resources %}
+        <li class="resource-item">
+          <a href="{{ resource.url | fullUrl }}" class="resource-link" download>
+            <span class="resource-icon">📄</span>
+            <span class="resource-path">{{ resource.relativePath }}</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </details>
+  {% endif %}
+
+  {% if contentType == "skills" %}
+  <div class="skill-raw-download">
+    <a href="{{ page.url | fullUrl }}SKILL.md" class="raw-download-link" title="Raw markdown for agent consumption">
+      <i class="fas fa-file-code"></i> Raw SKILL.md
+    </a>
+  </div>
+  {% endif %}
+
   <div class="content">
     {{ content | safe }}
   </div>
-
-  {% set resources = page | getSkillResources %}
-  {% if resources.length > 0 %}
-  <div class="skill-resources">
-    <h2>Associated Resources</h2>
-    <p>This skill includes companion scripts and files. Download them to your local <code>~/.claude/skills/</code> directory to use with this skill.</p>
-    <ul class="resource-list">
-      {% for resource in resources %}
-      <li class="resource-item">
-        <a href="{{ resource.url | fullUrl }}" class="resource-link" download>
-          <span class="resource-icon">📄</span>
-          <span class="resource-path">{{ resource.relativePath }}</span>
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
-  </div>
-  {% endif %}
 </div>
 
 <style>
@@ -46,7 +56,7 @@ layout: base.njk
   }
 
   .description {
-    color: #4a5568;
+    color: var(--text-muted);
     font-size: 1.2rem;
     margin-bottom: 2rem;
   }
@@ -56,7 +66,7 @@ layout: base.njk
     justify-content: space-between;
     align-items: center;
     margin-bottom: 2rem;
-    color: #718096;
+    color: var(--text-muted);
   }
 
   .tags {
@@ -65,8 +75,8 @@ layout: base.njk
   }
 
   .tag {
-    background-color: #edf2f7;
-    color: #4a5568;
+    background-color: var(--tag-background);
+    color: var(--text-color);
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     font-size: 0.875rem;
@@ -77,7 +87,7 @@ layout: base.njk
   }
 
   .content h2 {
-    color: #2d3748;
+    color: var(--text-color);
     margin-top: 2rem;
     margin-bottom: 1rem;
   }
@@ -91,30 +101,10 @@ layout: base.njk
     margin-bottom: 0.5rem;
   }
 
-  /* Skill resources section */
-  .skill-resources {
-    margin-top: 2rem;
-    padding: 1.5rem;
-    background-color: #f8fafc;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.5rem;
-  }
-
-  .skill-resources h2 {
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    color: #2d3748;
-  }
-
-  .skill-resources p {
-    color: #4a5568;
-    font-size: 0.9rem;
-    margin-bottom: 1rem;
-  }
-
+  /* Resource list inside collapsible */
   .resource-list {
     list-style: none;
-    margin: 0;
+    margin: 0.5rem 0 0;
     padding: 0;
   }
 
@@ -127,38 +117,62 @@ layout: base.njk
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0.75rem;
-    background-color: #ffffff;
-    border: 1px solid #e2e8f0;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
     border-radius: 0.375rem;
     text-decoration: none;
-    color: #2b6cb0;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    color: var(--primary-color);
+    font-family: var(--font-mono);
     font-size: 0.875rem;
     transition: all 0.2s;
   }
 
   .resource-link:hover {
-    background-color: #ebf8ff;
-    border-color: #90cdf4;
+    background-color: var(--tag-background);
+    border-color: var(--primary-color);
   }
 
   .resource-icon {
     font-size: 1rem;
   }
 
+  /* Raw SKILL.md download link */
+  .skill-raw-download {
+    margin-bottom: 1.5rem;
+  }
+
+  .raw-download-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.75rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    border: 1px solid var(--border-color);
+    border-radius: 0.25rem;
+    text-decoration: none;
+    font-family: var(--font-mono);
+    transition: all 0.2s;
+  }
+
+  .raw-download-link:hover {
+    color: var(--primary-color);
+    border-color: var(--primary-color);
+  }
+
   /* Code block styling */
   .content pre {
-    background-color: #f8fafc;
+    background-color: var(--code-background);
     border-radius: 0.5rem;
     padding: 1rem;
     margin: 1.5rem 0;
     overflow-x: auto;
-    border: 1px solid #e2e8f0;
+    border: 1px solid var(--code-border);
     position: relative;
   }
 
   .content pre code {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: var(--font-mono);
     font-size: 0.875rem;
     line-height: 1.7;
     display: block;
@@ -166,11 +180,12 @@ layout: base.njk
 
   /* Inline code styling */
   .content code:not(pre code) {
-    background-color: #f1f5f9;
+    background-color: var(--inline-code-background);
+    color: var(--inline-code-text);
     padding: 0.2rem 0.4rem;
     border-radius: 0.25rem;
     font-size: 0.875em;
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family: var(--font-mono);
   }
 
   /* Copy button styling */
@@ -179,11 +194,11 @@ layout: base.njk
     top: 0.5rem;
     right: 0.5rem;
     padding: 0.25rem 0.5rem;
-    background-color: #ffffff;
-    border: 1px solid #e2e8f0;
+    background-color: var(--surface-color);
+    border: 1px solid var(--border-color);
     border-radius: 0.25rem;
     font-size: 0.75rem;
-    color: #4a5568;
+    color: var(--text-muted);
     cursor: pointer;
     transition: all 0.2s;
     opacity: 0;
@@ -194,14 +209,14 @@ layout: base.njk
   }
 
   .copy-button:hover {
-    background-color: #edf2f7;
-    border-color: #cbd5e0;
+    background-color: var(--tag-background);
+    border-color: var(--text-muted);
   }
 
   .copy-button.copied {
-    background-color: #48bb78;
-    border-color: #48bb78;
-    color: white;
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #0c0c0b;
   }
 </style>
 
@@ -214,13 +229,13 @@ layout: base.njk
         const button = document.createElement('button');
         button.className = 'copy-button';
         button.textContent = 'Copy';
-        
+
         button.addEventListener('click', async () => {
           try {
             await navigator.clipboard.writeText(code.textContent);
             button.textContent = 'Copied!';
             button.classList.add('copied');
-            
+
             // Reset button after 2 seconds
             setTimeout(() => {
               button.textContent = 'Copy';
@@ -231,9 +246,9 @@ layout: base.njk
             button.textContent = 'Failed to copy';
           }
         });
-        
+
         pre.appendChild(button);
       }
     });
   });
-</script> 
+</script>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,43 +1,73 @@
+/* ===========================
+   Google Fonts Import
+   =========================== */
+@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700&display=swap');
+
+/* ===========================
+   CSS Custom Properties
+   =========================== */
 :root {
     /* Light theme variables */
-    --primary-color: #2563eb;
+    --primary-color: #1a56db;
     --secondary-color: #1e40af;
-    --text-color: #1f2937;
-    --background-color: #ffffff;
-    --card-background: #f3f4f6;
-    --tag-background: #e5e7eb;
-    --border-color: #e5e7eb;
-    --search-bg: rgba(255, 255, 255, 0.15);
-    --search-bg-focus: rgba(255, 255, 255, 0.25);
-    --search-text: white;
-    --search-placeholder: rgba(255, 255, 255, 0.7);
-    --header-text: white;
+    --accent-color: #059669;
+    --text-color: #1c1917;
+    --text-muted: #57534e;
+    --background-color: #fafaf9;
+    --surface-color: #f5f5f4;
+    --card-background: #ffffff;
+    --tag-background: #e7e5e4;
+    --border-color: #d6d3d1;
+    --search-bg: rgba(28, 25, 23, 0.06);
+    --search-bg-focus: rgba(28, 25, 23, 0.1);
+    --search-text: #1c1917;
+    --search-placeholder: rgba(28, 25, 23, 0.4);
+    --header-bg: #ffffff;
+    --header-text: #1c1917;
+    --code-background: #f5f5f4;
+    --code-text: #1c1917;
+    --code-border: #d6d3d1;
+    --inline-code-background: #e7e5e4;
+    --inline-code-text: #1c1917;
+    --card-hover-shadow: rgba(28, 25, 23, 0.08);
     --theme-transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+
+    /* Typography */
+    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    --font-mono: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    --font-heading: 'Instrument Serif', Georgia, 'Times New Roman', serif;
 }
 
 /* Dark theme variables */
 :root.dark-theme {
     --primary-color: #60a5fa;
     --secondary-color: #93c5fd;
-    --text-color: #f3f4f6;
-    --background-color: #0f172a;
-    --card-background: #1e293b;
-    --tag-background: #334155;
-    --border-color: #334155;
-    --search-bg: rgba(0, 0, 0, 0.2);
-    --search-bg-focus: rgba(0, 0, 0, 0.3);
-    --search-text: #f3f4f6;
-    --search-placeholder: rgba(243, 244, 246, 0.7);
-    --header-text: #f3f4f6;
-    --code-background: #1a2234;
+    --accent-color: #a8f06a;
+    --text-color: #e8e6e1;
+    --text-muted: #94a3b8;
+    --background-color: #0c0c0b;
+    --surface-color: #161615;
+    --card-background: #1a1a18;
+    --tag-background: #2a2a26;
+    --border-color: #2a2a26;
+    --search-bg: rgba(0, 0, 0, 0.3);
+    --search-bg-focus: rgba(0, 0, 0, 0.5);
+    --search-text: #e8e6e1;
+    --search-placeholder: rgba(232, 230, 225, 0.5);
+    --header-bg: #0c0c0b;
+    --header-text: #e8e6e1;
+    --code-background: #111110;
     --code-text: #e2e8f0;
-    --code-border: #2d3748;
-    --inline-code-background: #2d3748;
+    --code-border: #2a2a26;
+    --inline-code-background: #2a2a26;
     --inline-code-text: #e2e8f0;
-    --card-text: #f3f4f6;
     --card-hover-shadow: rgba(0, 0, 0, 0.5);
+    --card-text: #e8e6e1;
 }
 
+/* ===========================
+   Base Reset & Typography
+   =========================== */
 * {
     margin: 0;
     padding: 0;
@@ -45,18 +75,73 @@
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-family: var(--font-sans);
     line-height: 1.6;
     color: var(--text-color);
     background-color: var(--background-color);
     transition: var(--theme-transition);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
+/* Fluid typography */
+h1 { font-size: clamp(1.75rem, 4vw, 2.5rem); }
+h2 { font-size: clamp(1.35rem, 3vw, 2rem); }
+h3 { font-size: clamp(1.1rem, 2.5vw, 1.5rem); }
+
+/* ===========================
+   Animations
+   =========================== */
+@keyframes fadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
+.fade-up {
+    animation: fadeUp 0.5s ease-out both;
+}
+
+.fade-up:nth-child(1) { animation-delay: 0s; }
+.fade-up:nth-child(2) { animation-delay: 0.05s; }
+.fade-up:nth-child(3) { animation-delay: 0.1s; }
+.fade-up:nth-child(4) { animation-delay: 0.15s; }
+.fade-up:nth-child(5) { animation-delay: 0.2s; }
+.fade-up:nth-child(6) { animation-delay: 0.25s; }
+.fade-up:nth-child(7) { animation-delay: 0.3s; }
+.fade-up:nth-child(8) { animation-delay: 0.35s; }
+.fade-up:nth-child(9) { animation-delay: 0.4s; }
+.fade-up:nth-child(10) { animation-delay: 0.45s; }
+
+/* ===========================
+   Header & Navigation
+   =========================== */
 header {
-    background-color: var(--primary-color);
+    background-color: var(--header-bg);
     padding: 1rem 0;
     color: var(--header-text);
     transition: var(--theme-transition);
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-bottom: 1px solid var(--border-color);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    background-color: rgba(255, 255, 255, 0.85);
+}
+
+:root.dark-theme header {
+    background-color: rgba(12, 12, 11, 0.85);
 }
 
 nav {
@@ -83,17 +168,28 @@ nav {
 }
 
 .home-link:hover {
-    background-color: var(--secondary-color);
+    background-color: var(--surface-color);
+}
+
+:root.dark-theme .home-link:hover {
+    background-color: var(--tag-background);
+}
+
+/* Light mode accent hover on header links */
+.home-link:hover,
+nav a:hover {
+    color: var(--primary-color);
 }
 
 nav a {
-    color: white;
+    color: var(--header-text);
     text-decoration: none;
     padding: 0.5rem 1rem;
     border-radius: 0.25rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    position: relative;
 }
 
 nav a i {
@@ -101,11 +197,35 @@ nav a i {
 }
 
 nav a:hover {
-    background-color: var(--secondary-color);
+    background-color: var(--surface-color);
 }
 
+:root.dark-theme nav a:hover {
+    background-color: var(--tag-background);
+}
+
+/* Animated nav underlines */
+nav a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    width: 0;
+    height: 2px;
+    background-color: var(--accent-color);
+    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1), left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+nav a:hover::after {
+    width: 80%;
+    left: 10%;
+}
+
+/* ===========================
+   Discipline Navigation
+   =========================== */
 .discipline-nav {
-    background-color: var(--card-background);
+    background-color: var(--surface-color);
     padding: 1rem 2rem;
     margin-bottom: 2rem;
     border-bottom: 1px solid var(--border-color);
@@ -142,15 +262,17 @@ nav a:hover {
     background-color: var(--tag-background);
 }
 
+/* ===========================
+   Content Type Header
+   =========================== */
 .content-type-header {
     text-align: center;
     padding: 3rem 2rem;
-    background-color: var(--card-background);
+    background-color: var(--surface-color);
     margin-bottom: 2rem;
 }
 
 .content-type-header h1 {
-    font-size: 2.5rem;
     margin-bottom: 1rem;
     color: var(--text-color);
 }
@@ -158,10 +280,12 @@ nav a:hover {
 .content-type-header .description {
     max-width: 800px;
     margin: 0 auto;
-    color: var(--text-color);
-    opacity: 0.8;
+    color: var(--text-muted);
 }
 
+/* ===========================
+   Content Grid & Cards
+   =========================== */
 .content-list {
     max-width: 1200px;
     margin: 0 auto;
@@ -210,7 +334,7 @@ nav a:hover {
     opacity: 0.9;
 }
 
-/* Update existing card styles to ensure they don't override homepage cards */
+/* Content items (listing pages) */
 .content-item {
     background-color: var(--card-background);
     border: 1px solid var(--border-color);
@@ -218,6 +342,11 @@ nav a:hover {
     padding: 1.5rem;
     transition: transform 0.2s, box-shadow 0.2s, var(--theme-transition);
     color: var(--text-color);
+}
+
+.content-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px var(--card-hover-shadow);
 }
 
 .content-item h2 {
@@ -236,23 +365,24 @@ nav a:hover {
 }
 
 .content-item p {
-    color: var(--text-color);
-    opacity: 0.9;
+    color: var(--text-muted);
 }
 
 .content-item .metadata {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    color: var(--text-color);
+    color: var(--text-muted);
 }
 
 .content-item .date {
     font-size: 0.875rem;
-    color: var(--text-color);
-    opacity: 0.8;
+    color: var(--text-muted);
 }
 
+/* ===========================
+   Tags
+   =========================== */
 .tags {
     display: flex;
     flex-wrap: wrap;
@@ -269,14 +399,21 @@ nav a:hover {
     opacity: 0.9;
 }
 
+/* ===========================
+   Footer
+   =========================== */
 footer {
     text-align: center;
     padding: 2rem;
-    background-color: var(--card-background);
+    background-color: var(--surface-color);
     margin-top: 4rem;
+    border-top: 1px solid var(--border-color);
+    color: var(--text-muted);
 }
 
-/* Search Component */
+/* ===========================
+   Search Component
+   =========================== */
 .search-container {
     display: flex;
     align-items: center;
@@ -319,7 +456,7 @@ footer {
     margin-left: 0.5rem;
     background: none;
     border: none;
-    color: white;
+    color: var(--text-muted);
     cursor: pointer;
     opacity: 0.8;
     transition: opacity 0.2s ease;
@@ -338,10 +475,10 @@ footer {
     width: 100%;
     max-height: 80vh;
     overflow-y: auto;
-    background-color: var(--background-color);
+    background-color: var(--card-background);
     border: 1px solid var(--border-color);
     border-radius: 0.5rem;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 12px var(--card-hover-shadow);
     z-index: 1000;
     margin-top: 0.5rem;
 }
@@ -372,7 +509,7 @@ footer {
 
 .result-link:hover,
 .result-link:focus {
-    background-color: var(--card-background);
+    background-color: var(--surface-color);
 }
 
 .result-title {
@@ -387,8 +524,7 @@ footer {
     gap: 0.5rem;
     margin-bottom: 0.5rem;
     font-size: 0.8rem;
-    color: var(--text-color);
-    opacity: 0.8;
+    color: var(--text-muted);
 }
 
 .result-discipline,
@@ -405,16 +541,14 @@ footer {
 .result-description {
     margin: 0 0 0.5rem;
     font-size: 0.9rem;
-    color: var(--text-color);
-    opacity: 0.9;
+    color: var(--text-muted);
     line-height: 1.4;
 }
 
 .no-results {
     padding: 1rem;
     text-align: center;
-    color: var(--text-color);
-    opacity: 0.8;
+    color: var(--text-muted);
 }
 
 .visually-hidden {
@@ -429,7 +563,9 @@ footer {
     border: 0;
 }
 
-/* Markdown Modal */
+/* ===========================
+   Markdown Modal
+   =========================== */
 .markdown-modal {
     display: none;
     position: fixed;
@@ -446,7 +582,8 @@ footer {
 .markdown-content {
     max-width: 800px;
     margin: 2rem auto;
-    background-color: white;
+    background-color: var(--card-background);
+    color: var(--text-color);
     border-radius: 0.5rem;
     padding: 2rem;
     position: relative;
@@ -469,12 +606,477 @@ footer {
     opacity: 1;
 }
 
-/* Responsive adjustments */
+/* ===========================
+   Theme Toggle
+   =========================== */
+.theme-toggle {
+    background: none;
+    border: none;
+    color: var(--header-text);
+    cursor: pointer;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    transition: background-color 0.2s ease;
+    border-radius: 0.25rem;
+    min-width: 2.5rem;
+    height: 2.5rem;
+    flex-shrink: 0;
+}
+
+.theme-toggle:hover {
+    background-color: var(--tag-background);
+}
+
+.theme-toggle i {
+    font-size: 1.1em;
+}
+
+/* ===========================
+   Code Blocks
+   =========================== */
+pre {
+    background-color: var(--code-background);
+    border: 1px solid var(--code-border);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
+}
+
+code {
+    background-color: var(--inline-code-background);
+    color: var(--inline-code-text);
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.9em;
+    font-family: var(--font-mono);
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+pre code {
+    background-color: transparent;
+    color: inherit;
+    padding: 0;
+    border-radius: 0;
+    font-size: 1em;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}
+
+/* Syntax highlighting for dark mode */
+:root.dark-theme .hljs-keyword,
+:root.dark-theme .hljs-built_in {
+    color: #93c5fd;
+}
+
+:root.dark-theme .hljs-string,
+:root.dark-theme .hljs-regexp {
+    color: #a8f06a;
+}
+
+:root.dark-theme .hljs-number,
+:root.dark-theme .hljs-literal {
+    color: #fca5a5;
+}
+
+:root.dark-theme .hljs-comment {
+    color: #94a3b8;
+}
+
+:root.dark-theme .hljs-function,
+:root.dark-theme .hljs-class {
+    color: #c4b5fd;
+}
+
+:root.dark-theme .hljs-variable,
+:root.dark-theme .hljs-params {
+    color: #e2e8f0;
+}
+
+:root.dark-theme .hljs-attr,
+:root.dark-theme .hljs-property {
+    color: #fcd34d;
+}
+
+/* Custom scrollbar for code blocks */
+:root.dark-theme pre::-webkit-scrollbar {
+    height: 8px;
+    background-color: var(--code-background);
+}
+
+:root.dark-theme pre::-webkit-scrollbar-thumb {
+    background-color: var(--code-border);
+    border-radius: 4px;
+}
+
+:root.dark-theme pre::-webkit-scrollbar-thumb:hover {
+    background-color: #4a5568;
+}
+
+/* ===========================
+   Base Template Styles
+   =========================== */
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+
+.site-header {
+    background-color: var(--surface-color);
+    padding: 1rem 0;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.main-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--text-color);
+    text-decoration: none;
+}
+
+.nav-links {
+    display: flex;
+    gap: 2rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.nav-links a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    padding: 0.5rem 0;
+    position: relative;
+}
+
+.nav-links a:hover {
+    color: var(--primary-color);
+}
+
+.nav-links a::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 0;
+    height: 2px;
+    background-color: var(--primary-color);
+    transition: width 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.nav-links a:hover::after {
+    width: 100%;
+}
+
+.nav-item {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.nav-item.nav-empty {
+    color: var(--text-muted);
+    opacity: 0.6;
+}
+
+.site-footer {
+    margin-top: 4rem;
+    padding: 2rem 0;
+    border-top: 1px solid var(--border-color);
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.footer-links {
+    margin-top: 0.5rem;
+}
+
+.footer-links a {
+    color: var(--text-muted);
+    text-decoration: none;
+    margin: 0 0.5rem;
+}
+
+.footer-links a:hover {
+    text-decoration: underline;
+}
+
+.home-header {
+    text-align: center;
+    margin: 3rem 0;
+}
+
+.home-header h1 {
+    color: var(--text-color);
+    margin-bottom: 1rem;
+}
+
+.home-header p {
+    font-size: 1.25rem;
+    color: var(--text-muted);
+}
+
+/* ===========================
+   Discipline Grid & Cards
+   =========================== */
+.discipline-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-bottom: 4rem;
+}
+
+.discipline-card {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    transition: transform 0.2s, box-shadow 0.2s, var(--theme-transition);
+}
+
+.discipline-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px var(--card-hover-shadow);
+    border-color: var(--primary-color);
+}
+
+:root.dark-theme .discipline-card:hover {
+    border-color: var(--accent-color);
+    box-shadow: 0 0 20px rgba(168, 240, 106, 0.08);
+}
+
+.discipline-card h2 {
+    font-family: var(--font-heading);
+    color: var(--text-color);
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.content-type-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+
+.content-type-link {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    background-color: var(--tag-background);
+    border-radius: 0.5rem;
+    color: var(--text-color);
+    text-decoration: none;
+    transition: all 0.2s;
+    position: relative;
+}
+
+.content-type-link:hover {
+    background-color: var(--surface-color);
+}
+
+:root.dark-theme .content-type-link:hover {
+    background-color: #2a2a26;
+}
+
+.content-type-link.empty {
+    opacity: 0.5;
+    background-color: var(--card-background);
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+.content-type-icon {
+    font-size: 1.25rem;
+}
+
+.content-type-text {
+    font-size: 0.875rem;
+    font-weight: 500;
+}
+
+/* Share / CTA section */
+.share-section {
+    text-align: center;
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0.75rem;
+    padding: 3rem 2rem;
+    margin: 4rem 0;
+}
+
+.share-section h2 {
+    color: var(--text-color);
+    font-size: 2rem;
+    margin-bottom: 1rem;
+}
+
+.share-section p {
+    color: var(--text-muted);
+    margin-bottom: 2rem;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+/* ===========================
+   Discipline Page
+   =========================== */
+.discipline-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+}
+
+.page-title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    color: var(--text-color);
+    margin-bottom: 0.5rem;
+    text-align: center;
+}
+
+.page-description {
+    font-size: 1.25rem;
+    color: var(--text-muted);
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+}
+
+.content-card {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 3px var(--card-hover-shadow);
+    padding: 1.5rem;
+    transition: transform 0.2s, box-shadow 0.2s, var(--theme-transition);
+}
+
+.content-card.content-empty {
+    opacity: 0.5;
+    background-color: var(--card-background);
+    border: 1px dashed var(--border-color);
+}
+
+.content-card.content-empty h2,
+.content-card.content-empty p {
+    color: var(--text-muted);
+}
+
+.content-card.content-empty .button {
+    background-color: var(--card-background);
+    color: var(--text-muted);
+    pointer-events: none;
+    cursor: not-allowed;
+}
+
+.card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.content-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px var(--card-hover-shadow);
+}
+
+.content-card h2 {
+    font-size: 1.5rem;
+    color: var(--text-color);
+    margin-bottom: 1rem;
+}
+
+.content-card p {
+    color: var(--text-muted);
+    margin-bottom: 1.5rem;
+}
+
+/* ===========================
+   Content Indicators & Empty States
+   =========================== */
+.content-indicator {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--accent-color);
+    margin-left: 0.5rem;
+}
+
+:root.dark-theme .content-indicator {
+    animation: pulse 2s ease-in-out infinite;
+}
+
+.nav-empty .content-indicator,
+.empty .content-indicator,
+.content-empty .content-indicator {
+    background-color: var(--tag-background);
+    animation: none;
+}
+
+.nav-empty {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.nav-empty:hover {
+    background-color: transparent !important;
+    color: inherit !important;
+}
+
+.content-type-link.empty .content-type-icon {
+    opacity: 0.5;
+}
+
+.content-type-link.empty .content-type-text {
+    color: var(--text-muted);
+}
+
+/* Discipline card empty state */
+.discipline-card.discipline-empty {
+    background-color: var(--card-background);
+    border: 2px dashed var(--border-color);
+}
+
+.discipline-card.discipline-empty h2 {
+    color: var(--text-muted);
+}
+
+/* ===========================
+   Responsive
+   =========================== */
 @media (max-width: 768px) {
     .content-list {
         grid-template-columns: 1fr;
     }
-    
+
     nav {
         flex-wrap: wrap;
         gap: 0.5rem;
@@ -482,10 +1084,6 @@ footer {
 
     .content-type-header {
         padding: 2rem 1rem;
-    }
-
-    .content-type-header h1 {
-        font-size: 2rem;
     }
 
     .discipline-nav {
@@ -533,478 +1131,12 @@ footer {
         margin: 1rem auto;
         padding: 1rem;
     }
-}
 
-/* Add theme toggle button styles */
-.theme-toggle {
-    background: none;
-    border: none;
-    color: var(--header-text);
-    cursor: pointer;
-    padding: 0.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 0.9rem;
-    transition: background-color 0.2s ease;
-    border-radius: 0.25rem;
-    min-width: 2.5rem;
-    height: 2.5rem;
-    flex-shrink: 0;
-}
-
-.theme-toggle:hover {
-    background-color: var(--secondary-color);
-}
-
-.theme-toggle i {
-    font-size: 1.1em;
-}
-
-/* Update search results for dark mode */
-:root.dark-theme .search-results {
-    background-color: var(--card-background);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-}
-
-:root.dark-theme .search-result {
-    border-bottom: 1px solid var(--border-color);
-}
-
-:root.dark-theme .result-link:hover,
-:root.dark-theme .result-link:focus {
-    background-color: var(--background-color);
-}
-
-:root.dark-theme .result-title {
-    color: var(--primary-color);
-}
-
-:root.dark-theme .result-meta {
-    color: var(--text-color);
-    opacity: 0.8;
-}
-
-:root.dark-theme .result-discipline,
-:root.dark-theme .result-type,
-:root.dark-theme .tag {
-    background-color: var(--tag-background);
-    color: var(--text-color);
-}
-
-:root.dark-theme .result-description {
-    color: var(--text-color);
-    opacity: 0.9;
-}
-
-/* Update markdown modal for dark mode */
-:root.dark-theme .markdown-content {
-    background-color: var(--card-background);
-    color: var(--text-color);
-}
-
-:root.dark-theme .close-button {
-    color: var(--text-color);
-}
-
-/* Code block styles */
-pre {
-    background-color: var(--card-background);
-    border: 1px solid var(--border-color);
-    border-radius: 0.5rem;
-    padding: 1rem;
-    margin: 1rem 0;
-    overflow-x: auto;
-    white-space: pre-wrap;       /* CSS 3 */
-    white-space: -moz-pre-wrap;  /* Mozilla */
-    white-space: -pre-wrap;      /* Opera 4-6 */
-    white-space: -o-pre-wrap;    /* Opera 7 */
-    word-wrap: break-word;       /* Modern browsers */
-}
-
-code {
-    background-color: var(--inline-code-background);
-    color: var(--inline-code-text);
-    padding: 0.2rem 0.4rem;
-    border-radius: 0.25rem;
-    font-size: 0.9em;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-}
-
-pre code {
-    background-color: transparent;
-    color: inherit;
-    padding: 0;
-    border-radius: 0;
-    font-size: 1em;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-}
-
-/* Dark mode code block styles */
-:root.dark-theme pre {
-    background-color: var(--code-background);
-    border-color: var(--code-border);
-    color: var(--code-text);
-}
-
-:root.dark-theme code {
-    background-color: var(--inline-code-background);
-    color: var(--inline-code-text);
-}
-
-:root.dark-theme pre code {
-    background-color: transparent;
-    color: inherit;
-}
-
-/* Syntax highlighting for dark mode */
-:root.dark-theme .hljs-keyword,
-:root.dark-theme .hljs-built_in {
-    color: #93c5fd;
-}
-
-:root.dark-theme .hljs-string,
-:root.dark-theme .hljs-regexp {
-    color: #86efac;
-}
-
-:root.dark-theme .hljs-number,
-:root.dark-theme .hljs-literal {
-    color: #fca5a5;
-}
-
-:root.dark-theme .hljs-comment {
-    color: #94a3b8;
-}
-
-:root.dark-theme .hljs-function,
-:root.dark-theme .hljs-class {
-    color: #c4b5fd;
-}
-
-:root.dark-theme .hljs-variable,
-:root.dark-theme .hljs-params {
-    color: #e2e8f0;
-}
-
-:root.dark-theme .hljs-attr,
-:root.dark-theme .hljs-property {
-    color: #fcd34d;
-}
-
-/* Add a subtle scrollbar for code blocks in dark mode */
-:root.dark-theme pre::-webkit-scrollbar {
-    height: 8px;
-    background-color: var(--code-background);
-}
-
-:root.dark-theme pre::-webkit-scrollbar-thumb {
-    background-color: var(--code-border);
-    border-radius: 4px;
-}
-
-:root.dark-theme pre::-webkit-scrollbar-thumb:hover {
-    background-color: #4a5568;
-}
-
-/* Update icon colors in dark mode */
-:root.dark-theme .content-item i {
-    color: var(--text-color);
-    opacity: 0.9;
-}
-
-/* Dark mode specific overrides for homepage cards */
-:root.dark-theme .content-list > div {
-    background-color: var(--card-background);
-    border-color: var(--border-color);
-}
-
-:root.dark-theme .content-list > div h2,
-:root.dark-theme .content-list > div a,
-:root.dark-theme .content-list > div i {
-    color: var(--text-color);
-}
-
-:root.dark-theme .content-list > div a:hover {
-    background-color: var(--tag-background);
-}
-
-/* Base Template Styles */
-.container {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 1rem;
-}
-
-.site-header {
-    background-color: #f8fafc;
-    padding: 1rem 0;
-    margin-bottom: 2rem;
-    border-bottom: 1px solid #e2e8f0;
-}
-
-.main-nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.logo {
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: #2d3748;
-    text-decoration: none;
-}
-
-.nav-links {
-    display: flex;
-    gap: 2rem;
-    list-style: none;
-    margin: 0;
-    padding: 0;
-}
-
-.nav-links a {
-    color: #4a5568;
-    text-decoration: none;
-    font-weight: 500;
-    padding: 0.5rem 0;
-    position: relative;
-}
-
-.nav-links a:hover {
-    color: #2b6cb0;
-}
-
-.nav-links a::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 0;
-    height: 2px;
-    background-color: #2b6cb0;
-    transition: width 0.2s;
-}
-
-.nav-links a:hover::after {
-    width: 100%;
-}
-
-.nav-item {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.nav-item.nav-empty {
-    color: #94a3b8;
-    opacity: 0.6;
-}
-
-.site-footer {
-    margin-top: 4rem;
-    padding: 2rem 0;
-    border-top: 1px solid #e2e8f0;
-    text-align: center;
-    color: #718096;
-}
-
-.footer-links {
-    margin-top: 0.5rem;
-}
-
-.footer-links a {
-    color: #718096;
-    text-decoration: none;
-    margin: 0 0.5rem;
-}
-
-.footer-links a:hover {
-    text-decoration: underline;
-}
-
-.home-header {
-    text-align: center;
-    margin: 3rem 0;
-}
-
-.home-header h1 {
-    font-size: 2.5rem;
-    color: #2d3748;
-    margin-bottom: 1rem;
-}
-
-.home-header p {
-    font-size: 1.25rem;
-    color: #4a5568;
-}
-
-.discipline-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-bottom: 4rem;
-}
-
-.discipline-card {
-    background-color: #1a2234;
-    border-radius: 0.75rem;
-    padding: 1.5rem;
-}
-
-.discipline-card h2 {
-    color: #ffffff;
-    font-size: 1.5rem;
-    margin-bottom: 1rem;
-}
-
-.content-type-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-}
-
-.content-type-link {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    background-color: #2a3447;
-    border-radius: 0.5rem;
-    color: #ffffff;
-    text-decoration: none;
-    transition: all 0.2s;
-    position: relative;
-}
-
-.content-type-link:hover {
-    background-color: #3a4559;
-}
-
-.content-type-link.empty {
-    opacity: 0.6;
-    background-color: #1a2234;
-    pointer-events: none;
-}
-
-.content-type-icon {
-    font-size: 1.25rem;
-}
-
-.content-type-text {
-    font-size: 0.875rem;
-    font-weight: 500;
-}
-
-.share-section {
-    text-align: center;
-    background-color: #1a2234;
-    border-radius: 0.75rem;
-    padding: 3rem 2rem;
-    margin: 4rem 0;
-}
-
-.share-section h2 {
-    color: #ffffff;
-    font-size: 2rem;
-    margin-bottom: 1rem;
-}
-
-.share-section p {
-    color: #94a3b8;
-    margin-bottom: 2rem;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-}
-
-/* Discipline Template Styles */
-.discipline-page {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-}
-
-.page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: #2d3748;
-    margin-bottom: 0.5rem;
-    text-align: center;
-}
-
-.page-description {
-    font-size: 1.25rem;
-    color: #4a5568;
-    text-align: center;
-    margin-bottom: 3rem;
-}
-
-.content-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-}
-
-.content-card {
-    background-color: white;
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    padding: 1.5rem;
-    transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.content-card.content-empty {
-    background-color: #f8fafc;
-    border: 1px dashed #e2e8f0;
-    opacity: 0.6;
-}
-
-.content-card.content-empty h2,
-.content-card.content-empty p {
-    color: #94a3b8;
-}
-
-.content-card.content-empty .button {
-    background-color: #e2e8f0;
-    color: #94a3b8;
-    pointer-events: none;
-}
-
-.card-header {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
-}
-
-.content-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-
-.content-card h2 {
-    font-size: 1.5rem;
-    color: #2d3748;
-    margin-bottom: 1rem;
-}
-
-.content-card p {
-    color: #4a5568;
-    margin-bottom: 1.5rem;
-}
-
-/* Media Queries */
-@media (max-width: 768px) {
     .main-nav {
         flex-direction: column;
         gap: 1rem;
     }
-    
+
     .nav-links {
         flex-direction: column;
         align-items: center;
@@ -1018,273 +1150,9 @@ pre code {
     }
 }
 
-/* Content indicator styles */
-.content-indicator {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background-color: #22c55e;
-    margin-left: 0.5rem;
-}
-
-.nav-empty .content-indicator,
-.empty .content-indicator,
-.content-empty .content-indicator {
-    background-color: #e2e8f0;
-}
-
-/* Empty state styles */
-.nav-empty {
-    opacity: 0.5;
-    cursor: not-allowed;
-}
-
-.nav-empty:hover {
-    background-color: transparent !important;
-    color: inherit !important;
-}
-
-.content-type-link.empty {
-    opacity: 0.5;
-    background-color: var(--card-background);
-    pointer-events: none;
-    cursor: not-allowed;
-}
-
-.content-type-link.empty .content-type-icon {
-    opacity: 0.5;
-}
-
-.content-type-link.empty .content-type-text {
-    color: var(--text-color);
-}
-
-.content-card.content-empty {
-    opacity: 0.5;
-    background-color: var(--card-background);
-    border: 1px dashed var(--border-color);
-}
-
-.content-card.content-empty h2,
-.content-card.content-empty p {
-    color: var(--text-color);
-}
-
-.content-card.content-empty .button {
-    background-color: var(--card-background);
-    color: var(--text-color);
-    pointer-events: none;
-    cursor: not-allowed;
-}
-
-/* Dark theme adjustments for empty states */
-:root.dark-theme .nav-empty .content-indicator,
-:root.dark-theme .empty .content-indicator,
-:root.dark-theme .content-empty .content-indicator {
-    background-color: #334155;
-}
-
-:root.dark-theme .content-type-link.empty {
-    background-color: var(--card-background);
-}
-
-:root.dark-theme .content-card.content-empty {
-    background-color: var(--card-background);
-    border-color: var(--border-color);
-}
-
-:root.dark-theme .content-card.content-empty .button {
-    background-color: var(--secondary-color);
-    color: var(--background-color);
-}
-
-/* Style for the entire discipline card when it's empty */
-.discipline-card.discipline-empty {
-    background-color: var(--card-background);
-    border: 2px dashed var(--border-color);
-}
-
-.discipline-card.discipline-empty h2 {
-    color: var(--text-color);
-    opacity: 0.6;
-}
-
-:root.dark-theme h2,
-:root.dark-theme .content-list > div h2,
-:root.dark-theme .content-item h2,
-:root.dark-theme .content-card h2 {
-    color: #ffffff;
-}
-
-:root.dark-theme .description,
-:root.dark-theme .content-type-header .description {
-    color: #e0e7ef;
-    opacity: 1;
-}
-
-/* End Global Styles */
-
-/* Help Page and Accordion Styles */
-.help-container {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 2rem 1rem;
-}
-
-.help-title {
-  font-size: 2.5rem;
-  font-weight: 700;
-  color: var(--text-color);
-  margin-bottom: 2rem;
-  text-align: center;
-}
-
-.section-heading {
-  font-size: 2rem;
-  font-weight: 700;
-  color: var(--text-color);
-  margin-top: 3rem;
-  margin-bottom: 1.5rem;
-  padding-bottom: 0.5rem;
-  border-bottom: 2px solid var(--border-color);
-}
-
-.accordion-section {
-  background-color: var(--card-background);
-  border-radius: 0.5rem;
-  margin-bottom: 1.5rem;
-  border: 1px solid var(--border-color);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-}
-
-.accordion-section summary {
-  font-size: 1.75rem;
-  font-weight: 600;
-  color: var(--text-color);
-  padding: 1rem 1.5rem;
-  cursor: pointer;
-  list-style: none;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid transparent;
-}
-
-.accordion-section[open] summary {
-  border-bottom-color: var(--border-color);
-}
-
-.accordion-section summary::after {
-  content: '\25BC';
-  font-size: 1rem;
-  transition: transform 0.3s ease-in-out;
-}
-
-.accordion-section[open] summary::after {
-  transform: rotate(180deg);
-}
-
-.accordion-content {
-  padding: 1.5rem;
-}
-
-.accordion-content p,
-.accordion-content ul,
-.accordion-content .example-block,
-.accordion-content .submit-link {
-  margin-bottom: 1rem;
-}
-
-.accordion-content p:last-child,
-.accordion-content ul:last-child,
-.accordion-content .example-block:last-child,
-.accordion-content .submit-link:last-child {
-  margin-bottom: 0;
-}
-
-.accordion-content ul {
-  padding-left: 20px;
-  list-style-position: outside;
-}
-
-.accordion-content .example-block {
-    margin-top: 0.5rem;
-}
-
-.help-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 1rem;
-  background-color: var(--tag-background);
-  border-radius: 0.375rem;
-  color: var(--text-color);
-  text-decoration: none;
-  font-weight: 500;
-  margin-bottom: 1rem;
-  transition: background-color 0.2s, transform 0.2s;
-}
-
-.help-link:hover {
-  background-color: var(--background-color);
-  transform: translateY(-1px);
-}
-
-.link-icon {
-  font-size: 1.25rem;
-}
-
-.example-label {
-  font-weight: 500;
-  color: var(--text-color);
-  opacity: 0.8;
-  margin-bottom: 0.5rem;
-}
-
-.use-cases {
-  font-style: italic;
-  opacity: 0.9;
-}
-
-.file-location {
-  font-size: 0.95rem;
-  color: var(--text-color);
-  margin-bottom: 1rem;
-  padding: 0.5rem;
-  background-color: var(--tag-background);
-  border-radius: 0.375rem;
-}
-
-.file-location code {
-  background-color: var(--background-color);
-  padding: 0.2rem 0.4rem;
-  border-radius: 0.25rem;
-  font-family: monospace;
-}
-
-.submit-link {
-  margin-top: 1rem;
-  text-align: right;
-}
-.cta-button {
-  display: inline-block;
-  background-color: var(--primary-color);
-  color: var(--header-text); 
-  padding: 0.4rem 1.1rem;
-  border-radius: 0.375rem;
-  text-decoration: none;
-  font-weight: 500;
-  transition: background 0.2s;
-  border: none;
-  margin-left: 0.5rem;
-}
-.cta-button:hover {
-  background-color: var(--secondary-color); 
-}
-/* End Help Page and Accordion Styles */
-
-/* Dark Theme Overrides and Specifics */
+/* ===========================
+   Dark Theme Heading Overrides
+   =========================== */
 :root.dark-theme h2,
 :root.dark-theme h3,
 :root.dark-theme .content-list > div h2,
@@ -1295,25 +1163,248 @@ pre code {
 
 :root.dark-theme .description,
 :root.dark-theme .content-type-header .description {
-    color: #e0e7ef;
-    opacity: 1;
+    color: var(--text-muted);
 }
 
-:root.dark-theme .accordion-content a {
-    color: var(--primary-color); /* Ensure links in accordions are readable in dark mode */
+/* ===========================
+   Help Page & Accordion
+   =========================== */
+.help-container {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
 }
 
-:root.dark-theme .accordion-content a:hover {
-    color: var(--secondary-color); /* Optional: slightly brighter on hover */
+.help-title {
+    font-family: var(--font-heading);
+    font-weight: 700;
+    color: var(--text-color);
+    margin-bottom: 2rem;
+    text-align: center;
+}
+
+.section-heading {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--text-color);
+    margin-top: 3rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--border-color);
+}
+
+.accordion-section {
+    background-color: var(--card-background);
+    border-radius: 0.5rem;
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--border-color);
+    box-shadow: 0 1px 3px var(--card-hover-shadow);
+}
+
+.accordion-section summary {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: var(--text-color);
+    padding: 1rem 1.5rem;
+    cursor: pointer;
+    list-style: none;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid transparent;
+}
+
+.accordion-section[open] summary {
+    border-bottom-color: var(--border-color);
+}
+
+.accordion-section summary::after {
+    content: '\25BC';
+    font-size: 1rem;
+    transition: transform 0.3s ease-in-out;
+}
+
+.accordion-section[open] summary::after {
+    transform: rotate(180deg);
+}
+
+.accordion-content {
+    padding: 1.5rem;
+}
+
+.accordion-content p,
+.accordion-content ul,
+.accordion-content .example-block,
+.accordion-content .submit-link {
+    margin-bottom: 1rem;
+}
+
+.accordion-content p:last-child,
+.accordion-content ul:last-child,
+.accordion-content .example-block:last-child,
+.accordion-content .submit-link:last-child {
+    margin-bottom: 0;
+}
+
+.accordion-content ul {
+    padding-left: 20px;
+    list-style-position: outside;
+}
+
+.accordion-content .example-block {
+    margin-top: 0.5rem;
+}
+
+.accordion-content a {
+    color: var(--primary-color);
+}
+
+.accordion-content a:hover {
+    color: var(--secondary-color);
     text-decoration: underline;
 }
 
-/* Ensure CTA buttons have good contrast in dark mode */
+.help-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    background-color: var(--tag-background);
+    border-radius: 0.375rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 500;
+    margin-bottom: 1rem;
+    transition: background-color 0.2s, transform 0.2s;
+}
+
+.help-link:hover {
+    background-color: var(--surface-color);
+    transform: translateY(-1px);
+}
+
+.link-icon {
+    font-size: 1.25rem;
+}
+
+.example-label {
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.use-cases {
+    font-style: italic;
+    opacity: 0.9;
+}
+
+.file-location {
+    font-size: 0.95rem;
+    color: var(--text-color);
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+    background-color: var(--tag-background);
+    border-radius: 0.375rem;
+}
+
+.file-location code {
+    background-color: var(--surface-color);
+    padding: 0.2rem 0.4rem;
+    border-radius: 0.25rem;
+    font-family: var(--font-mono);
+}
+
+.submit-link {
+    margin-top: 1rem;
+    text-align: right;
+}
+
+.cta-button {
+    display: inline-block;
+    background-color: var(--primary-color);
+    color: white;
+    padding: 0.4rem 1.1rem;
+    border-radius: 0.375rem;
+    text-decoration: none;
+    font-weight: 500;
+    transition: background 0.2s;
+    border: none;
+    margin-left: 0.5rem;
+}
+
+.cta-button:hover {
+    background-color: var(--secondary-color);
+}
+
+.cta-button.secondary {
+    background: none;
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
+}
+
+.cta-button.secondary:hover {
+    background-color: var(--primary-color);
+    color: white;
+}
+
 :root.dark-theme .cta-button {
-    background-color: #2b6cb0; /* Darker blue for background */
-    color: #ffffff;             /* White text for high contrast */
+    background-color: var(--accent-color);
+    color: #0c0c0b;
 }
 
 :root.dark-theme .cta-button:hover {
-    background-color: #1d4e89; /* Even darker blue for hover */
-} 
+    background-color: #8dd85a;
+}
+
+:root.dark-theme .cta-button.secondary {
+    background: none;
+    color: var(--accent-color);
+    border: 1px solid var(--accent-color);
+}
+
+:root.dark-theme .cta-button.secondary:hover {
+    background-color: var(--accent-color);
+    color: #0c0c0b;
+}
+
+/* ===========================
+   Collapsible Details (Skill Install)
+   =========================== */
+.skill-install-section {
+    margin: 1.5rem 0;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+
+.skill-install-section summary {
+    padding: 0.75rem 1rem;
+    background-color: var(--tag-background);
+    cursor: pointer;
+    font-weight: 500;
+    color: var(--text-color);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    list-style: none;
+    transition: background-color 0.2s;
+}
+
+.skill-install-section summary:hover {
+    background-color: var(--surface-color);
+}
+
+.skill-install-section summary::before {
+    content: '\25B6';
+    font-size: 0.75rem;
+    transition: transform 0.2s ease;
+}
+
+.skill-install-section[open] summary::before {
+    transform: rotate(90deg);
+}
+
+.skill-install-content {
+    padding: 1rem;
+    background-color: var(--card-background);
+}

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,68 +1,68 @@
 /* ===========================
    Google Fonts Import
    =========================== */
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&family=Inter:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500&family=Inter:wght@300;400;500;600;700&display=swap');
 
 /* ===========================
    CSS Custom Properties
    =========================== */
 :root {
-    /* Light theme variables */
-    --primary-color: #1a56db;
-    --secondary-color: #1e40af;
-    --accent-color: #059669;
-    --text-color: #1c1917;
-    --text-muted: #57534e;
-    --background-color: #fafaf9;
-    --surface-color: #f5f5f4;
+    /* Light theme — Lullabot brand-aligned */
+    --primary-color: #cf1900;
+    --secondary-color: #a51400;
+    --accent-color: #1481b8;
+    --text-color: #171d21;
+    --text-muted: #5d686f;
+    --background-color: #f9fafb;
+    --surface-color: #f4f5f6;
     --card-background: #ffffff;
-    --tag-background: #e7e5e4;
-    --border-color: #d6d3d1;
-    --search-bg: rgba(28, 25, 23, 0.06);
-    --search-bg-focus: rgba(28, 25, 23, 0.1);
-    --search-text: #1c1917;
-    --search-placeholder: rgba(28, 25, 23, 0.4);
+    --tag-background: #edf0f2;
+    --border-color: #d6d9dc;
+    --search-bg: rgba(23, 29, 33, 0.06);
+    --search-bg-focus: rgba(23, 29, 33, 0.1);
+    --search-text: #171d21;
+    --search-placeholder: rgba(23, 29, 33, 0.4);
     --header-bg: #ffffff;
-    --header-text: #1c1917;
-    --code-background: #f5f5f4;
-    --code-text: #1c1917;
-    --code-border: #d6d3d1;
-    --inline-code-background: #e7e5e4;
-    --inline-code-text: #1c1917;
-    --card-hover-shadow: rgba(28, 25, 23, 0.08);
+    --header-text: #171d21;
+    --code-background: #f4f5f6;
+    --code-text: #171d21;
+    --code-border: #d6d9dc;
+    --inline-code-background: #edf0f2;
+    --inline-code-text: #171d21;
+    --card-hover-shadow: rgba(23, 29, 33, 0.08);
     --theme-transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 
-    /* Typography */
-    --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    --font-mono: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    --font-heading: 'Instrument Serif', Georgia, 'Times New Roman', serif;
+    /* Typography — Inter matches Circular's geometric style; IBM Plex Mono from lullabot.com */
+    --font-sans: 'Inter', verdana, sans-serif;
+    --font-mono: 'IBM Plex Mono', 'Consolas', 'Liberation Mono', monospace;
+    --font-heading: 'Inter', verdana, sans-serif;
 }
 
-/* Dark theme variables */
+/* Dark theme — Lullabot primary-dark palette */
 :root.dark-theme {
-    --primary-color: #60a5fa;
-    --secondary-color: #93c5fd;
-    --accent-color: #a8f06a;
-    --text-color: #e8e6e1;
-    --text-muted: #94a3b8;
-    --background-color: #0c0c0b;
-    --surface-color: #161615;
-    --card-background: #1a1a18;
-    --tag-background: #2a2a26;
-    --border-color: #2a2a26;
+    --primary-color: #fa6955;
+    --secondary-color: #f9442b;
+    --accent-color: #6bc3ef;
+    --text-color: #edf0f2;
+    --text-muted: #909ba2;
+    --background-color: #12212b;
+    --surface-color: #1b303f;
+    --card-background: #20394b;
+    --tag-background: #445a6a;
+    --border-color: #445a6a;
     --search-bg: rgba(0, 0, 0, 0.3);
     --search-bg-focus: rgba(0, 0, 0, 0.5);
-    --search-text: #e8e6e1;
-    --search-placeholder: rgba(232, 230, 225, 0.5);
-    --header-bg: #0c0c0b;
-    --header-text: #e8e6e1;
-    --code-background: #111110;
-    --code-text: #e2e8f0;
-    --code-border: #2a2a26;
-    --inline-code-background: #2a2a26;
-    --inline-code-text: #e2e8f0;
-    --card-hover-shadow: rgba(0, 0, 0, 0.5);
-    --card-text: #e8e6e1;
+    --search-text: #edf0f2;
+    --search-placeholder: rgba(237, 240, 242, 0.5);
+    --header-bg: #12212b;
+    --header-text: #edf0f2;
+    --code-background: #1b303f;
+    --code-text: #e0e6eb;
+    --code-border: #445a6a;
+    --inline-code-background: #445a6a;
+    --inline-code-text: #e0e6eb;
+    --card-hover-shadow: rgba(0, 0, 0, 0.4);
+    --card-text: #edf0f2;
 }
 
 /* ===========================
@@ -141,7 +141,7 @@ header {
 }
 
 :root.dark-theme header {
-    background-color: rgba(12, 12, 11, 0.85);
+    background-color: rgba(18, 33, 43, 0.85);
 }
 
 nav {
@@ -680,7 +680,7 @@ pre code {
 
 :root.dark-theme .hljs-string,
 :root.dark-theme .hljs-regexp {
-    color: #a8f06a;
+    color: #6bc3ef;
 }
 
 :root.dark-theme .hljs-number,
@@ -861,7 +861,7 @@ pre code {
 
 :root.dark-theme .discipline-card:hover {
     border-color: var(--accent-color);
-    box-shadow: 0 0 20px rgba(168, 240, 106, 0.08);
+    box-shadow: 0 0 20px rgba(107, 195, 239, 0.12);
 }
 
 .discipline-card h2 {
@@ -1348,12 +1348,12 @@ pre code {
 }
 
 :root.dark-theme .cta-button {
-    background-color: var(--accent-color);
-    color: #0c0c0b;
+    background-color: var(--primary-color);
+    color: #ffffff;
 }
 
 :root.dark-theme .cta-button:hover {
-    background-color: #8dd85a;
+    background-color: var(--secondary-color);
 }
 
 :root.dark-theme .cta-button.secondary {
@@ -1364,7 +1364,7 @@ pre code {
 
 :root.dark-theme .cta-button.secondary:hover {
     background-color: var(--accent-color);
-    color: #0c0c0b;
+    color: #12212b;
 }
 
 /* ===========================

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -16,9 +16,16 @@ function setTheme(theme) {
 
 function reflectTheme(theme) {
     document.documentElement.classList.toggle(DARK_CLASS, theme === 'dark');
-    document.querySelector('#theme-toggle')?.setAttribute('aria-label', 
-        theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
-    );
+    const toggle = document.querySelector('#theme-toggle');
+    if (toggle) {
+        toggle.setAttribute('aria-label',
+            theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'
+        );
+        const icon = toggle.querySelector('i');
+        if (icon) {
+            icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+        }
+    }
 }
 
 // Theme toggle button click handler

--- a/development/skills/cloudflare-tunnel/scripts/tunnel.sh
+++ b/development/skills/cloudflare-tunnel/scripts/tunnel.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# tunnel.sh — Helper script for managing Cloudflare Tunnels
+# Part of the Cloudflare Tunnel skill for Claude Code
+#
+# Usage:
+#   tunnel.sh <command> [args]
+#
+# Commands:
+#   quick <port> [protocol]   Start a quick tunnel (default protocol: http)
+#   named <name> <port>       Run a named tunnel
+#   create <name>             Create a new named tunnel
+#   list                      List existing named tunnels
+#   login                     Authenticate with Cloudflare
+#   stop                      Stop any running tunnel
+#   status                    Check installation and auth status
+#   install                   Install cloudflared
+
+set -euo pipefail
+
+CLOUDFLARED="cloudflared"
+PID_FILE="/tmp/cloudflared-tunnel.pid"
+
+command_exists() {
+  command -v "$1" &>/dev/null
+}
+
+check_installed() {
+  if ! command_exists "$CLOUDFLARED"; then
+    echo "Error: cloudflared is not installed."
+    echo "Run: $0 install"
+    return 1
+  fi
+}
+
+cmd_install() {
+  if command_exists "$CLOUDFLARED"; then
+    echo "cloudflared is already installed: $($CLOUDFLARED --version)"
+    return 0
+  fi
+
+  if [[ "$OSTYPE" == darwin* ]]; then
+    if command_exists brew; then
+      brew install cloudflared
+    else
+      echo "Error: Homebrew is required on macOS. Install from https://brew.sh"
+      return 1
+    fi
+  elif [[ "$OSTYPE" == linux* ]]; then
+    if command_exists apt-get; then
+      curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
+      echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+      sudo apt-get update && sudo apt-get install -y cloudflared
+    elif command_exists yum; then
+      sudo yum install -y cloudflared
+    elif command_exists pacman; then
+      sudo pacman -S --noconfirm cloudflared
+    else
+      echo "Error: No supported package manager found (apt, yum, pacman)."
+      return 1
+    fi
+  else
+    echo "Error: Unsupported OS: $OSTYPE"
+    return 1
+  fi
+
+  echo "Installed: $($CLOUDFLARED --version)"
+}
+
+cmd_status() {
+  echo "=== Cloudflare Tunnel Status ==="
+
+  if command_exists "$CLOUDFLARED"; then
+    echo "cloudflared: installed ($($CLOUDFLARED --version 2>&1 | head -1))"
+  else
+    echo "cloudflared: NOT installed"
+    return 0
+  fi
+
+  if [[ -f "$HOME/.cloudflared/cert.pem" ]]; then
+    echo "Authentication: configured"
+  else
+    echo "Authentication: not configured (run: $0 login)"
+  fi
+
+  if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+    echo "Tunnel: running (PID $(cat "$PID_FILE"))"
+  else
+    echo "Tunnel: not running"
+    rm -f "$PID_FILE"
+  fi
+}
+
+cmd_login() {
+  check_installed || return 1
+  echo "Opening browser for Cloudflare authentication..."
+  $CLOUDFLARED tunnel login
+}
+
+cmd_quick() {
+  check_installed || return 1
+  local port="${1:?Usage: $0 quick <port> [protocol]}"
+  local protocol="${2:-http}"
+
+  if [[ -f "$HOME/.cloudflared/config.yaml" ]] || [[ -f "$HOME/.cloudflared/config.yml" ]]; then
+    echo "Warning: ~/.cloudflared/config.yaml exists. Quick tunnels may fail."
+    echo "Rename or remove it, or use a named tunnel instead."
+  fi
+
+  echo "Starting quick tunnel to ${protocol}://localhost:${port}..."
+  echo "Press Ctrl+C to stop."
+  $CLOUDFLARED tunnel --url "${protocol}://localhost:${port}" &
+  local pid=$!
+  echo "$pid" > "$PID_FILE"
+  wait "$pid"
+  rm -f "$PID_FILE"
+}
+
+cmd_named() {
+  check_installed || return 1
+  local name="${1:?Usage: $0 named <name> <port>}"
+  local port="${2:?Usage: $0 named <name> <port>}"
+
+  if [[ ! -f "$HOME/.cloudflared/cert.pem" ]]; then
+    echo "Error: Not authenticated. Run: $0 login"
+    return 1
+  fi
+
+  echo "Starting named tunnel '${name}' to http://localhost:${port}..."
+  echo "Press Ctrl+C to stop."
+  $CLOUDFLARED tunnel run --url "http://localhost:${port}" "$name" &
+  local pid=$!
+  echo "$pid" > "$PID_FILE"
+  wait "$pid"
+  rm -f "$PID_FILE"
+}
+
+cmd_create() {
+  check_installed || return 1
+  local name="${1:?Usage: $0 create <name>}"
+
+  if [[ ! -f "$HOME/.cloudflared/cert.pem" ]]; then
+    echo "Error: Not authenticated. Run: $0 login"
+    return 1
+  fi
+
+  $CLOUDFLARED tunnel create "$name"
+  echo "Tunnel '${name}' created. Run it with: $0 named ${name} <port>"
+}
+
+cmd_list() {
+  check_installed || return 1
+  $CLOUDFLARED tunnel list
+}
+
+cmd_stop() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid=$(cat "$PID_FILE")
+    if kill -0 "$pid" 2>/dev/null; then
+      kill "$pid"
+      echo "Tunnel stopped (PID ${pid})."
+    else
+      echo "No running tunnel found (stale PID file)."
+    fi
+    rm -f "$PID_FILE"
+  else
+    echo "No running tunnel found."
+  fi
+}
+
+# Main dispatcher
+case "${1:-}" in
+  install) cmd_install ;;
+  status)  cmd_status ;;
+  login)   cmd_login ;;
+  quick)   shift; cmd_quick "$@" ;;
+  named)   shift; cmd_named "$@" ;;
+  create)  shift; cmd_create "$@" ;;
+  list)    cmd_list ;;
+  stop)    cmd_stop ;;
+  *)
+    echo "Usage: $0 <command> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  quick <port> [protocol]   Start a quick tunnel (default: http)"
+    echo "  named <name> <port>       Run a named tunnel"
+    echo "  create <name>             Create a new named tunnel"
+    echo "  list                      List existing named tunnels"
+    echo "  login                     Authenticate with Cloudflare"
+    echo "  stop                      Stop any running tunnel"
+    echo "  status                    Check installation and auth status"
+    echo "  install                   Install cloudflared"
+    exit 1
+    ;;
+esac

--- a/development/skills/cloudflare-tunnel/scripts/tunnel.sh
+++ b/development/skills/cloudflare-tunnel/scripts/tunnel.sh
@@ -47,8 +47,20 @@ cmd_install() {
     fi
   elif [[ "$OSTYPE" == linux* ]]; then
     if command_exists apt-get; then
+      local codename=""
+      if command_exists lsb_release; then
+        codename="$(lsb_release -cs)"
+      elif [[ -f /etc/os-release ]]; then
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        codename="${VERSION_CODENAME:-}"
+      fi
+      if [[ -z "$codename" ]]; then
+        echo "Error: Could not determine Debian/Ubuntu codename. Install lsb-release or provide /etc/os-release with VERSION_CODENAME."
+        return 1
+      fi
       curl -fsSL https://pkg.cloudflare.com/cloudflare-main.gpg | sudo tee /usr/share/keyrings/cloudflare-main.gpg >/dev/null
-      echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
+      echo "deb [signed-by=/usr/share/keyrings/cloudflare-main.gpg] https://pkg.cloudflare.com/cloudflared $codename main" | sudo tee /etc/apt/sources.list.d/cloudflared.list
       sudo apt-get update && sudo apt-get install -y cloudflared
     elif command_exists yum; then
       sudo yum install -y cloudflared

--- a/index.njk
+++ b/index.njk
@@ -50,7 +50,7 @@ hideSearch: false
         {% endif %}
       {% endfor %}
 
-      <div class="discipline-card {% if not hasAnyDisciplineContent %}discipline-empty{% endif %}">
+      <div class="discipline-card fade-up {% if not hasAnyDisciplineContent %}discipline-empty{% endif %}">
         <h2>{{ discipline | replace('-', ' ') | title }}</h2>
         <div class="content-types">
           {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
@@ -111,8 +111,7 @@ hideSearch: false
 
   .page-description {
     font-size: 1.25rem;
-    color: var(--text-color);
-    opacity: 0.8;
+    color: var(--text-muted);
     text-align: center;
     margin-bottom: 3rem;
   }
@@ -212,7 +211,7 @@ hideSearch: false
 
   .cta-button {
     display: inline-block;
-    background-color: #2b6cb0;
+    background-color: var(--primary-color);
     color: white;
     padding: 0.75rem 1.5rem;
     border-radius: 0.375rem;
@@ -222,7 +221,7 @@ hideSearch: false
   }
 
   .cta-button:hover {
-    background-color: #1d4e89;
+    background-color: var(--secondary-color);
   }
 
   .cta-button.secondary {

--- a/index.njk
+++ b/index.njk
@@ -319,7 +319,7 @@ hideSearch: false
     width: 100%; /* Make recent-item fill the slide */
     display: flex;
     flex-direction: column; /* Ensure content within card stacks vertically */
-    justify-content: space-between; /* Pushes meta/desc down if title is short */
+    justify-content: flex-start; /* Align content to top */
   }
   .swiper-pagination-bullet-active {
     background-color: var(--primary-color);


### PR DESCRIPTION
## Summary

Closes #114.

- **Directory convention**: Skills can now have a companion resource directory matching the skill filename (e.g., `cloudflare-tunnel.md` → `cloudflare-tunnel/scripts/tunnel.sh`)
- **Build support**: 11ty passthrough copy handles 11 resource file types (`.sh`, `.yml`, `.json`, `.py`, `.rb`, `.js`, `.txt`, `.cfg`, `.conf`, `.toml`, `.yaml`) across all discipline/skill directories
- **Template rendering**: Skill pages automatically display an "Associated Resources" section with download links when a companion directory exists; skills without resources render unchanged
- **Submission template**: Updated skill issue template with an optional "Associated Resources" field
- **First example**: Includes the cloudflare-tunnel `scripts/tunnel.sh` helper script as the inaugural resource

## Test plan

- [ ] `npm run build` succeeds
- [ ] `_site/development/skills/cloudflare-tunnel/scripts/tunnel.sh` exists in build output
- [ ] Cloudflare Tunnel skill page shows "Associated Resources" section with download link
- [ ] Skills without companion directories (e.g., htmx-expert) render normally with no empty resources section
- [ ] Download link for `tunnel.sh` works
- [ ] Tugboat preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)