### PR TITLE
Add 'By Type' navigation section to homepage

### DIFF
--- a/_includes/content-type-styles.njk
+++ b/_includes/content-type-styles.njk
@@ -1,0 +1,100 @@
+<style>
+  .content-type-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem 1rem;
+  }
+
+  .content-type-page .page-title {
+    font-size: clamp(1.75rem, 4vw, 2.5rem);
+    font-weight: 700;
+    color: var(--text-color);
+    margin-bottom: 0.5rem;
+    text-align: center;
+  }
+
+  .content-type-page .page-description {
+    font-size: 1.25rem;
+    color: var(--text-muted);
+    text-align: center;
+    margin-bottom: 3rem;
+  }
+
+  .content-type-page .content-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 2rem;
+  }
+
+  .content-type-page .content-item {
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  }
+
+  .content-type-page .content-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px var(--card-hover-shadow);
+  }
+
+  :root.dark-theme .content-type-page .content-item:hover {
+    border-color: var(--accent-color);
+  }
+
+  .content-type-page .content-item h2 {
+    font-size: 1.5rem;
+    color: var(--text-color);
+    margin-bottom: 0.5rem;
+  }
+
+  .content-type-page .content-item h2 a {
+    color: var(--primary-color);
+    text-decoration: none;
+  }
+
+  .content-type-page .content-item h2 a:hover {
+    text-decoration: underline;
+  }
+
+  .item-description {
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .item-meta {
+    display: flex;
+    gap: 1rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    margin-bottom: 1rem;
+  }
+
+  .item-discipline {
+    background-color: var(--tag-background);
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.25rem;
+    font-weight: 500;
+  }
+
+  .item-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .item-tags .tag {
+    background-color: var(--tag-background);
+    color: var(--text-color);
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.75rem;
+  }
+
+  @media (max-width: 640px) {
+    .content-type-page .content-list {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/agents/index.njk
+++ b/agents/index.njk
@@ -1,0 +1,30 @@
+---
+title: "All Agents"
+description: "Browse all agents across every discipline."
+layout: "base.njk"
+---
+
+<div class="content-type-page">
+  <h1 class="page-title">🤖 All Agents</h1>
+  <p class="page-description">{{ description }}</p>
+
+  <div class="content-list">
+    {% for item in collections.agents %}
+      <article class="content-item fade-up">
+        <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
+        <p class="item-description">{{ item.data.description }}</p>
+        <div class="item-meta">
+          <span class="item-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
+          <span class="item-date">{{ item.date | date }}</span>
+        </div>
+        <div class="item-tags">
+          {% for tag in item.data.tags %}
+            <span class="tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+
+{% include "content-type-styles.njk" %}

--- a/index.njk
+++ b/index.njk
@@ -39,6 +39,25 @@ hideSearch: false
     </div>
   </div>
   
+  <h2 class="recently-added-title">By Type</h2>
+  <div class="by-type-nav">
+    {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
+      {% set typeCount = collections[type] | length %}
+      <a href="#type-{{ type }}" class="by-type-link {% if typeCount == 0 %}empty{% endif %}" data-type="{{ type }}">
+        <span class="content-type-icon">
+          {% if type === 'prompts' %}💡
+          {% elif type === 'rules' %}📋
+          {% elif type === 'agents' %}🤖
+          {% elif type === 'skills' %}🛠️
+          {% elif type === 'resources' %}🔗
+          {% endif %}
+        </span>
+        <span class="by-type-label">{{ type | replace('-', ' ') | title }}</span>
+        <span class="by-type-count">{{ typeCount }}</span>
+      </a>
+    {% endfor %}
+  </div>
+
   <h2 class="recently-added-title">By Discipline</h2>
   <div class="discipline-grid">
     
@@ -114,6 +133,49 @@ hideSearch: false
     color: var(--text-muted);
     text-align: center;
     margin-bottom: 3rem;
+  }
+
+  .by-type-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+    margin-bottom: 3rem;
+  }
+
+  .by-type-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.2rem;
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 2rem;
+    color: var(--text-color);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.95rem;
+    transition: all 0.2s;
+  }
+
+  .by-type-link:hover {
+    border-color: var(--primary-color);
+    background-color: var(--surface-color);
+    transform: translateY(-1px);
+  }
+
+  .by-type-link.empty {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  .by-type-count {
+    background-color: var(--tag-background);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 1rem;
+    font-weight: 600;
   }
 
   .discipline-grid {

--- a/index.njk
+++ b/index.njk
@@ -43,8 +43,12 @@ hideSearch: false
   <div class="by-type-nav">
     {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
       {% set typeCount = collections[type] | length %}
-      <a href="#type-{{ type }}" class="by-type-link {% if typeCount == 0 %}empty{% endif %}" data-type="{{ type }}">
-        <span class="content-type-icon">
+      {% if typeCount > 0 %}
+      <a href="{{ baseUrl }}/{{ type }}/" class="by-type-link">
+      {% else %}
+      <span class="by-type-link empty" aria-disabled="true">
+      {% endif %}
+        <span class="content-type-icon" aria-hidden="true">
           {% if type === 'prompts' %}💡
           {% elif type === 'rules' %}📋
           {% elif type === 'agents' %}🤖
@@ -54,7 +58,11 @@ hideSearch: false
         </span>
         <span class="by-type-label">{{ type | replace('-', ' ') | title }}</span>
         <span class="by-type-count">{{ typeCount }}</span>
+      {% if typeCount > 0 %}
       </a>
+      {% else %}
+      </span>
+      {% endif %}
     {% endfor %}
   </div>
 
@@ -158,15 +166,20 @@ hideSearch: false
     transition: all 0.2s;
   }
 
-  .by-type-link:hover {
+  a.by-type-link:hover,
+  a.by-type-link:focus-visible {
     border-color: var(--primary-color);
     background-color: var(--surface-color);
     transform: translateY(-1px);
   }
 
+  a.by-type-link:focus-visible {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+  }
+
   .by-type-link.empty {
     opacity: 0.5;
-    pointer-events: none;
   }
 
   .by-type-count {

--- a/prompts/index.njk
+++ b/prompts/index.njk
@@ -1,0 +1,30 @@
+---
+title: "All Prompts"
+description: "Browse all prompts across every discipline."
+layout: "base.njk"
+---
+
+<div class="content-type-page">
+  <h1 class="page-title">💡 All Prompts</h1>
+  <p class="page-description">{{ description }}</p>
+
+  <div class="content-list">
+    {% for item in collections.prompts %}
+      <article class="content-item fade-up">
+        <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
+        <p class="item-description">{{ item.data.description }}</p>
+        <div class="item-meta">
+          <span class="item-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
+          <span class="item-date">{{ item.date | date }}</span>
+        </div>
+        <div class="item-tags">
+          {% for tag in item.data.tags %}
+            <span class="tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+
+{% include "content-type-styles.njk" %}

--- a/resources/index.njk
+++ b/resources/index.njk
@@ -1,0 +1,30 @@
+---
+title: "All Resources"
+description: "Browse all resources across every discipline."
+layout: "base.njk"
+---
+
+<div class="content-type-page">
+  <h1 class="page-title">🔗 All Resources</h1>
+  <p class="page-description">{{ description }}</p>
+
+  <div class="content-list">
+    {% for item in collections.resources %}
+      <article class="content-item fade-up">
+        <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
+        <p class="item-description">{{ item.data.description }}</p>
+        <div class="item-meta">
+          <span class="item-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
+          <span class="item-date">{{ item.date | date }}</span>
+        </div>
+        <div class="item-tags">
+          {% for tag in item.data.tags %}
+            <span class="tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+
+{% include "content-type-styles.njk" %}

--- a/rules/index.njk
+++ b/rules/index.njk
@@ -1,0 +1,30 @@
+---
+title: "All Rules"
+description: "Browse all rules across every discipline."
+layout: "base.njk"
+---
+
+<div class="content-type-page">
+  <h1 class="page-title">📋 All Rules</h1>
+  <p class="page-description">{{ description }}</p>
+
+  <div class="content-list">
+    {% for item in collections.rules %}
+      <article class="content-item fade-up">
+        <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
+        <p class="item-description">{{ item.data.description }}</p>
+        <div class="item-meta">
+          <span class="item-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
+          <span class="item-date">{{ item.date | date }}</span>
+        </div>
+        <div class="item-tags">
+          {% for tag in item.data.tags %}
+            <span class="tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+
+{% include "content-type-styles.njk" %}

--- a/skills/index.njk
+++ b/skills/index.njk
@@ -1,0 +1,30 @@
+---
+title: "All Skills"
+description: "Browse all skills across every discipline."
+layout: "base.njk"
+---
+
+<div class="content-type-page">
+  <h1 class="page-title">🛠️ All Skills</h1>
+  <p class="page-description">{{ description }}</p>
+
+  <div class="content-list">
+    {% for item in collections.skills %}
+      <article class="content-item fade-up">
+        <h2><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h2>
+        <p class="item-description">{{ item.data.description }}</p>
+        <div class="item-meta">
+          <span class="item-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
+          <span class="item-date">{{ item.date | date }}</span>
+        </div>
+        <div class="item-tags">
+          {% for tag in item.data.tags %}
+            <span class="tag">{{ tag }}</span>
+          {% endfor %}
+        </div>
+      </article>
+    {% endfor %}
+  </div>
+</div>
+
+{% include "content-type-styles.njk" %}


### PR DESCRIPTION
## Summary

- Adds a horizontal "By Type" section between "Recently Added" and "By Discipline" on the homepage
- Pill-shaped links for each content type (prompts, rules, agents, skills, resources) with emoji icons and item counts
- Empty types are dimmed and non-interactive
- Styled with CSS variables for light/dark mode support

## Test plan

- [ ] Homepage shows "By Type" section with all 5 content types
- [ ] Each pill displays correct item count from collections
- [ ] Light and dark mode both render correctly
- [ ] Responsive — wraps on smaller screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)