### PR TITLE
Add github-wiki, seo-expert, and slack-markdown-formatter skills

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,6 @@
+# Ignore markdown files inside skill companion directories
+# These are reference docs for skills, not pages
+*/skills/*/references/
+*/skills/*/assets/
+*/skills/*/scripts/
+*/skills/*/templates/

--- a/content-strategy/skills/slack-markdown-formatter.md
+++ b/content-strategy/skills/slack-markdown-formatter.md
@@ -1,0 +1,172 @@
+---
+title: "Slack Markdown Formatter"
+description: "Format messages for Slack using mrkdwn syntax, which differs from standard markdown. Covers text formatting, links, mentions, Block Kit, and common pitfalls."
+date: "2026-04-13"
+layout: "markdown.njk"
+discipline: "content-strategy"
+contentType: "skills"
+tags:
+  - slack
+  - markdown
+  - formatting
+  - communication
+---
+
+`````
+---
+name: slack-markdown-formatter
+description: "This skill should be used when users request messages, notifications, or content formatted for Slack. Use this skill when the user asks to write, draft, format, or compose messages specifically for Slack, as Slack uses 'mrkdwn' which differs from standard markdown. Also use when users mention Slack Block Kit or rich message formatting for Slack."
+---
+
+# Slack Markdown Formatter
+
+## Overview
+
+Slack uses its own markdown variant called "mrkdwn" which differs significantly from standard markdown. This skill provides the correct syntax and best practices for formatting messages that will be displayed properly in Slack.
+
+## When to Use This Skill
+
+Use this skill when:
+- User explicitly asks to format a message for Slack
+- User requests Slack notifications or Slack messages
+- User mentions Slack Block Kit or rich Slack messages
+- Converting existing markdown content to Slack format
+- User asks about Slack-specific formatting like mentions or channel links
+
+## Core Differences from Standard Markdown
+
+Slack's mrkdwn is NOT standard markdown. Key differences include:
+
+### Text Formatting
+
+**Bold:**
+- Standard markdown: `**bold**` or `__bold__`
+- Slack: `*bold*` (single asterisks)
+
+**Italic:**
+- Standard markdown: `*italic*` or `_italic_`
+- Slack: `_italic_` (underscores only)
+
+**Strikethrough:**
+- Standard markdown: `~~strikethrough~~`
+- Slack: `~strikethrough~` (single tildes)
+
+**Code:**
+- Standard markdown: `` `code` `` (backticks)
+- Slack: `` `code` `` (backticks - same as standard)
+
+**Code blocks:**
+- Standard markdown: ` ```language\ncode\n``` `
+- Slack: ` ```\ncode\n``` ` (backticks work, but no language highlighting syntax)
+
+**Blockquotes:**
+- Standard markdown: `> quote`
+- Slack: `> quote` or `>>> multi-line quote` (same, with special multi-line variant)
+
+### Links
+
+**IMPORTANT:** Despite Slack's official documentation suggesting `<url|text>` syntax, in practice this format often does NOT work correctly. Use standard markdown link format instead:
+
+```
+[link text](https://example.com)
+```
+
+**Auto-linking:**
+URLs are automatically linked when pasted directly:
+```
+https://example.com
+```
+
+### Lists
+
+**Unordered lists:**
+- Standard markdown: `- item` or `* item`
+- Slack: Use `- item` (hyphen-dash). Do NOT use bullet character — use `-` instead.
+
+**Ordered lists:**
+- Standard markdown: `1. item`
+- Slack: Limited support, often better to use bullet points
+
+### Slack-Specific Features
+
+**User mentions:**
+```
+<@U12345678>  # Mention user by ID
+<@username>   # May work in some contexts
+```
+
+**Channel mentions:**
+```
+<#C12345678>  # Link to channel by ID
+<#C12345678|channel-name>  # With display name
+```
+
+**Special mentions:**
+```
+<!here>      # Notify active users in channel
+<!channel>   # Notify all channel members
+<!everyone>  # Notify all workspace members (use sparingly)
+```
+
+**Date formatting:**
+```
+<!date^1392734382^{date_short}|Feb 18, 2014>
+<!date^1392734382^{date_num} {time_secs}>
+```
+
+## Unsupported Features
+
+The following standard markdown features DO NOT work in Slack:
+
+- Headings (`#`, `##`, etc.) - Not supported
+- Tables - Not supported in mrkdwn
+- HTML tags - Not supported
+- Nested formatting (e.g., `*bold _and italic_*`)
+- Image embedding with `![alt](url)` syntax
+- Footnotes
+- Task lists with `[ ]` and `[x]`
+
+## Block Kit for Rich Messages
+
+For programmatic message formatting or complex layouts, use Slack's Block Kit instead of mrkdwn. Block Kit provides:
+
+- Structured layouts with sections, dividers, and contexts
+- Interactive elements (buttons, select menus, date pickers)
+- Rich text blocks with more formatting options
+- Images, file attachments, and media
+
+Block Kit messages can embed mrkdwn text in specific text fields using:
+```json
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "Your *formatted* text here"
+  }
+}
+```
+
+## Workflow for Formatting Slack Messages
+
+### Step 1: Identify the Context
+- Is this a simple text message or needs Block Kit?
+- Does it need mentions, links, or special formatting?
+- Is it user-to-user chat or bot/webhook message?
+
+### Step 2: Apply Slack-Specific Syntax
+- Replace `**bold**` with `*bold*`
+- Replace `*italic*` with `_italic_`
+- Keep standard markdown links `[text](url)` format (do NOT use `<url|text>`)
+- Add Slack mentions using `<@user>` or `<#channel>` format
+- Remove unsupported features (headings, tables, etc.)
+
+### Step 3: Consider Context-Specific Formatting
+- For notifications: Keep concise, use <!here> or <!channel> appropriately
+- For documentation: Use code blocks
+- For structured data: Consider Block Kit instead
+
+### Step 4: Test and Validate
+- Verify all formatting renders correctly
+- Check that mentions and channel links use correct IDs
+- Ensure no standard markdown syntax remains
+`````

--- a/content-strategy/skills/slack-markdown-formatter/references/slack-mrkdwn-guide.md
+++ b/content-strategy/skills/slack-markdown-formatter/references/slack-mrkdwn-guide.md
@@ -1,0 +1,679 @@
+# Slack mrkdwn Complete Reference Guide
+
+This document provides comprehensive details on Slack's markdown variant ("mrkdwn"), including syntax comparisons, edge cases, and best practices.
+
+## Official Documentation Sources
+
+- **Slack API Reference**: https://api.slack.com/reference/surfaces/formatting
+- **Slack Developer Documentation**: https://docs.slack.dev/messaging/formatting-message-text
+- **Block Kit Builder**: https://api.slack.com/block-kit/building
+- **DX Documentation Guide**: https://docs.getdx.com/slack-markdown/
+- **SupraSend mrkdwn Guide**: https://dev.to/suprsend/the-only-guide-to-slack-mrkdwn-not-markdown-formatting-w-codes-4329
+- **Wrangle Comprehensive Guide**: https://www.wrangle.io/post/slack-markdown-a-comprehensive-guide-to-formatting-messages
+
+## Complete Syntax Comparison Table
+
+| Feature | Standard Markdown | Slack mrkdwn | Notes |
+|---------|------------------|--------------|-------|
+| **Bold** | `**text**` or `__text__` | `*text*` | Single asterisks only |
+| **Italic** | `*text*` or `_text_` | `_text_` | Underscores only |
+| **Strikethrough** | `~~text~~` | `~text~` | Single tildes |
+| **Inline code** | `` `code` `` | `` `code` `` | Same syntax |
+| **Code block** | ` ```lang\ncode\n``` ` | ` ```\ncode\n``` ` | No language syntax highlighting |
+| **Blockquote** | `> quote` | `> quote` | Same for single line |
+| **Multi-line quote** | `> line1\n> line2` | `>>> multi\nline\nquote` | Slack has special multi-line syntax |
+| **Link** | `[text](url)` | `<url\|text>` | Completely different syntax |
+| **Auto-link** | `<url>` | `<url>` | Same syntax |
+| **Unordered list** | `- item` or `* item` | `- item` or `* item` | Both work, rendering may differ |
+| **Ordered list** | `1. item` | Limited support | Better to use bullets |
+| **Headings** | `# H1`, `## H2`, etc. | Not supported | Use bold text instead |
+| **Tables** | Markdown tables | Not supported | Use Block Kit or pre-formatted text |
+| **Images** | `![alt](url)` | Not supported | Use Block Kit image blocks |
+| **Horizontal rule** | `---` or `***` | Not supported | Use Block Kit dividers |
+| **HTML** | Sometimes supported | Not supported | Use Block Kit instead |
+| **Task lists** | `- [ ]` and `- [x]` | Not supported | Use emoji checkmarks |
+
+## Text Formatting Details
+
+### Bold Text
+
+**Syntax:** `*bold text*`
+
+**Requirements:**
+- Must have spaces or punctuation before/after asterisks
+- Does NOT work mid-word: `wo*rd*` will not bold "rd"
+- DOES work: `This is *bold* text`
+
+**Examples:**
+```
+*Bold at start* of sentence
+Word in *bold* here
+*Bold* and *more bold*
+```
+
+**Common mistakes:**
+```
+No*space*works - ❌ Won't render as bold
+*Nospaceatstart-❌
+```
+
+### Italic Text
+
+**Syntax:** `_italic text_`
+
+**Requirements:**
+- Must have spaces or punctuation before/after underscores
+- Does NOT work mid-word
+- Cannot be nested with bold
+
+**Examples:**
+```
+This is _italic text_
+_Italic_ at the start
+```
+
+### Strikethrough
+
+**Syntax:** `~strikethrough~`
+
+**Requirements:**
+- Single tildes (not double like standard markdown)
+- Must have spaces or punctuation boundaries
+
+**Examples:**
+```
+This is ~wrong~ correct
+~Entire phrase can be struck~
+```
+
+### Code Formatting
+
+**Inline code:** `` `code` ``
+- Same as standard markdown
+- Preserves exact spacing
+- Disables other formatting
+
+**Code blocks:**
+```
+```
+multi-line
+code block
+```
+```
+
+**Important notes:**
+- No language syntax highlighting (no `python`, `javascript`, etc.)
+- All code blocks render the same way
+- Indentation and spacing preserved exactly
+
+## Links
+
+### Standard Links with Text
+
+**Syntax:** `<url|link text>`
+
+**Examples:**
+```
+<https://example.com|Visit Example>
+<https://slack.com|Slack Homepage>
+<mailto:user@example.com|Email Us>
+```
+
+**Notes:**
+- Pipe character `|` separates URL from display text
+- No nested formatting in link text
+- URL must be complete (include protocol)
+
+### Auto-Links
+
+**Syntax:** `<url>`
+
+**Examples:**
+```
+<https://example.com>
+<mailto:user@example.com>
+```
+
+**Behavior:**
+- Automatically creates clickable link
+- Shows full URL as text
+- No custom text display
+
+### Email Links
+
+```
+<mailto:email@example.com|Email Support>
+<mailto:email@example.com>  # Shows email address
+```
+
+## Slack-Specific Features
+
+### User Mentions
+
+**By User ID (recommended):**
+```
+<@U12345678>
+```
+
+**By Username (limited contexts):**
+```
+<@username>
+```
+
+**Behavior:**
+- Highlights the mentioned user
+- Sends notification to user
+- Displays user's display name (not ID)
+- Only works with valid user IDs in the workspace
+
+**Finding User IDs:**
+- Use Slack API methods like `users.list`
+- Check user profile in Slack (View profile → More → Copy member ID)
+- Available in webhook payloads and events
+
+### Channel Mentions
+
+**Basic syntax:**
+```
+<#C12345678>
+```
+
+**With custom display name:**
+```
+<#C12345678|general>
+```
+
+**Behavior:**
+- Creates clickable channel link
+- Shows channel name (with #)
+- Only works with valid channel IDs
+
+### Special Mentions
+
+**Notify active users:**
+```
+<!here>
+```
+- Notifies only currently active users in channel
+- Use for time-sensitive, non-critical updates
+
+**Notify all channel members:**
+```
+<!channel>
+```
+- Notifies ALL members of the channel (even inactive)
+- Use sparingly for important announcements
+
+**Notify entire workspace:**
+```
+<!everyone>
+```
+- Notifies EVERYONE in the workspace
+- Usually restricted to admins
+- Use only for critical, workspace-wide announcements
+
+**Other special mentions:**
+```
+<!date^timestamp^format|fallback>
+<!subteam^ID|handle>  # User group mentions
+```
+
+### Date Formatting
+
+**Syntax:**
+```
+<!date^unix_timestamp^format_string|fallback_text>
+```
+
+**Common format strings:**
+- `{date_short}` - "Feb 18, 2014"
+- `{date_long}` - "February 18, 2014"
+- `{date_pretty}` - "February 18, 2014"
+- `{date_num}` - "02/18/2014"
+- `{time}` - "2:34 PM"
+- `{time_secs}` - "2:34:56 PM"
+
+**Example:**
+```
+<!date^1392734382^{date_short} at {time}|Feb 18, 2014 at 2:34 PM>
+```
+
+**Behavior:**
+- Displays in user's timezone automatically
+- Falls back to provided text if formatting fails
+- Useful for scheduling and time-based notifications
+
+### Emoji
+
+**Syntax:** `:emoji_name:`
+
+**Examples:**
+```
+:smile: :rocket: :white_check_mark:
+:tada: :fire: :eyes:
+```
+
+**Custom emoji:**
+```
+:custom_emoji_name:
+```
+
+**Notes:**
+- Must match Slack's emoji names exactly
+- Custom emoji must exist in the workspace
+- Emoji codes: https://www.webfx.com/tools/emoji-cheat-sheet/
+
+## Lists and Structured Content
+
+### Unordered Lists
+
+**Syntax:**
+```
+• Item 1
+• Item 2
+• Item 3
+```
+
+OR
+
+```
+- Item 1
+- Item 2
+- Item 3
+```
+
+**Notes:**
+- Both `•` and `-` work
+- Consistent indentation recommended
+- Nested lists have limited support
+
+### Ordered Lists
+
+**Limited support:**
+```
+1. First item
+2. Second item
+3. Third item
+```
+
+**Best practice:**
+- Use bullet points instead
+- If numbering is needed, include in text:
+```
+• Step 1: Do this
+• Step 2: Do that
+• Step 3: Finish
+```
+
+### Structured Layouts
+
+For complex layouts with columns, sections, or interactive elements, use Block Kit instead of plain mrkdwn.
+
+## Blockquotes
+
+### Single-Line Quote
+
+**Syntax:** `> quote text`
+
+**Example:**
+```
+> This is a quoted line
+```
+
+### Multi-Line Quote
+
+**Syntax:** `>>>` followed by all quote content
+
+**Example:**
+```
+>>> This is a multi-line quote.
+It continues here.
+And here.
+All text after >>> is quoted.
+```
+
+**Notes:**
+- Everything after `>>>` is quoted until end of message or Block Kit section
+- No closing syntax needed
+- Cannot end mid-message (continues to end)
+
+## Edge Cases and Limitations
+
+### Nested Formatting
+
+**NOT supported:**
+```
+*bold and _italic_ together*  # ❌ Won't work
+_italic with *bold* inside_    # ❌ Won't work
+```
+
+**Workaround:**
+- Use separate formatting: `*bold* and _italic_`
+- Consider Block Kit rich text for complex formatting
+
+### Escaping Characters
+
+**To display special characters literally:**
+```
+\*not bold\*
+\_not italic\_
+\~not strikethrough\~
+```
+
+**Escaping in links:**
+```
+<https://example.com?param=value\&other=value|Link>
+```
+
+### Whitespace and Line Breaks
+
+**Single line break:**
+- Press Enter once
+- Creates a line break in the message
+
+**Paragraph break:**
+- Press Enter twice
+- Creates visible spacing between paragraphs
+
+**Preserving formatting:**
+- Use code blocks for exact spacing
+- Blockquotes preserve line breaks
+
+### Character Limits
+
+- **Single message:** ~40,000 characters (webhook/API)
+- **Text block in Block Kit:** ~3,000 characters
+- **Link text:** ~300 characters recommended
+
+### URLs and Auto-Linking
+
+**Auto-linked URLs:**
+- Slack automatically links `http://` and `https://` URLs
+- Also auto-links emails
+- No need to use `<url>` syntax unless customizing text
+
+**Example:**
+```
+Check out https://example.com  # Auto-linked
+Or <https://example.com|click here>  # Custom text
+```
+
+## Block Kit Integration
+
+### When to Use Block Kit vs mrkdwn
+
+**Use plain mrkdwn for:**
+- Simple text messages
+- Quick notifications
+- User-to-user chat
+- Bot responses without interaction
+
+**Use Block Kit for:**
+- Rich layouts with sections and columns
+- Interactive elements (buttons, menus, modals)
+- Structured data display
+- Images and media
+- Forms and user input
+
+### mrkdwn in Block Kit
+
+Block Kit text fields can use mrkdwn:
+
+```json
+{
+  "type": "section",
+  "text": {
+    "type": "mrkdwn",
+    "text": "This is *bold* and this is _italic_ with <https://example.com|a link>"
+  }
+}
+```
+
+**Block Kit text types:**
+- `"type": "mrkdwn"` - Enables mrkdwn formatting
+- `"type": "plain_text"` - No formatting, displays literally
+
+### Block Kit Builder
+
+Interactive tool for designing Block Kit messages:
+https://api.slack.com/block-kit/building
+
+**Features:**
+- Visual message editor
+- Real-time preview
+- JSON payload generator
+- Template library
+
+## Best Practices
+
+### Message Formatting
+
+1. **Keep it readable:**
+   - Use formatting sparingly
+   - Don't overuse bold/italic
+   - Break up long messages into sections
+
+2. **Use appropriate mentions:**
+   - `<!here>` for time-sensitive, non-critical
+   - `<!channel>` for important channel announcements
+   - `<!everyone>` only for critical workspace alerts
+   - Avoid mass mentions for routine messages
+
+3. **Link text should be descriptive:**
+   ```
+   ✅ <https://docs.example.com|View Documentation>
+   ❌ <https://docs.example.com|click here>
+   ```
+
+4. **Code formatting:**
+   - Use inline code for commands, variables, file names
+   - Use code blocks for multi-line code or output
+   - Don't use code blocks for emphasis
+
+5. **Structure long messages:**
+   - Use bullet points for lists
+   - Use blockquotes for references or quotes
+   - Consider Block Kit for complex layouts
+
+### Accessibility
+
+1. **Don't rely solely on formatting:**
+   - Don't use bold as only indication of importance
+   - Include context in text, not just formatting
+
+2. **Link text should be meaningful:**
+   - Screen readers read link text
+   - Avoid "click here" or bare URLs
+
+3. **Use emoji thoughtfully:**
+   - Can enhance meaning but don't rely on them
+   - Provide text alternatives when critical
+
+### Performance
+
+1. **Message size:**
+   - Keep messages under 4,000 characters when possible
+   - Break very long content into multiple messages
+   - Use Block Kit for large structured data
+
+2. **Avoid excessive mentions:**
+   - Mass mentions can cause notification fatigue
+   - Consider DMs for urgent individual notifications
+
+3. **Rate limits:**
+   - Respect Slack API rate limits
+   - Consider batching messages when possible
+
+## Common Mistakes
+
+### 1. Using Standard Markdown Syntax
+
+**Wrong:**
+```
+**bold**  # Won't work
+# Heading  # Won't work
+[link](url)  # Won't work
+```
+
+**Right:**
+```
+*bold*
+*Heading in bold*
+<url|link>
+```
+
+### 2. Mid-Word Formatting
+
+**Wrong:**
+```
+un*bold*ed  # Won't format
+in_italic_ed  # Won't format
+```
+
+**Right:**
+```
+un-*bold*-ed  # Use separators
+in *italic* text  # Separate words
+```
+
+### 3. Nested Formatting
+
+**Wrong:**
+```
+*bold _and italic_*  # Won't work
+```
+
+**Right:**
+```
+*bold* and _italic_  # Separate
+```
+
+### 4. Incorrect Link Syntax
+
+**Wrong:**
+```
+[Visit site](https://example.com)  # Standard markdown
+<https://example.com, visit site>  # Wrong separator
+```
+
+**Right:**
+```
+<https://example.com|Visit site>  # Pipe separator
+```
+
+### 5. Invalid Mentions
+
+**Wrong:**
+```
+@username  # Plain text, no notification
+<@username>  # May not work without valid ID
+```
+
+**Right:**
+```
+<@U12345678>  # Valid user ID
+```
+
+## Testing and Validation
+
+### Testing Messages
+
+1. **Use Slack App tester:**
+   - Block Kit Builder preview
+   - Test in private channel first
+   - Verify formatting renders correctly
+
+2. **Check mentions:**
+   - Verify user/channel IDs are valid
+   - Confirm notifications are sent
+   - Test special mentions in safe channel
+
+3. **Cross-platform testing:**
+   - Desktop app
+   - Mobile app
+   - Web client
+
+### Debugging
+
+**Common issues:**
+
+1. **Formatting not rendering:**
+   - Check for spaces around format markers
+   - Verify not mid-word
+   - Ensure proper syntax
+
+2. **Links not working:**
+   - Verify pipe separator `|` not comma
+   - Check URL includes protocol
+   - Ensure no nested formatting
+
+3. **Mentions not notifying:**
+   - Verify user/channel IDs are correct
+   - Check bot has permission to mention
+   - Confirm users are in the channel
+
+## Migration from Standard Markdown
+
+When converting standard markdown to Slack mrkdwn:
+
+1. **Replace bold:**
+   - Find: `**text**` or `__text__`
+   - Replace: `*text*`
+
+2. **Replace italic:**
+   - Find: `*text*`
+   - Replace: `_text_`
+
+3. **Replace strikethrough:**
+   - Find: `~~text~~`
+   - Replace: `~text~`
+
+4. **Convert links:**
+   - Find: `[text](url)`
+   - Replace: `<url|text>`
+
+5. **Remove headings:**
+   - Find: `# Heading`
+   - Replace: `*Heading*` (use bold instead)
+
+6. **Handle tables:**
+   - Convert to bulleted lists or
+   - Use Block Kit sections
+
+7. **Handle images:**
+   - Remove `![alt](url)` syntax
+   - Use Block Kit image blocks or share links
+
+## Quick Reference Card
+
+### Essential Syntax
+
+| Formatting | Syntax | Example |
+|------------|--------|---------|
+| Bold | `*text*` | This is *bold* |
+| Italic | `_text_` | This is _italic_ |
+| Strikethrough | `~text~` | This is ~wrong~ |
+| Code | `` `code` `` | Run `npm install` |
+| Link | `<url\|text>` | <https://slack.com\|Slack> |
+| Mention | `<@U123>` | Hey <@U123> |
+| Channel | `<#C123>` | See <#C123> |
+| Quote | `> text` | > Quoted |
+| Multi-quote | `>>> text` | >>> Multiple<br>lines |
+| Emoji | `:name:` | :smile: |
+
+### Special Mentions
+
+| Mention | Effect |
+|---------|--------|
+| `<!here>` | Active users in channel |
+| `<!channel>` | All channel members |
+| `<!everyone>` | Entire workspace |
+
+## Additional Resources
+
+- **Slack API Documentation**: https://api.slack.com/
+- **Block Kit Framework**: https://api.slack.com/block-kit
+- **mrkdwn Formatting Guide**: https://api.slack.com/reference/surfaces/formatting
+- **Emoji Cheat Sheet**: https://www.webfx.com/tools/emoji-cheat-sheet/
+- **Block Kit Builder**: https://api.slack.com/block-kit/building
+- **Message Builder**: https://app.slack.com/block-kit-builder

--- a/development/skills/github-wiki.md
+++ b/development/skills/github-wiki.md
@@ -1,0 +1,189 @@
+---
+title: "GitHub Wiki"
+description: "Create, edit, and manage GitHub wiki pages with correct Gollum link syntax, sidebar navigation, and image handling."
+date: "2026-04-13"
+layout: "markdown.njk"
+discipline: "development"
+contentType: "skills"
+tags:
+  - github
+  - wiki
+  - documentation
+  - gollum
+---
+
+`````
+---
+name: github-wiki
+description: "This skill should be used when creating, editing, or managing GitHub wiki pages. Use when writing wiki content, creating internal links between wiki pages, adding images, updating sidebar navigation, or working with .wiki.git repositories. Triggers on 'wiki', 'wiki page', 'update the wiki', 'add to wiki', or when working in a *.wiki directory or *.wiki.git repository."
+---
+
+# GitHub Wiki
+
+## Overview
+
+GitHub wikis are powered by [Gollum](https://github.com/gollum/gollum),
+a git-backed wiki engine. Wiki content lives in a separate `.wiki.git`
+repository alongside the main code repository. Understanding Gollum's
+link syntax and page resolution is essential — it differs from both
+standard Markdown and MediaWiki in ways that cause subtle, hard-to-debug
+broken links.
+
+## Critical: Link Syntax
+
+**The most common mistake when working with GitHub wikis is getting the
+pipe syntax backwards.** Gollum uses the opposite order from MediaWiki:
+
+```
+CORRECT:  [[Display Text|page-name]]
+WRONG:    [[page-name|Display Text]]
+```
+
+- Left of pipe = what the reader sees
+- Right of pipe = the page to link to (filename without `.md`)
+
+When the order is reversed, links silently resolve to non-existent pages
+and render as red/broken links with no error message.
+
+## Working with Wiki Repositories
+
+### Locating the Wiki Repo
+
+Wiki repositories are cloned separately from the main repo:
+
+```bash
+git clone https://github.com/OWNER/REPO.wiki.git
+```
+
+### Pushing Changes
+
+Wiki changes are pushed with standard git commands. Changes appear
+on GitHub immediately after push — there is no build step or CI.
+
+```bash
+cd path/to/repo.wiki
+git add -A
+git commit -m "Description of changes"
+git push origin master
+```
+
+Note: Wiki repos typically use `master` as the default branch, not `main`.
+
+## Creating Wiki Pages
+
+### Page Files
+
+Each wiki page is a Markdown file at the root of the wiki repository.
+
+- **Filename** = URL slug and link target (e.g., `my-page.md` → `/wiki/my-page`)
+- **H1 heading** = Page title displayed at the top
+- Use **kebab-case** for filenames: `setup-guide.md`, not `Setup Guide.md`
+- Capitalize proper nouns: `Banner.md`, `Home.md`
+
+### Naming for Grouping
+
+Prefix related pages to keep them organized:
+
+```
+its-training-session-1-pantheon.md
+its-training-session-2-git.md
+its-training-session-3-drupal.md
+```
+
+### Internal Links
+
+Always use wiki-style `[[links]]` for internal pages:
+
+```markdown
+See [[Setup Guide|setup-guide]] for details.
+```
+
+Never use markdown-style `[text](page)` for internal wiki links — they
+will not resolve.
+
+### Cross-Page Navigation
+
+Add prev/next navigation at the bottom of sequential pages:
+
+```markdown
+**Previous:** [[Session 1|training-session-1]] | **Next:** [[Session 3|training-session-3]]
+```
+
+## Special Pages
+
+| File | Purpose |
+|---|---|
+| `Home.md` | Landing page, always exists |
+| `_Sidebar.md` | Navigation sidebar, rendered on every page |
+| `_Footer.md` | Footer rendered on every page (optional) |
+| `_Header.md` | Header rendered on every page (optional, rare) |
+
+### Sidebar Best Practices
+
+Keep the sidebar organized with sections and wiki-style links:
+
+```markdown
+# Project Wiki
+
+[[Home]]
+
+---
+
+### Section Name
+
+- [[Page One|page-one]]
+- [[Page Two|page-two]]
+
+---
+
+### External Links
+
+- [GitHub Issues](https://github.com/OWNER/REPO/issues)
+```
+
+## Images
+
+Store images in an `images/` directory at the wiki repo root.
+Reference with standard markdown or wiki syntax:
+
+```markdown
+![Alt text](images/screenshot.png)
+```
+
+GitHub wiki does not support image sizing in markdown. Use HTML for
+controlled dimensions:
+
+```html
+<img src="images/screenshot.png" alt="Alt text" width="600">
+```
+
+## Workflow: Adding a New Wiki Section
+
+1. **Create the page files** at the wiki repo root with kebab-case names
+2. **Add internal links** using `[[Display Text|page-name]]` syntax
+3. **Update `_Sidebar.md`** to add navigation links to the new pages
+4. **Update `Home.md`** if the new section should be listed on the landing page
+5. **Commit and push** to make changes live immediately
+6. **Verify links** — broken links render as red text with class `internal absent`
+
+## Troubleshooting
+
+### Links Show as Red / "absent"
+
+- Check pipe order: must be `[[Display|target]]` not `[[target|Display]]`
+- Verify the target filename exists (without `.md` extension) at repo root
+- Check for typos — resolution is case-insensitive but must otherwise match
+
+### Images Not Rendering
+
+- Verify the image file is committed and pushed to the wiki repo
+- Check the relative path from the wiki root (e.g., `images/file.png`)
+- Ensure the image filename has no spaces
+
+### Page Not Appearing in Wiki
+
+- Verify the `.md` file is at the repository root (not in a subdirectory
+  unless using Gollum subdirectory support)
+- Verify the file was pushed to the remote (`git push origin master`)
+- Check that the file has a `.md` extension
+`````

--- a/development/skills/github-wiki/references/api_reference.md
+++ b/development/skills/github-wiki/references/api_reference.md
@@ -1,0 +1,34 @@
+# Reference Documentation for Github Wiki
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices

--- a/development/skills/github-wiki/references/gollum-link-syntax.md
+++ b/development/skills/github-wiki/references/gollum-link-syntax.md
@@ -1,0 +1,162 @@
+# Gollum Link Syntax Reference
+
+GitHub wikis are powered by Gollum. This reference covers link
+resolution, page naming, and image handling.
+
+## Link Formats
+
+### Wiki-Style Links (Preferred for Internal Pages)
+
+```
+[[page-name]]                       → links to page-name.md, displays page title
+[[Display Text|page-name]]          → links to page-name.md, displays "Display Text"
+```
+
+**Critical:** The pipe syntax is `[[display|target]]` — display text BEFORE
+the pipe, link target AFTER. This is the opposite of MediaWiki syntax.
+
+### Standard Markdown Links (for External URLs)
+
+```markdown
+[Display Text](https://example.com)
+```
+
+Use standard markdown links only for external URLs. Do not use
+`[text](wiki-page)` for internal wiki pages — it will not resolve.
+
+## Link Resolution Rules
+
+1. Links resolve **case-insensitively**.
+2. **Hyphens and spaces are interchangeable**: `my-page` matches `my page`
+   matches `My Page` matches `my-Page`.
+3. The link target matches against the **filename** (without `.md` extension).
+4. Resolution searches the **same directory first**, then the repository root.
+5. Absolute paths use a leading slash: `[[/root-level-page]]`.
+6. Anchor links to headings within a page are **not supported** in wiki-style
+   links. Use standard markdown links for same-page anchors.
+
+## Pipe Syntax Details
+
+The `|` character separates display text from the link target:
+
+```
+[[Display Text|link-target]]
+```
+
+- **Left of pipe:** What the user sees (rendered text)
+- **Right of pipe:** The page to link to (filename without extension)
+
+### Why This Matters
+
+If you write `[[page-name|Pretty Title]]` (target first, display second),
+Gollum interprets "page-name" as the display text and "Pretty Title" as
+the link target. It will look for a page named `Pretty-Title.md` and
+display the text "page-name" — the exact opposite of what was intended.
+
+### Correct Examples
+
+| Syntax | Displays | Links To |
+|---|---|---|
+| `[[project-brief]]` | "project brief" | project-brief.md |
+| `[[Project Brief\|project-brief]]` | "Project Brief" | project-brief.md |
+| `[[Home]]` | "Home" | Home.md |
+| `[[Back to Home\|Home]]` | "Back to Home" | Home.md |
+| `[[1. Setup Guide\|setup-guide]]` | "1. Setup Guide" | setup-guide.md |
+
+### Incorrect Examples (Common Mistakes)
+
+| Syntax | Problem |
+|---|---|
+| `[[project-brief\|Project Brief]]` | Links to `Project-Brief.md`, displays "project-brief" |
+| `[Setup Guide](setup-guide)` | Markdown link syntax does not resolve internal wiki pages |
+| `[[setup-guide#section]]` | Anchor links not supported in wiki-style links |
+
+## Page Naming Conventions
+
+### Filename to URL Mapping
+
+The filename (without `.md`) becomes the URL slug:
+
+- `my-page.md` → `/wiki/my-page`
+- `Home.md` → `/wiki/Home`
+- `Banner.md` → `/wiki/Banner`
+
+### Recommended Naming
+
+- Use **kebab-case** for filenames: `my-page-title.md`
+- Capitalize proper nouns: `Banner.md`, `Home.md`
+- Prefix related pages for grouping:
+  `its-training-session-1-setup.md`,
+  `its-training-session-2-workflow.md`
+
+### Page Title Display
+
+When using bare `[[page-name]]` links (no pipe), Gollum displays the
+page title by converting the filename:
+
+- Hyphens become spaces
+- First letter of each word is capitalized
+- `my-page-title` displays as "My Page Title"
+
+To override the display text, use the pipe syntax:
+`[[Custom Title|my-page-title]]`.
+
+## Images
+
+### Storing Images
+
+Store images in the wiki repository (e.g., an `images/` directory at the
+root of the wiki repo).
+
+### Referencing Images
+
+Use standard markdown image syntax with relative paths:
+
+```markdown
+![Alt text](images/screenshot.png)
+```
+
+Wiki-style image embeds also work:
+
+```
+[[images/screenshot.png]]
+[[Alt text|images/screenshot.png]]
+```
+
+### Image Sizing
+
+GitHub wiki does not support image sizing in markdown. To control image
+dimensions, use raw HTML:
+
+```html
+<img src="images/screenshot.png" alt="Alt text" width="600">
+```
+
+## Special Pages
+
+- **Home.md** — The wiki landing page. Always exists.
+- **_Sidebar.md** — Rendered as the sidebar on every page. Use wiki-style
+  links here for navigation.
+- **_Footer.md** — Rendered as footer on every page (optional).
+- **_Header.md** — Rendered as header on every page (optional, rare).
+
+## Wiki Repository Structure
+
+GitHub wiki content lives in a separate git repository:
+
+```
+<repo-name>.wiki.git
+├── Home.md
+├── _Sidebar.md
+├── _Footer.md (optional)
+├── page-one.md
+├── page-two.md
+└── images/
+    ├── screenshot-1.png
+    └── diagram.png
+```
+
+Clone with: `git clone https://github.com/OWNER/REPO.wiki.git`
+
+Push changes with standard git commands. Changes appear on the wiki
+immediately after push.

--- a/sales-marketing/skills/seo-expert.md
+++ b/sales-marketing/skills/seo-expert.md
@@ -1,0 +1,180 @@
+---
+title: "SEO Expert"
+description: "Comprehensive SEO and GEO (Generative Engine Optimization) auditing for websites. Analyzes traditional SEO factors plus AI-readiness including content structure, schema markup, readability, and E-E-A-T signals."
+date: "2026-04-13"
+layout: "markdown.njk"
+discipline: "sales-marketing"
+contentType: "skills"
+tags:
+  - seo
+  - geo
+  - audit
+  - performance
+  - accessibility
+  - ai-search
+---
+
+`````
+---
+name: seo-expert
+description: "This skill should be used when users need SEO audits, website optimization recommendations, technical SEO analysis, or competitive research. Use when users request to analyze a website's search engine performance, identify SEO issues, or get prioritized action items to improve rankings. Ideal for tasks like 'audit this website for SEO' or 'what are the top issues affecting this site's SEO performance.'"
+---
+
+# SEO Expert (with GEO Optimization)
+
+## Overview
+
+This skill enables comprehensive SEO and GEO (Generative Engine Optimization) auditing for websites. It analyzes traditional SEO factors plus AI-readiness: content structure for AI citations, schema markup for AI extraction, readability for conversational queries, and question-based formatting.
+
+**Key Insight:** 52% of searches now trigger AI Overviews. 92.36% of AI citations come from Google's top 10 organic results. Strong SEO is prerequisite for GEO success.
+
+## Quick Start
+
+Trigger this skill when users request:
+- "Audit [website] for SEO issues"
+- "Optimize [site] for AI search and citations"
+- "Check if [website] is ready for Google AI Overviews"
+- "Analyze [page] for GEO optimization"
+- "Help me improve [content] for ChatGPT/Perplexity citations"
+
+The skill provides detailed audit reports with 5-15 prioritized recommendations covering both traditional SEO and GEO optimization.
+
+## Website Auditing Workflow
+
+To conduct a comprehensive SEO + GEO audit:
+
+1. **Gather baseline data** using scripts:
+   - Run `scripts/lighthouse_audit.sh [url]` to get performance/SEO metrics
+   - Run `scripts/check_robots.sh [url]` to analyze robots.txt
+   - Run `scripts/check_sitemap.sh [url]` to validate XML sitemap
+
+2. **Analyze page structure and meta data**:
+   - Use WebFetch to retrieve the target page HTML
+   - Run `scripts/extract_meta.py [html_file]` to extract meta tags AND validate GEO-critical schema (FAQ, HowTo, Article)
+   - Run `scripts/analyze_headings.py [html_file]` to check heading hierarchy AND question-based headers for GEO
+
+3. **Analyze GEO content optimization**:
+   - Run `scripts/check_readability.py [html_file]` to ensure 8th-grade reading level
+   - Run `scripts/check_bluf.py [html_file]` to validate Bottom Line Up Front format
+   - Run `scripts/analyze_eeat.py [html_file]` to score E-E-A-T signals (authors, citations, dates, trust)
+   - Review first paragraphs for 50-70 word direct answers
+
+4. **Evaluate against best practices**:
+   - Consult `references/seo_checklist.md` for comprehensive SEO audit criteria
+   - Review `references/geo_best_practices.md` for AI optimization strategies
+   - Check `references/content_structure_guide.md` for BLUF, FAQ, and question-based formatting
+   - Review `references/technical_seo.md` for technical requirements
+   - Check `references/core_web_vitals.md` for performance thresholds
+
+5. **Generate prioritized recommendations**:
+   - Use `assets/audit_report_template.md` as the report structure
+   - Apply `assets/priority_matrix.md` to rank issues by impact/effort
+   - Include both traditional SEO and GEO recommendations
+   - Focus on 5-15 actionable items with clear implementation steps
+
+## GEO (Generative Engine Optimization) Analysis
+
+### Content Structure (CRITICAL)
+- **BLUF Format**: Run `scripts/check_bluf.py [html_file]` to validate 50-70 word direct answers at the top
+- **Readability**: Run `scripts/check_readability.py [html_file]` to ensure 8th-grade reading level (Flesch-Kincaid)
+- **Question Headers**: Enhanced `scripts/analyze_headings.py [html_file]` detects question-based H2/H3 headers (target: 30%+)
+- **Long-tail**: Identify 8+ word headers (7x more likely to trigger AI Overviews)
+
+### E-E-A-T Signals (CRITICAL)
+- **E-E-A-T Analysis**: Run `scripts/analyze_eeat.py [html_file]` for comprehensive trust signal detection
+- Detects author bylines with credentials (PhD, MD, CPA, etc.)
+- Counts external authoritative links (.gov, .edu, established orgs)
+- Verifies publish/modified dates in meta, schema, and visible content
+- Finds blockquotes and expert attributions
+- Checks trust signals (ISO, HIPAA, privacy policy, author bios)
+- Scores each E-E-A-T dimension out of 25 for a 0-100 total
+
+### Schema Markup (CRITICAL)
+- **FAQ Schema**: Validates FAQ Schema (highest priority for GEO)
+- **HowTo Schema**: Check for process/tutorial content structured data
+- **Article Schema**: Verify author information and dates (E-E-A-T signals)
+
+### Key GEO Principles
+1. **Strong SEO First**: 92.36% of AI citations come from top 10 organic results
+2. **Natural Language**: AI mentions exact keywords only 5.4% of the time
+3. **Conversational Tone**: Target 8th-grade readability for AI-friendly content
+4. **Direct Answers**: 50-70 word BLUF format optimal for AI citations
+5. **Structured Data**: FAQ Schema drives 3.2x higher AI citation rates
+
+## Technical SEO Analysis
+
+For technical SEO issues, evaluate:
+
+- **Crawlability**: robots.txt, XML sitemaps, internal linking
+- **Indexability**: canonical tags, noindex directives, duplicate content
+- **Site Architecture**: URL structure, navigation, breadcrumbs
+- **Security**: HTTPS/SSL, mixed content warnings
+- **Mobile**: Responsive design, mobile-first indexing
+- **Performance**: Page speed, Core Web Vitals, lazy loading
+
+## On-Page Optimization
+
+Evaluate:
+
+- **Title Tags**: Uniqueness, keyword placement, length (50-60 chars)
+- **Meta Descriptions**: Compelling copy, keywords, length (150-160 chars)
+- **Header Tags**: Proper H1-H6 hierarchy, keyword usage
+- **Content Quality**: Readability, depth, E-E-A-T signals
+- **Images**: Alt text, file size optimization, modern formats (WebP)
+- **Internal Links**: Relevant anchor text, strategic link placement
+- **Schema Markup**: Appropriate structured data types
+
+## Performance Analysis
+
+Core Web Vitals are critical ranking factors:
+
+- **LCP (Largest Contentful Paint)**: Target < 2.5s
+- **FID (First Input Delay)**: Target < 100ms
+- **CLS (Cumulative Layout Shift)**: Target < 0.1
+
+## Report Generation
+
+Structure audit reports with:
+
+1. **Executive Summary**: 2-3 sentence overview of site health
+2. **Critical Issues**: High-impact problems requiring immediate attention
+3. **Priority Recommendations**: 5-15 actionable items with issue description, current vs. desired state, implementation steps, and priority rating
+4. **Performance Metrics**: Lighthouse scores and Core Web Vitals
+5. **Next Steps**: Sequenced action plan
+
+## Resources
+
+### scripts/
+
+**Full-Site Crawling:**
+- `crawl_site.sh` - LibreCrawl wrapper with tier configs (tier1/2/3)
+- `generate_crawl_report.py` - Transform crawl JSON to client reports
+- `compare_crawls.py` - Month-over-month comparison analysis
+
+**Traditional SEO:**
+- `lighthouse_audit.sh` - Google Lighthouse performance/SEO metrics
+- `check_robots.sh` - Analyze robots.txt configuration
+- `check_sitemap.sh` - Validate XML sitemap structure
+
+**GEO Optimization:**
+- `check_readability.py` - Flesch-Kincaid readability (target: 8th grade)
+- `check_bluf.py` - BLUF (Bottom Line Up Front) validation
+- `analyze_headings.py` - Question-based header detection (target: 30%+)
+- `extract_meta.py` - GEO schema validation (FAQ, HowTo, Article)
+- `analyze_eeat.py` - E-E-A-T signal detection (0-100 score)
+
+### references/
+
+- `seo_checklist.md` - Comprehensive audit checklist
+- `core_web_vitals.md` - Performance thresholds and optimization
+- `technical_seo.md` - Technical requirements and best practices
+- `meta_tags_guide.md` - Essential meta tags and implementation
+- `schema_markup_guide.md` - Common schema.org types with examples
+- `geo_best_practices.md` - 15 essential GEO practices
+- `content_structure_guide.md` - BLUF format, question headers, FAQ sections
+- `readability_standards.md` - Flesch-Kincaid targets and writing techniques
+
+### assets/
+- `audit_report_template.md` - Structured template for audit reports
+- `priority_matrix.md` - Framework for prioritizing issues by impact/effort
+`````

--- a/sales-marketing/skills/seo-expert/assets/audit_report_template.md
+++ b/sales-marketing/skills/seo-expert/assets/audit_report_template.md
@@ -1,0 +1,299 @@
+# SEO Audit Report: [Website Name]
+
+**Date:** [Audit Date]
+**Website:** [URL]
+**Audited By:** Claude SEO Expert
+
+---
+
+## Executive Summary
+
+[2-3 sentence overview of the website's overall SEO health. Include overall assessment (Excellent/Good/Needs Improvement/Poor) and highlight 1-2 most critical findings.]
+
+**Overall SEO Health:** [Rating]
+**Critical Issues Found:** [Number]
+**High Priority Items:** [Number]
+**Opportunities Identified:** [Number]
+
+---
+
+## Quick Metrics Overview
+
+| Metric | Score/Status | Target |
+|--------|--------------|---------|
+| Lighthouse SEO Score | [X/100] | 90+ |
+| Lighthouse Performance | [X/100] | 90+ |
+| Mobile-Friendly | [✓/✗] | ✓ |
+| HTTPS Enabled | [✓/✗] | ✓ |
+| Largest Contentful Paint (LCP) | [X.Xs] | < 2.5s |
+| First Input Delay (FID) | [Xms] | < 100ms |
+| Cumulative Layout Shift (CLS) | [X.XX] | < 0.1 |
+| XML Sitemap | [✓/✗] | ✓ |
+| robots.txt | [✓/✗] | ✓ |
+
+---
+
+## Critical Issues
+
+### 🔴 [Issue Name]
+
+**Impact:** High
+**Effort:** [Low/Medium/High]
+**Priority:** Critical
+
+**Current State:**
+[Describe what's currently wrong]
+
+**Impact on SEO:**
+[Explain how this affects search rankings and user experience]
+
+**Recommended Action:**
+[Specific steps to fix the issue]
+
+**Implementation:**
+```html
+<!-- Code example if applicable -->
+```
+
+---
+
+## High Priority Recommendations
+
+### 🟡 [Issue Name]
+
+**Impact:** Medium
+**Effort:** [Low/Medium/High]
+**Priority:** Important
+
+**Current State:**
+[Describe what's currently wrong]
+
+**Impact on SEO:**
+[Explain how this affects search rankings and user experience]
+
+**Recommended Action:**
+[Specific steps to fix the issue]
+
+**Expected Results:**
+[What improvements to expect after fixing]
+
+---
+
+### 🟡 [Issue Name]
+
+[Repeat format above for 4-8 high priority items]
+
+---
+
+## Enhancement Opportunities
+
+### 🟢 [Enhancement Name]
+
+**Impact:** Low-Medium
+**Effort:** [Low/Medium/High]
+**Priority:** Enhancement
+
+**Description:**
+[What could be improved]
+
+**Benefits:**
+[How this would help SEO/user experience]
+
+**Implementation:**
+[How to implement this enhancement]
+
+---
+
+## Detailed Analysis by Category
+
+### Technical SEO
+
+#### Crawlability
+- **robots.txt:** [Status and findings]
+- **XML Sitemap:** [Status and findings]
+- **Internal Linking:** [Assessment]
+- **Site Architecture:** [Assessment]
+
+#### Indexability
+- **Canonical Tags:** [Status]
+- **Meta Robots:** [Status]
+- **Duplicate Content:** [Issues found]
+- **URL Structure:** [Assessment]
+
+#### Performance
+- **Page Load Time:** [X seconds]
+- **Core Web Vitals:** [Summary of LCP, FID, CLS]
+- **Image Optimization:** [Assessment]
+- **Resource Loading:** [Assessment]
+
+#### Mobile Optimization
+- **Mobile-Friendly:** [Yes/No + details]
+- **Viewport Configuration:** [Status]
+- **Touch Elements:** [Assessment]
+- **Mobile Performance:** [Score]
+
+#### Security
+- **HTTPS:** [Status]
+- **Mixed Content:** [Status]
+- **Security Headers:** [Assessment]
+
+---
+
+### On-Page SEO
+
+#### Title Tags
+- **Status:** [Assessment]
+- **Issues:** [List any problems]
+- **Recommendations:** [What to improve]
+
+#### Meta Descriptions
+- **Status:** [Assessment]
+- **Issues:** [List any problems]
+- **Recommendations:** [What to improve]
+
+#### Heading Structure
+- **H1 Tags:** [Assessment]
+- **Hierarchy:** [Assessment]
+- **Issues:** [List any problems]
+
+#### Content Quality
+- **Depth:** [Assessment]
+- **Readability:** [Score/assessment]
+- **Keyword Usage:** [Assessment]
+- **E-E-A-T Signals:** [Assessment]
+
+#### Images
+- **Alt Text:** [Status]
+- **File Sizes:** [Assessment]
+- **Formats:** [Assessment]
+- **Lazy Loading:** [Status]
+
+#### Internal Links
+- **Strategy:** [Assessment]
+- **Anchor Text:** [Assessment]
+- **Broken Links:** [Count and severity]
+
+---
+
+### Structured Data
+
+#### Current Implementation
+[List what schema types are currently implemented]
+
+#### Missing Opportunities
+[List schema types that should be added]
+
+#### Validation Issues
+[Any errors or warnings from Rich Results Test]
+
+---
+
+### Social Media Integration
+
+- **Open Graph Tags:** [Status and assessment]
+- **Twitter Card Tags:** [Status and assessment]
+- **Social Images:** [Assessment]
+
+---
+
+## Competitive Insights
+
+[Optional section if competitor analysis was performed]
+
+**Strengths vs. Competitors:**
+- [List areas where the site excels]
+
+**Gaps vs. Competitors:**
+- [List areas where competitors are ahead]
+
+---
+
+## Action Plan
+
+### Immediate (Week 1)
+1. [Critical fix #1]
+2. [Critical fix #2]
+3. [Critical fix #3]
+
+### Short-term (Weeks 2-4)
+1. [High priority item #1]
+2. [High priority item #2]
+3. [High priority item #3]
+
+### Medium-term (Months 2-3)
+1. [Enhancement #1]
+2. [Enhancement #2]
+3. [Enhancement #3]
+
+### Long-term (Months 4-6)
+1. [Strategic improvement #1]
+2. [Strategic improvement #2]
+3. [Strategic improvement #3]
+
+---
+
+## Monitoring & Measurement
+
+**KPIs to Track:**
+- Organic search traffic
+- Keyword rankings for target terms
+- Core Web Vitals scores
+- Crawl efficiency (Search Console)
+- Indexation rate
+- Click-through rate (CTR) from search
+- Conversion rate from organic traffic
+
+**Recommended Tools:**
+- Google Search Console
+- Google Analytics
+- Google PageSpeed Insights
+- Lighthouse CI (for continuous monitoring)
+
+**Review Schedule:**
+- Weekly: Search Console data, Core Web Vitals
+- Monthly: Ranking changes, traffic trends
+- Quarterly: Comprehensive audit refresh
+
+---
+
+## Resources & Next Steps
+
+**Documentation:**
+- [Link to Google Search Console property]
+- [Link to Google Analytics]
+- [Link to any other relevant resources]
+
+**Support:**
+For questions or assistance with implementation, consult the SEO expert skill reference documentation:
+- `references/seo_checklist.md` - Comprehensive audit checklist
+- `references/core_web_vitals.md` - Performance optimization guide
+- `references/technical_seo.md` - Technical requirements
+- `references/meta_tags_guide.md` - Meta tag implementation
+- `references/schema_markup_guide.md` - Structured data examples
+
+---
+
+## Appendix
+
+### Page-Specific Issues
+
+| Page URL | Issue | Priority | Recommendation |
+|----------|-------|----------|----------------|
+| [URL] | [Issue] | [Priority] | [Fix] |
+| [URL] | [Issue] | [Priority] | [Fix] |
+
+### Broken Links
+
+| Source Page | Broken Link | HTTP Status |
+|-------------|-------------|-------------|
+| [URL] | [Broken URL] | [404/500] |
+
+### Image Optimization Opportunities
+
+| Image URL | Current Size | Potential Savings | Recommendation |
+|-----------|--------------|-------------------|----------------|
+| [URL] | [XXkb] | [YY%] | [Compress/Convert to WebP] |
+
+---
+
+*This audit was generated using the SEO Expert skill for Claude Code. For updates or re-audits, re-run the skill with updated website data.*

--- a/sales-marketing/skills/seo-expert/assets/priority_matrix.md
+++ b/sales-marketing/skills/seo-expert/assets/priority_matrix.md
@@ -1,0 +1,317 @@
+# SEO Issue Priority Matrix
+
+This framework helps prioritize SEO issues based on their impact on search rankings and the effort required to fix them.
+
+## Priority Levels
+
+### 🔴 Critical (Fix Immediately)
+**Characteristics:**
+- High impact on rankings or user experience
+- Blocks search engine indexing or crawling
+- Security vulnerabilities
+- Broken core functionality
+
+**Timeline:** Fix within 24-48 hours
+
+### 🟡 Important (Fix Soon)
+**Characteristics:**
+- Medium-to-high impact on rankings
+- Affects multiple pages
+- User experience issues
+- Competitive disadvantages
+
+**Timeline:** Fix within 1-2 weeks
+
+### 🟢 Enhancement (Optimize When Possible)
+**Characteristics:**
+- Low-to-medium impact
+- Incremental improvements
+- Best practices
+- Nice-to-have optimizations
+
+**Timeline:** Fix within 1-3 months
+
+---
+
+## Impact Assessment
+
+### High Impact Issues
+Issues that significantly affect search rankings, traffic, or conversions:
+
+**Technical:**
+- Indexability blocks (noindex on important pages, robots.txt blocking)
+- Major crawl errors (extensive 404s, 500 errors)
+- No HTTPS/SSL certificate
+- Mobile usability failures
+- Severe Core Web Vitals failures (LCP > 4s, CLS > 0.25)
+- Duplicate content across many pages
+- Broken canonical implementation
+
+**On-Page:**
+- Missing or duplicate title tags on high-value pages
+- Missing meta descriptions on high-value pages
+- No H1 tags or multiple H1s
+- Thin content on important pages (<300 words)
+- Keyword cannibalization
+
+**Structural:**
+- Poor site architecture (pages >5 clicks deep)
+- Extensive broken internal links
+- Missing XML sitemap
+- Orphan pages with valuable content
+
+### Medium Impact Issues
+Issues that moderately affect rankings or user experience:
+
+**Technical:**
+- Slow page load times (3-5 seconds)
+- Core Web Vitals need improvement (not failing, but not optimal)
+- Some redirect chains
+- Parameter handling issues
+- Faceted navigation problems
+- Missing canonical tags
+
+**On-Page:**
+- Suboptimal title/description length
+- Poor heading hierarchy
+- Missing alt text on images
+- Weak internal linking
+- Content depth opportunities
+- Missing schema markup
+
+**Mobile:**
+- Touch elements too close
+- Text too small
+- Viewport issues
+
+### Low Impact Issues
+Issues that have minimal direct ranking impact but improve overall quality:
+
+**Technical:**
+- Minor image optimization opportunities
+- Some external resources not optimized
+- HTTP/2 not enabled
+- No resource hints (preload, prefetch)
+
+**On-Page:**
+- Social media tags missing
+- Additional schema types could be added
+- Content freshness updates
+- Advanced structured data
+
+**Enhancement:**
+- Additional internal links
+- More comprehensive content
+- Better formatting
+- Video/rich media additions
+
+---
+
+## Effort Assessment
+
+### Low Effort
+**Characteristics:**
+- Quick fixes (< 2 hours)
+- No development required
+- Configuration changes
+- Content updates
+
+**Examples:**
+- Add missing meta descriptions
+- Fix title tag lengths
+- Add alt text to images
+- Update robots.txt
+- Add schema markup to existing content
+- Fix broken internal links
+
+### Medium Effort
+**Characteristics:**
+- Moderate work (2-8 hours)
+- Some development required
+- Multiple page changes
+- Testing needed
+
+**Examples:**
+- Implement site-wide canonical tags
+- Restructure heading hierarchy
+- Image optimization across site
+- Implement lazy loading
+- Fix redirect chains
+- Add structured data to templates
+
+### High Effort
+**Characteristics:**
+- Significant work (> 8 hours)
+- Major development/design changes
+- Site-wide impacts
+- Extensive testing required
+
+**Examples:**
+- HTTPS migration
+- Complete site restructure
+- Major performance optimization
+- Implement server-side rendering
+- Rebuild URL structure
+- Full mobile redesign
+
+---
+
+## Priority Matrix
+
+| Impact / Effort | Low Effort | Medium Effort | High Effort |
+|-----------------|------------|---------------|-------------|
+| **High Impact** | 🔴 **CRITICAL**<br>Fix immediately<br><br>Examples:<br>• Fix noindex on key pages<br>• Add missing title tags<br>• Fix robots.txt blocking | 🔴 **CRITICAL**<br>Fix within 48h<br><br>Examples:<br>• HTTPS migration<br>• Fix extensive 404s<br>• Mobile usability fixes | 🟡 **IMPORTANT**<br>Plan & prioritize<br><br>Examples:<br>• Major site restructure<br>• Complete performance overhaul<br>• SSR implementation |
+| **Medium Impact** | 🟡 **IMPORTANT**<br>Fix within 1-2 weeks<br><br>Examples:<br>• Optimize meta descriptions<br>• Add schema markup<br>• Fix alt text | 🟡 **IMPORTANT**<br>Fix within 2-4 weeks<br><br>Examples:<br>• Image optimization<br>• Internal linking strategy<br>• Breadcrumb implementation | 🟢 **ENHANCEMENT**<br>Schedule for sprint<br><br>Examples:<br>• Advanced schema types<br>• Performance fine-tuning<br>• Content expansion |
+| **Low Impact** | 🟢 **ENHANCEMENT**<br>Fix when convenient<br><br>Examples:<br>• Social media tags<br>• Additional internal links<br>• Content formatting | 🟢 **ENHANCEMENT**<br>Include in roadmap<br><br>Examples:<br>• Additional structured data<br>• Resource hints<br>• Advanced features | ⚪ **BACKLOG**<br>Nice to have<br><br>Examples:<br>• Marginal optimizations<br>• Experimental features<br>• Edge case fixes |
+
+---
+
+## Prioritization Framework
+
+### Step 1: Categorize Issues
+For each identified issue, determine:
+1. **Impact Level** (High/Medium/Low)
+2. **Effort Level** (Low/Medium/High)
+3. **Affected Scope** (Single page, section, site-wide)
+
+### Step 2: Apply Business Context
+Consider:
+- **Traffic to affected pages:** Higher traffic = higher priority
+- **Conversion value:** Pages with conversion goals = higher priority
+- **Competitive landscape:** Being behind competitors = higher priority
+- **Seasonal factors:** Time-sensitive content = adjust timing
+- **Resource availability:** Team capacity affects scheduling
+
+### Step 3: Create Action Sequence
+1. **Critical + Low Effort:** Do immediately (quick wins)
+2. **Critical + Medium/High Effort:** Schedule urgently
+3. **Important + Low Effort:** Include in next sprint
+4. **Important + Medium Effort:** Plan into roadmap
+5. **Enhancement + Low Effort:** Opportunistic fixes
+6. **Other combinations:** Backlog with regular review
+
+---
+
+## Special Considerations
+
+### Page Value Multipliers
+Increase priority for issues affecting:
+- **Homepage:** Often highest authority, represents brand
+- **Top traffic pages:** Check Google Analytics for top 10-20 pages
+- **Conversion pages:** Product pages, pricing, contact forms
+- **Entry pages:** Where users first land from search
+- **Money pages:** Direct revenue generators
+
+### Quick Win Strategy
+Focus on:
+1. High impact + low effort first (maximum ROI)
+2. Multiple small fixes vs. one large fix
+3. Visible improvements (user-facing changes)
+4. Measurable outcomes (can track success)
+
+### Technical Debt Considerations
+Some high-effort items may need to be prioritized higher if:
+- They're blocking other improvements
+- They're accumulating interest (getting worse)
+- They're creating cascade effects
+- They're exposing security risks
+
+---
+
+## Example Prioritization
+
+### Issue: Missing HTTPS on entire site
+- **Impact:** High (ranking factor, user trust, security)
+- **Effort:** Medium-High (cert installation, redirects, testing)
+- **Priority:** 🔴 Critical
+- **Timeline:** Complete within 1 week
+- **Justification:** Security and ranking impact outweigh effort
+
+### Issue: Some images missing alt text
+- **Impact:** Medium (accessibility, image SEO)
+- **Effort:** Low (simple content update)
+- **Priority:** 🟡 Important
+- **Timeline:** Complete within 2 weeks
+- **Justification:** Quick fix with meaningful impact
+
+### Issue: Could add FAQ schema to blog posts
+- **Impact:** Low-Medium (potential rich snippets)
+- **Effort:** Medium (template changes, testing)
+- **Priority:** 🟢 Enhancement
+- **Timeline:** Include in next quarter
+- **Justification:** Nice to have but not critical
+
+---
+
+## Priority Indicators in Reports
+
+Use these indicators in audit reports:
+
+### Critical Issues
+```
+🔴 CRITICAL - Fix immediately
+Impact: High | Effort: [Level] | Timeline: 24-48 hours
+```
+
+### Important Issues
+```
+🟡 IMPORTANT - Fix soon
+Impact: Medium | Effort: [Level] | Timeline: 1-4 weeks
+```
+
+### Enhancement Opportunities
+```
+🟢 ENHANCEMENT - Optimize when possible
+Impact: Low-Medium | Effort: [Level] | Timeline: 1-3 months
+```
+
+### Backlog Items
+```
+⚪ BACKLOG - Nice to have
+Impact: Low | Effort: High | Timeline: Future consideration
+```
+
+---
+
+## ROI Calculation
+
+For each issue, estimate:
+
+**Potential Impact Score (1-10):**
+- Traffic increase potential
+- Ranking improvement potential
+- Conversion rate improvement
+- User experience enhancement
+
+**Implementation Cost:**
+- Hours required × hourly rate
+- Tools/resources needed
+- Opportunity cost
+
+**ROI = (Potential Impact Score × Traffic Value) / Implementation Cost**
+
+Prioritize issues with highest ROI first, adjusted for urgency.
+
+---
+
+## Review & Adjustment
+
+### Continuous Monitoring
+- Track progress on implemented fixes
+- Measure actual impact vs. predicted impact
+- Adjust future prioritization based on results
+- Re-evaluate backlog items quarterly
+
+### Success Metrics
+- Ranking improvements for target keywords
+- Organic traffic increases
+- Core Web Vitals improvements
+- Crawl efficiency improvements (Search Console)
+- Conversion rate changes
+
+### Re-prioritization Triggers
+- Algorithm updates
+- Competitive landscape changes
+- Business priority shifts
+- New issues discovered
+- Resource availability changes

--- a/sales-marketing/skills/seo-expert/references/content_structure_guide.md
+++ b/sales-marketing/skills/seo-expert/references/content_structure_guide.md
@@ -1,0 +1,443 @@
+# Content Structure Guide for GEO Optimization
+
+## Overview
+
+Proper content structure is critical for both user experience and AI citation rates. This guide covers BLUF format, question-based headers, FAQ sections, and other structural elements optimized for GEO.
+
+## BLUF: Bottom Line Up Front
+
+### What is BLUF?
+
+BLUF is a writing approach that places the most important information—the "bottom line"—at the beginning of content. For GEO, this means starting with a direct, concise answer before providing details.
+
+### Why BLUF Matters for GEO
+
+- AI extracts and cites direct, concise answers
+- 50-70 word answers are optimal for AI Overviews
+- Users (and AI) get immediate value
+- Improves engagement and reduces bounce rate
+- Featured snippet optimization
+
+### BLUF Structure
+
+**First Paragraph (50-70 words):**
+- Direct answer to the main query
+- Complete, self-contained information
+- Conversational and accessible
+- Think: "What would I want in an AI Overview?"
+
+**Following Paragraphs:**
+- Expand on the BLUF
+- Provide context and details
+- Include examples and evidence
+- Link to related information
+
+### BLUF Examples
+
+**Topic: "What is SEO?"**
+
+✅ **Good BLUF (61 words):**
+```
+SEO (Search Engine Optimization) is the practice of improving website
+visibility in search engine results. It involves optimizing content,
+technical elements, and building authority through links. Good SEO
+increases organic traffic and helps potential customers find your
+business online without paying for ads.
+```
+
+❌ **Poor - Too Short (22 words):**
+```
+SEO stands for Search Engine Optimization. It's a way to get more
+visitors to your website from Google.
+```
+
+❌ **Poor - Too Long (95 words):**
+```
+Search Engine Optimization, commonly abbreviated as SEO, represents a
+comprehensive digital marketing discipline that encompasses a wide variety
+of strategies, techniques, and best practices aimed at improving a
+website's visibility and ranking position within search engine results
+pages, thereby increasing the quantity and quality of organic (non-paid)
+traffic to the site by making it more accessible, relevant, and
+authoritative in the eyes of search engine algorithms, which ultimately
+helps businesses attract potential customers who are actively searching
+for related products, services, or information.
+```
+
+**Topic: "How to optimize images for SEO"**
+
+✅ **Good BLUF (68 words):**
+```
+Image optimization for SEO involves three key steps: compress file sizes
+to improve page speed, add descriptive alt text for accessibility and
+search engines, and use descriptive file names before uploading. Modern
+formats like WebP reduce file size by 30% compared to JPEG. These changes
+help images rank in image search and improve overall page performance.
+```
+
+### BLUF Testing
+
+Use `scripts/check_bluf.py` to validate:
+```bash
+python3 scripts/check_bluf.py page.html
+```
+
+**Checks:**
+- First paragraph word count (50-70 target)
+- Whether it's a direct answer
+- Sentence structure completeness
+- Quality scoring
+
+## Question-Based Headers
+
+### Why Questions Work for GEO
+
+- Long-tail queries of 8+ words are 7x more likely to trigger AI Overviews
+- Users search in natural language questions
+- AI favors content that directly answers queries
+- Improves content scanability and structure
+
+### Target Metrics
+
+- **Goal:** 30%+ of H2/H3 headers should be questions
+- **Ideal:** Questions should be 8+ words (long-tail)
+- **Format:** Natural language, how users actually search
+
+### Question Patterns
+
+**Common Question Starters:**
+- What is/are...?
+- How do/does...?
+- How to...?
+- Why does/do...?
+- When should...?
+- Where can...?
+- Which...?
+- Who...?
+
+### Header Conversion Examples
+
+| Non-Question Header | Question-Based Header |
+|---------------------|----------------------|
+| Benefits of Local SEO | What are the benefits of local SEO? |
+| Page Speed Optimization | How do I improve my page speed for SEO? |
+| Keyword Research | How to do keyword research for SEO? |
+| Mobile Optimization | Why is mobile optimization important for SEO? |
+| Core Web Vitals | What are Core Web Vitals and why do they matter? |
+| Backlink Building | How can I build quality backlinks to my website? |
+
+### Long-Tail Question Examples (8+ words)
+
+✅ **Optimal for GEO:**
+- "How do I optimize my Drupal website for voice search results?" (11 words)
+- "What are the best practices for implementing FAQ schema markup?" (10 words)
+- "Why does page speed affect my search engine rankings in 2025?" (11 words)
+
+⚠️ **Good but shorter:**
+- "How to optimize images for SEO?" (6 words)
+- "What is schema markup?" (4 words)
+
+### Testing Headers
+
+Use `scripts/analyze_headings.py` for automated analysis:
+```bash
+python3 scripts/analyze_headings.py page.html
+```
+
+**Provides:**
+- Percentage of question-based headers
+- Long-tail heading identification
+- Conversion suggestions
+- H2/H3 specific analysis
+
+## FAQ Content & Schema
+
+### FAQ Pages vs FAQ Schema — Know the Difference
+
+These are two separate things that are often conflated:
+
+- **FAQ pages** are a UX/content pattern — a dedicated page listing questions and answers. These often become dumping grounds for outdated, disorganized content and are generally a UX anti-pattern.
+- **FAQ Schema** (FAQPage structured data) is technical markup that helps search engines and AI models parse Q&A content. This remains highly valuable for AI citations.
+
+**Recommendation:** Embed Q&A content within topical pages rather than creating standalone FAQ pages. A program page with 5 well-maintained questions about admissions is far more useful than a catch-all FAQ page with 50 stale entries.
+
+### Why FAQ Schema Still Matters for GEO
+
+- Pages with FAQ Schema are 3.2x more likely to appear in AI Overviews
+- 44% increase in AI citations compared to pages without FAQ Schema
+- Provides direct answers AI can extract and attribute
+- Natural question-answer format matches how users query AI tools
+
+**Important context:** Google removed FAQ rich results for most sites in August 2023 ([announcement](https://developers.google.com/search/blog/2023/08/howto-faq-changes)). FAQ Schema no longer generates those expandable SERP features for most publishers. However, the Schema still signals content structure to AI models, which is where its value now lives.
+
+### FAQ Quality Checklist for GEO
+
+Before adding FAQ Schema to any content, ensure it meets this quality bar:
+
+- [ ] **Genuine user questions** — based on real search queries, support tickets, or user research (not invented by the content team)
+- [ ] **Substantive answers** — 50-300 words per answer; enough to be useful, not so long they lose focus
+- [ ] **Active maintenance** — questions and answers reviewed at least quarterly; stale content removed
+- [ ] **Topically coherent** — all Q&A on a page relates to that page's topic (no catch-all dumps)
+- [ ] **Limited scope** — max 5-10 questions per page; if you need more, split across topical pages
+- [ ] **Embedded in context** — Q&A appears on the relevant topical page, not on a standalone FAQ page
+
+### FAQ Structure
+
+**Question (H2 or H3):**
+- Actual user question
+- Natural language
+- 8+ words ideal
+
+**Answer (2-3 paragraphs):**
+- Direct, complete response
+- 50-300 words (longer than a snippet, shorter than an article)
+- Include examples if relevant
+- Link to detailed resources
+
+### FAQ Example
+
+```html
+<!-- Embedded Q&A on a program page — NOT a standalone FAQ page -->
+<h2>What is the difference between on-page and off-page SEO?</h2>
+
+<p>On-page SEO refers to optimizations you make directly on your website,
+including content quality, title tags, meta descriptions, header structure,
+and internal linking. You have full control over these elements.</p>
+
+<p>Off-page SEO involves factors outside your website, primarily backlinks
+from other sites, social signals, and brand mentions. These signals tell
+search engines that others find your content valuable and trustworthy.</p>
+```
+
+### FAQ Schema Implementation
+
+**Add FAQ Schema to well-maintained Q&A content that passes the quality checklist above:**
+
+```json
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [{
+    "@type": "Question",
+    "name": "What is the difference between on-page and off-page SEO?",
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": "On-page SEO refers to optimizations you make directly on your website, including content quality, title tags, meta descriptions, header structure, and internal linking. Off-page SEO involves factors outside your website, primarily backlinks from other sites, social signals, and brand mentions."
+    }
+  }]
+}
+</script>
+```
+
+**Note:** FAQ rich results were removed for most sites in August 2023. The value of this Schema is now primarily for AI model comprehension and citation, not SERP features.
+
+## Lists and Formatting
+
+### Why Lists Work for GEO
+
+- Highly favored by AI for extraction
+- Easy to scan and understand
+- Natural fit for step-by-step content
+- Featured snippet optimization
+
+### List Types
+
+**Numbered Lists (Ordered):**
+- Use for: Steps, processes, rankings, sequences
+- Implies order matters
+- Good for HowTo content
+
+```html
+<ol>
+  <li>Research keywords</li>
+  <li>Optimize content</li>
+  <li>Build backlinks</li>
+</ol>
+```
+
+**Bulleted Lists (Unordered):**
+- Use for: Features, benefits, options, tips
+- No specific order
+- Good for FAQ answers
+
+```html
+<ul>
+  <li>Improved search visibility</li>
+  <li>Increased organic traffic</li>
+  <li>Better user experience</li>
+</ul>
+```
+
+### List Best Practices
+
+- **Keep items concise:** 1-2 lines per item
+- **Parallel structure:** Start each item similarly
+- **Semantic HTML:** Use `<ol>` and `<ul>` tags, not `<div>` with bullets
+- **Descriptive:** Each item should be self-explanatory
+
+### Testing Lists
+
+Use `scripts/analyze_lists.py` (Phase 3) to check:
+- List count and types
+- Item length and structure
+- Proper HTML markup
+- Optimization recommendations
+
+## Featured Snippet Optimization
+
+### Snippet-Ready Content
+
+**Target length:** 40-50 words for paragraph snippets
+
+**Structure:**
+1. Direct answer immediately after header
+2. Complete, self-contained
+3. Clear and concise
+4. Natural language
+
+### Snippet Example
+
+```html
+<h2>What is a 301 redirect?</h2>
+
+<p>A 301 redirect is a permanent redirect from one URL to another. When
+a user or search engine tries to access the old URL, they're automatically
+sent to the new location. 301 redirects preserve about 90-99% of SEO value
+from the original page.</p>
+```
+
+**Why this works:**
+- 46 words (optimal for snippets)
+- Defines the term clearly
+- Explains what happens
+- Mentions SEO benefit
+- Conversational tone
+
+## Comparison Tables
+
+### Why Tables Work for GEO
+
+- 46-70% of AI citations are product/comparison content
+- Structured data easy for AI to parse
+- Clear side-by-side information
+- High commercial intent
+
+### Table Structure
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Feature</th>
+      <th>Option A</th>
+      <th>Option B</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Price</td>
+      <td>$99/month</td>
+      <td>$149/month</td>
+    </tr>
+    <tr>
+      <td>Support</td>
+      <td>Email only</td>
+      <td>24/7 phone & email</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+### Table Best Practices
+
+- Use semantic HTML (`<table>`, `<th>`, `<td>`)
+- Include clear headers
+- Keep cells concise
+- Balance pros/cons objectively
+- Mobile-responsive design
+
+## Content Hierarchy
+
+### Optimal Page Structure
+
+```
+H1: Main Topic (only one per page)
+├── Introduction (BLUF format)
+├── H2: First Subtopic (question format)
+│   ├── Paragraph (40-70 words)
+│   ├── List or table
+│   └── Paragraph
+├── H2: Second Subtopic (question format)
+│   ├── Paragraph
+│   └── H3: Sub-section (question format)
+│       └── Paragraph
+├── H2: FAQ Section
+│   ├── H3: Question 1?
+│   ├── Answer paragraph(s)
+│   ├── H3: Question 2?
+│   └── Answer paragraph(s)
+└── Conclusion (summary + CTA)
+```
+
+### Hierarchy Best Practices
+
+- **One H1 per page** (main topic)
+- **No skipped levels** (don't jump from H2 to H4)
+- **Logical nesting** (H3s under H2s they relate to)
+- **Descriptive headers** (not "Introduction" or "Overview")
+- **Question-based** when appropriate
+
+## Quick Implementation Checklist
+
+**BLUF Format:**
+- [ ] First paragraph 50-70 words
+- [ ] Direct answer to main query
+- [ ] Complete and self-contained
+- [ ] Tested with check_bluf.py
+
+**Headers:**
+- [ ] 30%+ of H2/H3 are questions
+- [ ] Natural language questions
+- [ ] Long-tail (8+ words) where possible
+- [ ] Tested with analyze_headings.py
+
+**FAQ Content (embed in topical pages, not standalone FAQ pages):**
+- [ ] Genuine user questions (from search data or support tickets)
+- [ ] Substantive answers (50-300 words each)
+- [ ] Max 5-10 questions per page, topically coherent
+- [ ] FAQ Schema applied to quality Q&A content
+- [ ] Validated with extract_meta.py
+- [ ] Maintenance schedule established (quarterly review minimum)
+
+**Lists and Formatting:**
+- [ ] Semantic HTML lists
+- [ ] Concise list items
+- [ ] Tables for comparisons
+- [ ] Featured snippet optimization
+
+**Hierarchy:**
+- [ ] Single H1 tag
+- [ ] Logical nesting
+- [ ] No skipped levels
+- [ ] Descriptive headers
+
+## Tools
+
+**Included in This Skill:**
+- `check_bluf.py` - Validates BLUF format
+- `analyze_headings.py` - Question-based header analysis
+- `extract_meta.py` - Schema validation
+- `check_readability.py` - Ensure 8th-grade level
+
+**External Resources:**
+- Google's Rich Results Test - Validate FAQ Schema
+- Schema.org - Schema reference
+- Answer the Public - Find question variations
+
+## References
+
+- Content structure impacts both UX and GEO performance
+- AI favors well-structured, scannable content
+- Question-answer format aligns with natural language queries
+- Lists and tables improve AI extraction rates

--- a/sales-marketing/skills/seo-expert/references/core_web_vitals.md
+++ b/sales-marketing/skills/seo-expert/references/core_web_vitals.md
@@ -1,0 +1,337 @@
+# Core Web Vitals Guide
+
+Core Web Vitals are a set of specific metrics that Google considers important in a webpage's overall user experience. They are critical ranking factors and should be prioritized in any SEO optimization effort.
+
+## The Three Core Web Vitals
+
+### 1. Largest Contentful Paint (LCP)
+
+**What it measures:** Loading performance - the time it takes for the largest content element to become visible.
+
+**Target Threshold:**
+- Good: ≤ 2.5 seconds
+- Needs Improvement: 2.5 - 4.0 seconds
+- Poor: > 4.0 seconds
+
+**What counts as LCP:**
+- `<img>` elements
+- `<image>` elements inside `<svg>`
+- `<video>` elements (poster image)
+- Element with background image loaded via CSS
+- Block-level text elements (paragraphs, headings)
+
+**Common Causes of Poor LCP:**
+- Slow server response times
+- Render-blocking JavaScript and CSS
+- Slow resource load times (images, fonts)
+- Client-side rendering delays
+
+**Optimization Strategies:**
+
+1. **Optimize Server Response Time**
+   - Use a CDN
+   - Cache assets
+   - Serve HTML statically when possible
+   - Use HTTP/2 or HTTP/3
+   - Establish early connections (dns-prefetch, preconnect)
+
+2. **Eliminate Render-Blocking Resources**
+   - Minify CSS and JavaScript
+   - Defer non-critical CSS
+   - Inline critical CSS
+   - Defer or async load non-critical JavaScript
+   - Remove unused CSS/JavaScript
+
+3. **Optimize Images**
+   - Compress images (TinyPNG, ImageOptim)
+   - Use modern formats (WebP, AVIF)
+   - Implement responsive images (srcset)
+   - Set explicit width/height to prevent layout shifts
+   - Preload critical images: `<link rel="preload" as="image">`
+
+4. **Optimize Fonts**
+   - Use font-display: swap or optional
+   - Preload key fonts
+   - Use variable fonts to reduce file count
+   - Subset fonts to include only needed characters
+
+5. **Reduce Client-Side Rendering**
+   - Use server-side rendering (SSR)
+   - Pre-render static content
+   - Use static site generation where possible
+
+---
+
+### 2. First Input Delay (FID)
+
+**What it measures:** Interactivity - the time from when a user first interacts with your page to when the browser responds.
+
+**Note:** FID is being replaced by Interaction to Next Paint (INP) in March 2024.
+
+**Target Threshold:**
+- Good: ≤ 100 milliseconds
+- Needs Improvement: 100 - 300 milliseconds
+- Poor: > 300 milliseconds
+
+**Common Causes of Poor FID:**
+- Long-running JavaScript tasks
+- Large JavaScript bundles
+- Heavy JavaScript execution
+- Long main thread blocking time
+
+**Optimization Strategies:**
+
+1. **Break Up Long Tasks**
+   - Split large JavaScript bundles
+   - Use code splitting
+   - Implement lazy loading for non-critical scripts
+   - Use web workers for heavy computations
+
+2. **Reduce JavaScript Execution Time**
+   - Minimize and compress JavaScript
+   - Remove unused JavaScript
+   - Use tree shaking to eliminate dead code
+   - Defer third-party scripts
+
+3. **Minimize Main Thread Work**
+   - Reduce complexity of event handlers
+   - Debounce/throttle input handlers
+   - Use passive event listeners
+   - Avoid large, complex layouts
+
+4. **Keep Request Counts Low and Transfer Sizes Small**
+   - Use HTTP/2 multiplexing
+   - Implement resource hints (preload, prefetch)
+   - Minimize third-party code
+   - Use a CDN
+
+---
+
+### 3. Cumulative Layout Shift (CLS)
+
+**What it measures:** Visual stability - unexpected layout shifts during page load.
+
+**Target Threshold:**
+- Good: ≤ 0.1
+- Needs Improvement: 0.1 - 0.25
+- Poor: > 0.25
+
+**Common Causes of Poor CLS:**
+- Images without dimensions
+- Ads, embeds, and iframes without dimensions
+- Dynamically injected content
+- Web fonts causing FOIT/FOUT (Flash of Invisible/Unstyled Text)
+- Actions waiting for network response before updating DOM
+
+**Optimization Strategies:**
+
+1. **Always Include Size Attributes on Images and Videos**
+   ```html
+   <img src="image.jpg" width="640" height="360" alt="...">
+   ```
+   - Use CSS aspect-ratio for responsive images
+   - Reserve space with aspect ratio boxes
+
+2. **Never Insert Content Above Existing Content**
+   - Reserve space for dynamic content
+   - Use skeleton screens or placeholders
+   - Load ads in reserved spaces
+   - Use transform animations instead of layout properties
+
+3. **Prefer Transform Animations**
+   - Use `transform` and `opacity` (won't cause layout shifts)
+   - Avoid animating: width, height, top, left, margin, padding
+
+4. **Optimize Font Loading**
+   ```css
+   @font-face {
+     font-family: 'MyFont';
+     font-display: optional; /* or swap */
+     src: url('font.woff2') format('woff2');
+   }
+   ```
+   - Use font-display: optional or swap
+   - Preload key fonts
+   - Consider system fonts
+
+5. **Handle Ads and Embeds Properly**
+   - Reserve space for ad slots
+   - Style ad container to prevent collapse
+   - Avoid placing ads near top of viewport
+   - Use placeholder dimensions for embeds
+
+---
+
+## Interaction to Next Paint (INP)
+
+**New metric replacing FID (March 2024)**
+
+**What it measures:** Overall responsiveness - the time from user interaction to visual update.
+
+**Target Threshold:**
+- Good: ≤ 200 milliseconds
+- Needs Improvement: 200 - 500 milliseconds
+- Poor: > 500 milliseconds
+
+**Differences from FID:**
+- Considers all interactions (not just first)
+- Measures to visual update (not just input delay)
+- More comprehensive responsiveness metric
+
+**Optimization strategies are similar to FID** with additional focus on:
+- Optimizing event handler code
+- Reducing rendering work
+- Minimizing layout/style calculations
+
+---
+
+## Measuring Core Web Vitals
+
+### Tools for Measurement
+
+1. **Lab Data (Synthetic Testing)**
+   - Google Lighthouse (in Chrome DevTools)
+   - PageSpeed Insights
+   - WebPageTest
+   - Chrome DevTools Performance panel
+
+2. **Field Data (Real User Monitoring)**
+   - Chrome User Experience Report (CrUX)
+   - Google Search Console (Core Web Vitals report)
+   - PageSpeed Insights (field data section)
+   - Web Vitals JavaScript library
+   - Real User Monitoring (RUM) tools
+
+3. **JavaScript Library**
+   ```javascript
+   import {onCLS, onFID, onLCP} from 'web-vitals';
+
+   onCLS(console.log);
+   onFID(console.log);
+   onLCP(console.log);
+   ```
+
+### Interpreting Thresholds
+
+Google uses the **75th percentile** of page loads for assessment:
+- At least 75% of page loads must meet "Good" threshold
+- Measured separately for mobile and desktop
+- Based on 28 days of aggregated data
+
+---
+
+## Testing Strategy
+
+### Recommended Testing Approach
+
+1. **Start with Field Data**
+   - Check Google Search Console Core Web Vitals report
+   - Identify problematic URLs
+   - Understand real-user experiences
+
+2. **Use Lab Data for Diagnosis**
+   - Run Lighthouse on slow pages
+   - Use Chrome DevTools Performance panel
+   - Identify specific issues and bottlenecks
+
+3. **Test Across Devices**
+   - Mobile performance is typically worse
+   - Test on real devices, not just emulation
+   - Consider slower networks (3G, 4G)
+
+4. **Monitor Continuously**
+   - Set up Real User Monitoring
+   - Track metrics over time
+   - Monitor after deployments
+
+---
+
+## Common Optimization Patterns
+
+### Priority Order
+
+1. **Fix Critical Issues First**
+   - Poor LCP (> 4s)
+   - Poor CLS (> 0.25)
+   - Poor FID/INP (> 300ms/500ms)
+
+2. **Server and Network**
+   - Optimize server response time
+   - Implement CDN
+   - Enable compression
+   - Use HTTP/2+
+
+3. **Critical Rendering Path**
+   - Eliminate render-blocking resources
+   - Inline critical CSS
+   - Defer non-critical JavaScript
+
+4. **Resource Optimization**
+   - Compress and optimize images
+   - Optimize fonts
+   - Minimize JavaScript bundles
+
+5. **Fine-Tuning**
+   - Code splitting
+   - Resource hints (preload, prefetch, preconnect)
+   - Implement caching strategies
+
+### Quick Wins
+
+- Add width/height to all images
+- Implement lazy loading
+- Use modern image formats (WebP)
+- Defer third-party scripts
+- Use font-display: swap
+- Minify CSS and JavaScript
+- Enable text compression (gzip/Brotli)
+- Implement browser caching
+- Use a CDN
+
+---
+
+## Impact on SEO
+
+### Ranking Factor
+
+- Core Web Vitals are confirmed ranking factors
+- Part of "Page Experience" signals
+- Tiebreaker between similar content quality
+- More important for mobile search
+
+### Threshold Requirements
+
+- Must pass for mobile version (mobile-first indexing)
+- Desktop metrics also considered
+- Assessed at page level, not site level
+- Can affect individual page rankings
+
+### Best Practices
+
+- Prioritize pages with high traffic/visibility
+- Focus on pages with conversion goals
+- Don't sacrifice content quality for metrics
+- Balance user experience with technical optimization
+- Monitor changes after optimization
+- Test on real devices and networks
+
+---
+
+## Resources and Tools
+
+### Official Google Resources
+- [web.dev/vitals](https://web.dev/vitals/)
+- [PageSpeed Insights](https://pagespeed.web.dev/)
+- Google Search Console Core Web Vitals Report
+- Chrome DevTools
+
+### Testing Tools
+- Lighthouse CI (automated testing)
+- WebPageTest
+- Chrome User Experience Report API
+- Web Vitals Chrome Extension
+
+### Monitoring Solutions
+- Google Analytics (with web-vitals library)
+- Cloudflare Web Analytics
+- Commercial RUM solutions (SpeedCurve, Calibre, etc.)

--- a/sales-marketing/skills/seo-expert/references/geo_best_practices.md
+++ b/sales-marketing/skills/seo-expert/references/geo_best_practices.md
@@ -1,0 +1,255 @@
+# GEO (Generative Engine Optimization) Best Practices
+
+## Overview
+
+GEO is the practice of optimizing content to appear in AI-powered search results and citations across ChatGPT, Google AI Overviews, Perplexity, Gemini, and other generative AI platforms.
+
+**Key Insight:** 92.36% of AI Overview citations come from Google's top 10 organic results. Strong traditional SEO is a prerequisite for GEO success.
+
+## Market Context
+
+- **52% of searches** now trigger AI Overviews (up from 25% in August 2024)
+- **26% of brands** have zero AI visibility
+- **AI-referred traffic** converts 4.4x better than traditional search
+- **Long-tail queries** (8+ words) are 7x more likely to trigger AI Overviews
+
+## 15 Essential GEO Best Practices
+
+### 1. Direct Answer Format (CRITICAL)
+
+**BLUF: Bottom Line Up Front**
+- Start content with 50-70 word TL;DR answering the primary query
+- Place key information in first 2-3 paragraphs
+- Provide immediate, complete answers before details
+
+**Example:**
+```
+SEO (Search Engine Optimization) is the practice of improving website
+visibility in search engine results. It involves optimizing content,
+technical elements, and building authority through links. Good SEO
+increases organic traffic and helps potential customers find your
+business online.
+```
+
+### 2. Question-Based Content Structure
+
+- Use H2/H3 headers as questions users actually ask
+- Format: "What is [Topic]?" "How to [Action]?" "Why does [Thing]?"
+- Target: 30%+ of H2/H3 headers should be questions
+- Long-tail queries (8+ words) preferred
+
+**Good Examples:**
+- "What are the benefits of organic SEO?"
+- "How do I optimize my website for voice search?"
+- "Why does page speed affect my search rankings?"
+
+**Poor Examples:**
+- "Benefits" (too short, not a question)
+- "Page Speed" (not conversational)
+- "Overview" (vague, not user-focused)
+
+### 3. Schema Markup Implementation (CRITICAL)
+
+**Priority Order:**
+1. **FAQ Schema** - CRITICAL for AI citations on well-structured Q&A content (note: rich results removed for most sites Aug 2023; value is now in AI citation rates — 3.2x increase)
+2. **HowTo Schema** - For processes and tutorials
+3. **Article Schema** - For blog posts (include author)
+
+**Why it matters:**
+- Google Gemini leverages structured data
+- 92.36% of AI citations have proper schema markup
+- Dramatically improves AI citation rates
+
+### 4. E-E-A-T Signals Maximization
+
+**Experience, Expertise, Authoritativeness, Trustworthiness**
+
+- Include author bylines with credentials
+- Add expert quotes and first-hand experiences
+- Cite authoritative sources prominently
+- Display certifications and credentials
+- Show publication and update dates
+
+### 5. Natural Conversational Language
+
+- Write how people speak
+- AI mentions exact keywords only 5.4% of the time
+- Prioritize semantic variations naturally
+- Target 8th-grade readability (Flesch-Kincaid)
+- Avoid jargon and complex terminology
+
+### 6. Structured Content Formats
+
+**AI Favors:**
+- Numbered and bulleted lists
+- Comparison tables
+- FAQ sections (embedded in topical pages preferred over standalone FAQ pages)
+- One idea per paragraph
+- Clear, scannable structure
+
+### 7. Topic Cluster Strategy
+
+- Build comprehensive content hubs
+- Pillar page + 8-12 supporting articles
+- Strategic internal linking
+- Cover "query fan-out" (all related questions)
+
+### 8. Content Freshness
+
+**AI prefers content 25.7% fresher than traditional SEO**
+
+- Update articles every 3-6 months
+- Include "(Updated Month Year)" in titles
+- Add dateModified to Article Schema
+- Refresh statistics with current data
+
+### 9. Statistical Data Integration
+
+- Lead with compelling recent statistics (2024-2025)
+- Cite sources prominently
+- Make content quotable
+- Link to authoritative data sources
+
+### 10. Mobile-First Excellence
+
+- Google uses mobile version for AI Overview decisions
+- 2/3 of searches are mobile
+- Majority of mobile searches get AI Overviews
+- Ensure responsive design and fast loading
+
+### 11. Featured Snippet Targeting
+
+- 40-50 word answers in snippet format
+- Use numbered/bulleted lists
+- Format definitions prominently
+- Provide direct, concise answers
+
+### 12. Multi-Platform Presence
+
+**Optimize for multiple AI platforms:**
+- ChatGPT
+- Perplexity
+- Google AI Overviews
+- Gemini
+
+**Also build presence on:**
+- Reddit (5.5% of all citations)
+- LinkedIn (#4 most cited source)
+- Industry forums
+
+### 13. Product Content Strategy
+
+**46-70% of all AI citations are product-related**
+
+- Product specifications
+- Feature comparisons
+- Technical documentation
+- Clear, detailed descriptions
+
+### 14. Question-Answer Pairs
+
+- Question as H2
+- Concise 2-3 paragraph answer immediately following
+- FAQ Schema markup
+- Direct, complete information
+
+### 15. Page Experience Optimization
+
+- Fast loading speeds (Core Web Vitals)
+- Clear navigation
+- Mobile-responsive design
+- HTTPS secure
+- Clean, accessible HTML
+
+## GEO vs SEO Differences
+
+| Aspect | SEO | GEO |
+|--------|-----|-----|
+| **Focus** | Keywords, backlinks, SERP rankings | Context, brand mentions, AI citations |
+| **Measurement** | Rankings, organic traffic, CTR | Citation frequency, brand visibility rate, AI referral traffic |
+| **Content** | Keyword-optimized, 1-2% density | Context-rich, natural language, 8th-grade readability |
+| **Structure** | Keyword placement in titles/headers | Question-based headers, BLUF format, FAQ sections |
+
+## Content Types Supporting Both SEO and GEO
+
+### Comprehensive Guides (2,000-5,000 words)
+- Rank well for competitive keywords (SEO)
+- Provide complete answers AI can cite (GEO)
+- Include FAQ sections benefiting both
+
+### Data-Driven Research
+- Original statistics attract backlinks (SEO)
+- Become quotable sources (GEO)
+- Cite methodology clearly
+
+### Step-by-Step Tutorials
+- Target "how to" searches (SEO)
+- Provide actionable answers AI surfaces (GEO)
+- Use clear numbered steps with HowTo Schema
+
+### Comparison Content
+- High commercial intent keywords (SEO)
+- Direct answers to buyer questions (GEO)
+- Side-by-side tables with objective perspectives
+
+### Topic Clusters
+- Hub-and-spoke model with pillar page linking to 8-12 supporting articles
+- Internal linking strength (SEO)
+- Comprehensive coverage AI favors (GEO)
+
+### Expert Thought Leadership
+- Brand authority signals (SEO)
+- Quotable expert content (GEO)
+- Include author bylines with credentials prominently
+
+## Measurement & Tracking
+
+### Citation Tracking (Manual)
+1. Manually query ChatGPT, Perplexity, Gemini with target keywords monthly
+2. Document when your brand/URL appears
+3. Track: citation frequency, position in response, context
+
+### AI Referral Traffic
+- Set up source/medium tracking in Google Analytics
+- Monitor: chat.openai.com, perplexity.ai, gemini.google.com
+- AI traffic shows 6-14% higher engagement
+- 30% lower session duration (users find answers faster)
+
+### Brand Visibility Rate
+Percentage of relevant AI queries mentioning your brand:
+```
+(AI answers mentioning brand / Total relevant AI queries tested) × 100
+```
+
+## Quick Implementation Checklist
+
+- [ ] Add BLUF (50-70 words) to content openings
+- [ ] Convert 30%+ of H2/H3 headers to questions
+- [ ] Apply FAQ Schema to well-maintained Q&A content (embedded in topical pages preferred)
+- [ ] Add author bylines with credentials
+- [ ] Ensure 8th-grade readability
+- [ ] Include recent statistics (2024-2025)
+- [ ] Embed Q&A content in topical pages (avoid standalone FAQ dumping grounds)
+- [ ] Implement Article Schema with dates
+- [ ] Create comparison tables where relevant
+- [ ] Build topic clusters around pillar content
+
+## Tools for GEO Optimization
+
+### Included in This Skill
+- `check_readability.py` - Flesch-Kincaid grade level analysis
+- `analyze_headings.py` - Question-based header detection
+- `check_bluf.py` - BLUF format validation
+- `extract_meta.py` - Schema validation and meta analysis
+
+### External Free Tools
+- Google's Rich Results Test - Validate schema
+- Hemingway Editor - Readability scoring
+- Google Search Console - Performance data
+
+## References
+
+- Industry research confirms GEO as the dominant term
+- Leading agencies: Terakeet, iPullRank, First Page Sage, Intero Digital
+- AI search projected to overtake traditional by 2027
+- Early movers capture emerging market before competitors mobilize

--- a/sales-marketing/skills/seo-expert/references/meta_tags_guide.md
+++ b/sales-marketing/skills/seo-expert/references/meta_tags_guide.md
@@ -1,0 +1,457 @@
+# Meta Tags Guide for SEO
+
+This guide covers essential meta tags for SEO and how to implement them effectively.
+
+## Essential Meta Tags
+
+### Title Tag
+
+**Purpose:** Most important on-page SEO element. Appears as clickable headline in search results.
+
+**Syntax:**
+```html
+<title>Page Title - Brand Name</title>
+```
+
+**Best Practices:**
+- **Length:** 50-60 characters (512-600 pixels)
+- **Uniqueness:** Every page should have unique title
+- **Keywords:** Include primary keyword near beginning
+- **Brand:** Include brand name (usually at end)
+- **Compelling:** Write for users, not just search engines
+- **Format:** Page Title | Section | Brand Name
+
+**Good Examples:**
+```html
+<title>Organic Coffee Beans | Premium Selection | CoffeeShop</title>
+<title>How to Train Your Dog: Complete Guide 2024 | PetExperts</title>
+<title>Women's Running Shoes - Free Shipping | SportStore</title>
+```
+
+**Bad Examples:**
+```html
+<!-- Too short -->
+<title>Home</title>
+
+<!-- Too long (will be truncated) -->
+<title>Buy the Best Organic Fair Trade Coffee Beans Online with Free Shipping and 30 Day Money Back Guarantee at CoffeeShop</title>
+
+<!-- Keyword stuffing -->
+<title>Coffee, Coffee Beans, Buy Coffee, Organic Coffee, Coffee Shop</title>
+
+<!-- Not unique -->
+<title>Products - CoffeeShop</title>
+```
+
+**Character Limits by Platform:**
+- Google: ~60 characters or 600 pixels
+- Bing: ~65 characters
+- Mobile: ~78 characters
+
+---
+
+### Meta Description
+
+**Purpose:** Summary shown in search results. Affects click-through rate (CTR), not direct ranking.
+
+**Syntax:**
+```html
+<meta name="description" content="Compelling page description that includes keywords and a call to action.">
+```
+
+**Best Practices:**
+- **Length:** 150-160 characters (920-1000 pixels)
+- **Uniqueness:** Every page should have unique description
+- **Keywords:** Include target keywords naturally
+- **CTA:** Include call-to-action
+- **Accuracy:** Accurately describe page content
+- **Compelling:** Encourage clicks
+
+**Good Examples:**
+```html
+<meta name="description" content="Shop premium organic coffee beans with free shipping. Ethically sourced, freshly roasted. Order online today and save 20% on your first purchase.">
+
+<meta name="description" content="Learn how to train your dog with our complete 2024 guide. Expert tips, step-by-step instructions, and video tutorials for all breeds.">
+```
+
+**Bad Examples:**
+```html
+<!-- Too short -->
+<meta name="description" content="Welcome to our website.">
+
+<!-- Too long (will be truncated) -->
+<meta name="description" content="We offer the finest selection of organic fair trade coffee beans sourced from sustainable farms around the world with free shipping on orders over fifty dollars and a thirty day money back guarantee plus our loyalty program gives you points for every purchase.">
+
+<!-- Keyword stuffing -->
+<meta name="description" content="Coffee beans, organic coffee, fair trade coffee, buy coffee beans, coffee shop, coffee online.">
+
+<!-- Duplicate/generic -->
+<meta name="description" content="Products page">
+```
+
+**Note:** Google may generate its own description if:
+- None provided
+- Too short/vague
+- Not relevant to query
+- Better text found on page
+
+---
+
+### Meta Robots
+
+**Purpose:** Control crawling and indexing behavior.
+
+**Syntax:**
+```html
+<meta name="robots" content="index, follow">
+```
+
+**Directives:**
+- `index` / `noindex`: Allow/prevent indexing
+- `follow` / `nofollow`: Allow/prevent link following
+- `none`: Same as "noindex, nofollow"
+- `noarchive`: Prevent cached version
+- `nosnippet`: Prevent description snippet
+- `noimageindex`: Don't index images
+- `notranslate`: Don't offer translation
+
+**Common Uses:**
+```html
+<!-- Default (can omit) -->
+<meta name="robots" content="index, follow">
+
+<!-- Prevent indexing (staging site, thin content) -->
+<meta name="robots" content="noindex, follow">
+
+<!-- Block specific crawler -->
+<meta name="googlebot" content="noindex">
+
+<!-- Prevent caching -->
+<meta name="robots" content="noarchive">
+
+<!-- Maximum snippet length -->
+<meta name="robots" content="max-snippet:100">
+
+<!-- Maximum image preview -->
+<meta name="robots" content="max-image-preview:large">
+```
+
+---
+
+### Canonical Tag
+
+**Purpose:** Specify preferred URL for duplicate/similar content.
+
+**Syntax:**
+```html
+<link rel="canonical" href="https://example.com/preferred-url">
+```
+
+**Best Practices:**
+- Use absolute URLs
+- Self-referencing on all pages
+- Points to accessible URL (not 404 or redirect)
+- One canonical per page
+- Consistent with hreflang
+
+**Use Cases:**
+```html
+<!-- Original page -->
+<link rel="canonical" href="https://example.com/product">
+
+<!-- Duplicate/variant points to original -->
+<link rel="canonical" href="https://example.com/product">
+
+<!-- HTTPS canonical -->
+<link rel="canonical" href="https://example.com/page">
+```
+
+---
+
+## Open Graph Tags (Social Media)
+
+**Purpose:** Control how content appears when shared on social media (Facebook, LinkedIn, etc.).
+
+**Required Tags:**
+```html
+<meta property="og:title" content="Page Title">
+<meta property="og:description" content="Page description">
+<meta property="og:image" content="https://example.com/image.jpg">
+<meta property="og:url" content="https://example.com/page">
+<meta property="og:type" content="website">
+```
+
+**Optional but Recommended:**
+```html
+<meta property="og:site_name" content="Brand Name">
+<meta property="og:locale" content="en_US">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:image:alt" content="Image description">
+```
+
+**Content Types:**
+- `website`: General pages
+- `article`: Blog posts, news articles
+- `product`: E-commerce products
+- `video.movie`, `video.episode`, `video.tv_show`, `video.other`
+- `music.song`, `music.album`, `music.playlist`
+
+**Article-Specific Tags:**
+```html
+<meta property="article:published_time" content="2024-01-15T08:00:00+00:00">
+<meta property="article:modified_time" content="2024-01-16T10:30:00+00:00">
+<meta property="article:author" content="Author Name">
+<meta property="article:section" content="Technology">
+<meta property="article:tag" content="SEO">
+```
+
+**Image Requirements:**
+- Minimum: 600x315 pixels
+- Recommended: 1200x630 pixels
+- Maximum: 8MB
+- Formats: JPG, PNG, WebP
+- Aspect ratio: 1.91:1
+
+**Testing:**
+- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
+- [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/)
+
+---
+
+## Twitter Card Tags
+
+**Purpose:** Control how content appears when shared on Twitter/X.
+
+**Required Tags:**
+```html
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Page Title">
+<meta name="twitter:description" content="Page description">
+<meta name="twitter:image" content="https://example.com/image.jpg">
+```
+
+**Optional:**
+```html
+<meta name="twitter:site" content="@username">
+<meta name="twitter:creator" content="@authorusername">
+<meta name="twitter:image:alt" content="Image description">
+```
+
+**Card Types:**
+- `summary`: Small image thumbnail
+- `summary_large_image`: Large image
+- `app`: Mobile app promotion
+- `player`: Video/audio player
+
+**Summary Card:**
+```html
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Page Title">
+<meta name="twitter:description" content="Description under 200 characters">
+<meta name="twitter:image" content="https://example.com/image.jpg">
+```
+
+**Large Image Card:**
+```html
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Page Title">
+<meta name="twitter:description" content="Description under 200 characters">
+<meta name="twitter:image" content="https://example.com/large-image.jpg">
+```
+
+**Image Requirements:**
+- Summary: 144x144 minimum (1:1 ratio)
+- Large: 300x157 minimum, 4096x4096 maximum (2:1 ratio recommended)
+- Maximum: 5MB
+- Formats: JPG, PNG, WebP, GIF
+
+**Relationship with Open Graph:**
+- Twitter falls back to OG tags if Twitter tags missing
+- OG `og:title` → `twitter:title`
+- OG `og:description` → `twitter:description`
+- OG `og:image` → `twitter:image`
+
+**Testing:**
+- [Twitter Card Validator](https://cards-dev.twitter.com/validator)
+
+---
+
+## Viewport Tag (Mobile)
+
+**Purpose:** Control layout on mobile browsers.
+
+**Required for Mobile:**
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
+
+**Parameters:**
+- `width=device-width`: Match screen width
+- `initial-scale=1`: Initial zoom level
+- `maximum-scale=5`: Maximum zoom allowed
+- `minimum-scale=0.5`: Minimum zoom allowed
+- `user-scalable=yes`: Allow/prevent pinch zoom
+
+**Recommended:**
+```html
+<!-- Standard responsive -->
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Allow zoom (accessibility) -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
+```
+
+**Avoid:**
+```html
+<!-- Bad: Prevents zoom (accessibility issue) -->
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+<!-- Bad: Fixed width -->
+<meta name="viewport" content="width=1024">
+```
+
+---
+
+## Additional Meta Tags
+
+### Charset
+
+**Purpose:** Specify character encoding.
+
+**Required:**
+```html
+<meta charset="UTF-8">
+```
+
+**Best Practice:** Place as early as possible in `<head>` (within first 1024 bytes).
+
+---
+
+### Author
+
+**Purpose:** Specify content author.
+
+```html
+<meta name="author" content="Author Name">
+```
+
+---
+
+### Keywords (Deprecated)
+
+**Status:** Not used by Google, Bing, or other major search engines.
+
+```html
+<!-- Don't use - has no SEO value -->
+<meta name="keywords" content="keyword1, keyword2, keyword3">
+```
+
+---
+
+### Geo Tags
+
+**Purpose:** Specify geographic location (for local businesses).
+
+```html
+<meta name="geo.region" content="US-CA">
+<meta name="geo.placename" content="San Francisco">
+<meta name="geo.position" content="37.7749;-122.4194">
+<meta name="ICBM" content="37.7749, -122.4194">
+```
+
+**Note:** Limited impact. Better to use LocalBusiness schema markup.
+
+---
+
+### Theme Color (Mobile)
+
+**Purpose:** Browser UI color on mobile.
+
+```html
+<meta name="theme-color" content="#4285f4">
+```
+
+---
+
+## Complete Example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Character encoding -->
+  <meta charset="UTF-8">
+
+  <!-- Viewport -->
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Primary Meta Tags -->
+  <title>Organic Coffee Beans | Premium Selection | CoffeeShop</title>
+  <meta name="description" content="Shop premium organic coffee beans with free shipping. Ethically sourced, freshly roasted. Order online today and save 20% on your first purchase.">
+  <meta name="keywords" content="organic coffee, coffee beans, fair trade coffee">
+
+  <!-- Canonical -->
+  <link rel="canonical" href="https://example.com/products/organic-coffee">
+
+  <!-- Open Graph / Facebook -->
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://example.com/products/organic-coffee">
+  <meta property="og:title" content="Organic Coffee Beans | Premium Selection">
+  <meta property="og:description" content="Shop premium organic coffee beans with free shipping. Ethically sourced, freshly roasted.">
+  <meta property="og:image" content="https://example.com/images/coffee-beans-og.jpg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:url" content="https://example.com/products/organic-coffee">
+  <meta name="twitter:title" content="Organic Coffee Beans | Premium Selection">
+  <meta name="twitter:description" content="Shop premium organic coffee beans with free shipping. Ethically sourced, freshly roasted.">
+  <meta name="twitter:image" content="https://example.com/images/coffee-beans-twitter.jpg">
+  <meta name="twitter:site" content="@coffeeshop">
+
+  <!-- Robots -->
+  <meta name="robots" content="index, follow, max-image-preview:large">
+
+  <!-- Additional -->
+  <meta name="author" content="CoffeeShop">
+  <meta name="theme-color" content="#6B4423">
+</head>
+<body>
+  <!-- Page content -->
+</body>
+</html>
+```
+
+---
+
+## Testing & Validation
+
+### Tools
+- **Google:** Rich Results Test, Mobile-Friendly Test
+- **Social:** Facebook Debugger, Twitter Card Validator, LinkedIn Post Inspector
+- **General:** Meta Tags Checker, SEO Meta Checker
+- **Browser DevTools:** Inspect `<head>` section
+
+### Common Issues
+- Missing or duplicate title/description
+- Title/description too long or too short
+- Incorrect canonical URL
+- Missing social media images
+- Wrong image dimensions
+- Conflicting directives (noindex + canonical)
+- Missing viewport tag
+- Incorrect character encoding
+
+### Best Practices Checklist
+- [ ] Unique title and description on every page
+- [ ] Title 50-60 characters
+- [ ] Description 150-160 characters
+- [ ] Canonical tag on all pages
+- [ ] Open Graph tags for social sharing
+- [ ] Twitter Card tags
+- [ ] Viewport tag for mobile
+- [ ] UTF-8 character encoding
+- [ ] No conflicting meta robots directives
+- [ ] Images meet social media requirements

--- a/sales-marketing/skills/seo-expert/references/readability_standards.md
+++ b/sales-marketing/skills/seo-expert/references/readability_standards.md
@@ -1,0 +1,284 @@
+# Readability Standards for SEO and GEO
+
+## Overview
+
+Readability measures how easily text can be understood. For GEO (Generative Engine Optimization), content should target 8th-grade reading level or below to maximize AI citation rates.
+
+## Why Readability Matters for GEO
+
+- AI prefers conversational, accessible content
+- 8th-grade level aligns with how people speak
+- Natural language queries require natural language answers
+- Complex writing reduces AI citation likelihood
+- User engagement improves with clearer writing
+
+## Target Metrics
+
+### Flesch-Kincaid Grade Level
+**Target:** 8.0 or below
+
+**Formula:**
+```
+0.39 × (total words / total sentences) + 11.8 × (total syllables / total words) - 15.59
+```
+
+**Scoring:**
+- 0-8: Optimal for GEO
+- 9-12: Acceptable for technical content
+- 13+: Too complex, revise for accessibility
+
+### Flesch Reading Ease
+**Target:** 60-70 (Standard) or higher
+
+**Formula:**
+```
+206.835 - 1.015 × (total words / total sentences) - 84.6 × (total syllables / total words)
+```
+
+**Scoring:**
+- 90-100: Very Easy (5th grade)
+- 80-89: Easy (6th grade)
+- 70-79: Fairly Easy (7th grade)
+- **60-69: Standard (8th-9th grade)** ✅ Target
+- 50-59: Fairly Difficult (10th-12th grade)
+- 30-49: Difficult (College level)
+- 0-29: Very Difficult (College graduate)
+
+## Key Factors Affecting Readability
+
+### 1. Sentence Length
+**Impact:** Shorter sentences improve readability
+
+**Targets:**
+- **Ideal:** 15-20 words per sentence
+- **Maximum:** 25 words per sentence
+- **Break up:** Sentences over 30 words
+
+**Example - Poor:**
+```
+Search Engine Optimization, which is commonly referred to as SEO by
+digital marketing professionals and practitioners, involves a comprehensive
+set of strategies and techniques that are designed to improve the visibility
+and ranking of websites in search engine results pages, thereby increasing
+organic traffic and potentially leading to higher conversion rates.
+(59 words)
+```
+
+**Example - Good:**
+```
+SEO (Search Engine Optimization) improves website visibility in search
+results. It uses various strategies to increase organic traffic. Better
+rankings often lead to higher conversion rates.
+(3 sentences, avg 9 words each)
+```
+
+### 2. Word Complexity (Syllables)
+**Impact:** Simpler words improve readability
+
+**Targets:**
+- **Ideal:** 1.5 syllables per word or less
+- **Maximum:** 1.7 syllables per word
+
+**Common Replacements:**
+| Complex (3+ syllables) | Simple (1-2 syllables) |
+|------------------------|------------------------|
+| utilize | use |
+| implement | set up, add |
+| comprehensive | full, complete |
+| methodology | method, way |
+| facilitate | help, ease |
+| additional | more, extra |
+| modification | change |
+| subsequently | then, next |
+| demonstrate | show |
+| approximately | about |
+
+### 3. Paragraph Length
+**Impact:** Shorter paragraphs are easier to scan
+
+**Targets:**
+- **Ideal:** 2-4 sentences per paragraph
+- **Maximum:** 5-6 sentences per paragraph
+- **Digital content:** Shorter is better
+
+### 4. Active vs Passive Voice
+**Impact:** Active voice is clearer and more direct
+
+**Passive (Poor):**
+- "The website was optimized by our team"
+- "Results were achieved after implementation"
+
+**Active (Good):**
+- "Our team optimized the website"
+- "We achieved results after implementation"
+
+## Writing Techniques for Better Readability
+
+### Use Conversational Language
+
+**Academic/Formal:**
+```
+The implementation of search engine optimization strategies necessitates
+a comprehensive understanding of algorithmic ranking factors.
+```
+
+**Conversational:**
+```
+To use SEO effectively, you need to understand how search engines rank
+pages.
+```
+
+### Break Down Complex Ideas
+
+**Complex:**
+```
+SEO encompasses on-page optimization, technical SEO, link building, and
+content strategy, all working synergistically to improve rankings.
+```
+
+**Simple:**
+```
+SEO has four main parts:
+1. On-page optimization (titles, content, structure)
+2. Technical SEO (speed, mobile, indexing)
+3. Link building (getting quality backlinks)
+4. Content strategy (creating valuable content)
+
+These work together to improve your rankings.
+```
+
+### Use Lists and Formatting
+
+**Dense paragraph:**
+```
+To optimize for voice search, ensure your content answers questions
+directly, uses natural language, targets long-tail keywords, implements
+FAQ schema, optimizes for local search if applicable, and improves page
+speed for mobile users.
+```
+
+**Formatted list:**
+```
+To optimize for voice search:
+- Answer questions directly
+- Use natural language
+- Target long-tail keywords
+- Implement FAQ schema
+- Optimize for local search
+- Improve mobile page speed
+```
+
+### Define Jargon When Necessary
+
+**Poor:**
+```
+Implement canonical tags to prevent duplicate content issues.
+```
+
+**Good:**
+```
+Add canonical tags (a special HTML element) to prevent duplicate content
+issues. This tells search engines which version of a page is the "main"
+one.
+```
+
+## Testing Your Content
+
+### Using check_readability.py
+
+```bash
+python3 scripts/check_readability.py page.html
+```
+
+**Output provides:**
+- Flesch-Kincaid Grade Level
+- Flesch Reading Ease score
+- Average words per sentence
+- Average syllables per word
+- Specific recommendations
+
+### Manual Checks
+
+1. **Read aloud** - If you stumble, simplify
+2. **Have someone else read** - Fresh eyes catch complexity
+3. **Check sentence variety** - Mix short and medium lengths
+4. **Scan for long words** - Replace with simpler alternatives
+5. **Look for passive voice** - Convert to active
+
+## Content Type Specific Targets
+
+### Blog Posts & Articles
+- **Target:** Grade 8 or below
+- **Flesch Reading Ease:** 60-70+
+- Prioritize accessibility and engagement
+
+### Technical Documentation
+- **Target:** Grade 10-12 acceptable
+- **Flesch Reading Ease:** 50-60
+- Define technical terms clearly
+
+### Landing Pages
+- **Target:** Grade 6-8
+- **Flesch Reading Ease:** 70-80
+- Maximize clarity for conversions
+
+### FAQs
+- **Target:** Grade 6-8
+- **Flesch Reading Ease:** 70-80
+- Direct, simple answers
+
+## Common Mistakes
+
+### 1. Academic Writing Style
+- Using complex vocabulary unnecessarily
+- Long, compound sentences
+- Passive voice dominance
+
+### 2. Jargon Overload
+- Assuming reader knowledge
+- Not defining technical terms
+- Industry-specific acronyms without explanation
+
+### 3. Dense Paragraphs
+- Wall of text with no breaks
+- Multiple ideas in single paragraph
+- No visual breathing room
+
+### 4. Complex Sentence Structure
+- Multiple clauses and subclauses
+- Nested parenthetical statements
+- Overuse of commas
+
+## Quick Improvement Checklist
+
+- [ ] Average sentence length under 20 words
+- [ ] Average syllables per word under 1.6
+- [ ] Paragraphs 2-4 sentences each
+- [ ] Defined all jargon and acronyms
+- [ ] Used active voice (80%+)
+- [ ] Added lists for complex information
+- [ ] Included examples and definitions
+- [ ] Removed unnecessary complexity
+- [ ] Tested with check_readability.py
+- [ ] Achieved Grade 8 or below
+
+## Tools
+
+### Included in This Skill
+- `scripts/check_readability.py` - Automated Flesch-Kincaid analysis
+
+### Free External Tools
+- Hemingway Editor (hemingwayapp.com) - Highlights complex sentences
+- Readable.com - Free readability testing
+- Grammarly - Free version checks readability
+
+### Browser Extensions
+- Hemingway Editor Desktop App ($19.99 one-time)
+- Readable browser extension
+
+## References
+
+- Flesch-Kincaid formulas developed by Rudolf Flesch and J. Peter Kincaid
+- Used by U.S. Department of Defense for document clarity
+- Standard for consumer-facing content accessibility
+- Correlates with AI citation rates in GEO research

--- a/sales-marketing/skills/seo-expert/references/schema_markup_guide.md
+++ b/sales-marketing/skills/seo-expert/references/schema_markup_guide.md
@@ -1,0 +1,748 @@
+# Schema Markup Guide for SEO
+
+Schema.org structured data helps search engines understand your content and can enable rich results in search.
+
+## What is Schema Markup?
+
+**Schema.org** is a collaborative vocabulary for structured data. It helps search engines:
+- Understand content context
+- Display rich snippets
+- Enable enhanced search features
+- Improve content categorization
+
+**Formats:**
+- **JSON-LD** (Recommended by Google)
+- Microdata (HTML attributes)
+- RDFa (Resource Description Framework)
+
+**This guide focuses on JSON-LD** as it's the preferred format.
+
+---
+
+## JSON-LD Basics
+
+**Syntax:**
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TypeName",
+  "property": "value"
+}
+</script>
+```
+
+**Placement:** Typically in `<head>` or `<body>`, can be anywhere.
+
+**Multiple Schemas:** Use multiple `<script>` tags or array format.
+
+---
+
+## Common Schema Types
+
+### 1. Organization
+
+**Use for:** Company/organization homepage.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Example Company",
+  "url": "https://example.com",
+  "logo": "https://example.com/logo.png",
+  "description": "Brief company description",
+  "sameAs": [
+    "https://www.facebook.com/examplecompany",
+    "https://twitter.com/examplecompany",
+    "https://www.linkedin.com/company/examplecompany"
+  ],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "+1-555-123-4567",
+    "contactType": "customer service",
+    "email": "support@example.com",
+    "availableLanguage": ["English", "Spanish"]
+  },
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "San Francisco",
+    "addressRegion": "CA",
+    "postalCode": "94102",
+    "addressCountry": "US"
+  }
+}
+```
+
+---
+
+### 2. Website & SearchAction
+
+**Use for:** Homepage, enables site search box in results.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Example Company",
+  "url": "https://example.com",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://example.com/search?q={search_term_string}"
+    },
+    "query-input": "required name=search_term_string"
+  }
+}
+```
+
+---
+
+### 3. Article / BlogPosting
+
+**Use for:** Blog posts, news articles.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Article Title",
+  "image": [
+    "https://example.com/image.jpg",
+    "https://example.com/image-4x3.jpg",
+    "https://example.com/image-16x9.jpg"
+  ],
+  "datePublished": "2024-01-15T08:00:00+00:00",
+  "dateModified": "2024-01-16T10:30:00+00:00",
+  "author": {
+    "@type": "Person",
+    "name": "Author Name",
+    "url": "https://example.com/author/authorname"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Example Company",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://example.com/logo.png",
+      "width": 600,
+      "height": 60
+    }
+  },
+  "description": "Article description or excerpt",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://example.com/article"
+  }
+}
+```
+
+**Image Requirements:**
+- High resolution (1200px wide minimum)
+- Multiple aspect ratios (16x9, 4x3, 1x1)
+- Logo: 600x60px
+
+---
+
+### 4. Product
+
+**Use for:** E-commerce product pages.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Product Name",
+  "image": [
+    "https://example.com/product-image-1.jpg",
+    "https://example.com/product-image-2.jpg"
+  ],
+  "description": "Product description",
+  "sku": "SKU123",
+  "mpn": "MPN456",
+  "brand": {
+    "@type": "Brand",
+    "name": "Brand Name"
+  },
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/product",
+    "priceCurrency": "USD",
+    "price": "99.99",
+    "priceValidUntil": "2024-12-31",
+    "availability": "https://schema.org/InStock",
+    "itemCondition": "https://schema.org/NewCondition",
+    "seller": {
+      "@type": "Organization",
+      "name": "Example Company"
+    }
+  },
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "reviewCount": "89"
+  }
+}
+```
+
+**Availability Values:**
+- `https://schema.org/InStock`
+- `https://schema.org/OutOfStock`
+- `https://schema.org/PreOrder`
+- `https://schema.org/Discontinued`
+
+---
+
+### 5. Review / AggregateRating
+
+**Use for:** Product/service reviews.
+
+**Single Review:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Review",
+  "itemReviewed": {
+    "@type": "Product",
+    "name": "Product Name",
+    "image": "https://example.com/product.jpg"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "Reviewer Name"
+  },
+  "reviewRating": {
+    "@type": "Rating",
+    "ratingValue": "5",
+    "bestRating": "5",
+    "worstRating": "1"
+  },
+  "reviewBody": "This is an excellent product. Highly recommended!",
+  "datePublished": "2024-01-15"
+}
+```
+
+**Aggregate Rating:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Product",
+  "name": "Product Name",
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.5",
+    "ratingCount": "89",
+    "reviewCount": "72",
+    "bestRating": "5",
+    "worstRating": "1"
+  }
+}
+```
+
+---
+
+### 6. Breadcrumbs
+
+**Use for:** Navigation breadcrumbs.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://example.com"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "Category",
+      "item": "https://example.com/category"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Product",
+      "item": "https://example.com/category/product"
+    }
+  ]
+}
+```
+
+---
+
+### 7. FAQ
+
+**Use for:** Frequently Asked Questions pages/sections.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is your return policy?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>We offer a 30-day money-back guarantee on all products.</p>"
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do you ship internationally?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "<p>Yes, we ship to over 100 countries worldwide.</p>"
+      }
+    }
+  ]
+}
+```
+
+**Notes:**
+- Answer text can include HTML
+- Minimum 2 questions
+- Maximum 1 FAQPage per page
+
+---
+
+### 8. HowTo
+
+**Use for:** Step-by-step instructions.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Bake Chocolate Chip Cookies",
+  "description": "Simple recipe for classic chocolate chip cookies",
+  "image": "https://example.com/cookie-recipe.jpg",
+  "totalTime": "PT45M",
+  "estimatedCost": {
+    "@type": "MonetaryAmount",
+    "currency": "USD",
+    "value": "10"
+  },
+  "supply": [
+    {
+      "@type": "HowToSupply",
+      "name": "flour"
+    },
+    {
+      "@type": "HowToSupply",
+      "name": "chocolate chips"
+    }
+  ],
+  "tool": [
+    {
+      "@type": "HowToTool",
+      "name": "mixing bowl"
+    }
+  ],
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Mix ingredients",
+      "text": "Combine flour, sugar, and butter in a bowl",
+      "image": "https://example.com/step1.jpg",
+      "url": "https://example.com/recipe#step1"
+    },
+    {
+      "@type": "HowToStep",
+      "name": "Bake",
+      "text": "Bake at 350°F for 12 minutes",
+      "image": "https://example.com/step2.jpg",
+      "url": "https://example.com/recipe#step2"
+    }
+  ]
+}
+```
+
+---
+
+### 9. Local Business
+
+**Use for:** Local businesses (restaurants, stores, services).
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "LocalBusiness",
+  "name": "Example Coffee Shop",
+  "image": "https://example.com/storefront.jpg",
+  "@id": "https://example.com",
+  "url": "https://example.com",
+  "telephone": "+1-555-123-4567",
+  "priceRange": "$$",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "123 Main St",
+    "addressLocality": "San Francisco",
+    "addressRegion": "CA",
+    "postalCode": "94102",
+    "addressCountry": "US"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 37.7749,
+    "longitude": -122.4194
+  },
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday"
+      ],
+      "opens": "08:00",
+      "closes": "18:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Saturday", "Sunday"],
+      "opens": "09:00",
+      "closes": "17:00"
+    }
+  ],
+  "sameAs": [
+    "https://www.facebook.com/examplecoffee",
+    "https://www.instagram.com/examplecoffee"
+  ]
+}
+```
+
+**More Specific Types:**
+- Restaurant
+- Hotel
+- Store
+- AutoRepair
+- MedicalOrganization
+- etc.
+
+---
+
+### 10. Event
+
+**Use for:** Concerts, conferences, classes, etc.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Event",
+  "name": "SEO Conference 2024",
+  "description": "Annual conference for SEO professionals",
+  "image": "https://example.com/event-banner.jpg",
+  "startDate": "2024-06-15T09:00:00-07:00",
+  "endDate": "2024-06-17T17:00:00-07:00",
+  "eventStatus": "https://schema.org/EventScheduled",
+  "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
+  "location": {
+    "@type": "Place",
+    "name": "Convention Center",
+    "address": {
+      "@type": "PostalAddress",
+      "streetAddress": "123 Main St",
+      "addressLocality": "San Francisco",
+      "addressRegion": "CA",
+      "postalCode": "94102",
+      "addressCountry": "US"
+    }
+  },
+  "offers": {
+    "@type": "Offer",
+    "url": "https://example.com/event/tickets",
+    "price": "299",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock",
+    "validFrom": "2024-01-01"
+  },
+  "performer": {
+    "@type": "Person",
+    "name": "Keynote Speaker"
+  },
+  "organizer": {
+    "@type": "Organization",
+    "name": "Example Company",
+    "url": "https://example.com"
+  }
+}
+```
+
+**Event Status:**
+- `https://schema.org/EventScheduled`
+- `https://schema.org/EventCancelled`
+- `https://schema.org/EventPostponed`
+- `https://schema.org/EventRescheduled`
+
+**Attendance Mode:**
+- `https://schema.org/OfflineEventAttendanceMode` (In-person)
+- `https://schema.org/OnlineEventAttendanceMode` (Virtual)
+- `https://schema.org/MixedEventAttendanceMode` (Hybrid)
+
+---
+
+### 11. Video
+
+**Use for:** Video content.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "How to Train Your Dog",
+  "description": "Complete guide to dog training",
+  "thumbnailUrl": "https://example.com/video-thumbnail.jpg",
+  "uploadDate": "2024-01-15T08:00:00+00:00",
+  "duration": "PT10M30S",
+  "contentUrl": "https://example.com/video.mp4",
+  "embedUrl": "https://example.com/embed/video123",
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "https://schema.org/WatchAction",
+    "userInteractionCount": 5647
+  }
+}
+```
+
+---
+
+### 12. Recipe
+
+**Use for:** Recipe content.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "Recipe",
+  "name": "Chocolate Chip Cookies",
+  "image": [
+    "https://example.com/cookie-1x1.jpg",
+    "https://example.com/cookie-4x3.jpg",
+    "https://example.com/cookie-16x9.jpg"
+  ],
+  "author": {
+    "@type": "Person",
+    "name": "Chef Name"
+  },
+  "datePublished": "2024-01-15",
+  "description": "Classic homemade chocolate chip cookies",
+  "prepTime": "PT20M",
+  "cookTime": "PT12M",
+  "totalTime": "PT32M",
+  "keywords": "cookies, dessert, baking",
+  "recipeYield": "24 cookies",
+  "recipeCategory": "Dessert",
+  "recipeCuisine": "American",
+  "nutrition": {
+    "@type": "NutritionInformation",
+    "calories": "150 calories",
+    "fatContent": "7g",
+    "carbohydrateContent": "22g",
+    "proteinContent": "2g"
+  },
+  "recipeIngredient": [
+    "2 cups flour",
+    "1 cup sugar",
+    "1 cup chocolate chips",
+    "1/2 cup butter"
+  ],
+  "recipeInstructions": [
+    {
+      "@type": "HowToStep",
+      "text": "Preheat oven to 350°F"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Mix dry ingredients"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Add wet ingredients and mix"
+    },
+    {
+      "@type": "HowToStep",
+      "text": "Bake for 12 minutes"
+    }
+  ],
+  "aggregateRating": {
+    "@type": "AggregateRating",
+    "ratingValue": "4.8",
+    "ratingCount": "127"
+  }
+}
+```
+
+---
+
+## Multiple Schemas on One Page
+
+**Option 1: Multiple script tags**
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "Example Company"
+}
+</script>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Example Company",
+  "url": "https://example.com"
+}
+</script>
+```
+
+**Option 2: Array format**
+```html
+<script type="application/ld+json">
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Example Company"
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "name": "Example Company",
+    "url": "https://example.com"
+  }
+]
+</script>
+```
+
+**Option 3: Graph format**
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://example.com/#organization",
+      "name": "Example Company"
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://example.com/#website",
+      "url": "https://example.com",
+      "publisher": {
+        "@id": "https://example.com/#organization"
+      }
+    }
+  ]
+}
+</script>
+```
+
+---
+
+## Testing & Validation
+
+### Google Tools
+- [Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema Markup Validator](https://validator.schema.org/)
+- Google Search Console (Enhancement reports)
+
+### Testing Process
+1. Run Rich Results Test
+2. Fix any errors (red)
+3. Address warnings (yellow) if possible
+4. Deploy to production
+5. Monitor in Search Console
+
+### Common Errors
+- Missing required properties
+- Invalid property values
+- Incorrect date formats
+- Wrong image dimensions
+- Invalid URLs
+- Type mismatches
+
+---
+
+## Best Practices
+
+### General
+- Use JSON-LD format
+- Place in `<head>` or near relevant content
+- Validate before deployment
+- Include all required properties
+- Use specific types when available
+- Keep data accurate and up-to-date
+- Match visible page content
+- Don't markup hidden content
+
+### Images
+- Use high-resolution images
+- Include multiple aspect ratios
+- Specify width and height
+- Use absolute URLs
+- Optimize file sizes
+
+### Dates
+- Use ISO 8601 format
+- Include timezone
+- Example: `2024-01-15T08:00:00-08:00`
+
+### Prices
+- Always include currency
+- Keep prices updated
+- Specify availability
+- Include priceValidUntil
+
+---
+
+## Schema Priority by Page Type
+
+**Homepage:**
+1. Organization
+2. WebSite + SearchAction
+3. LocalBusiness (if applicable)
+
+**Blog Posts:**
+1. Article/BlogPosting
+2. Breadcrumbs
+
+**Products:**
+1. Product
+2. AggregateRating
+3. Breadcrumbs
+
+**FAQ Pages:**
+1. FAQPage
+
+**How-To Guides:**
+1. HowTo or Article
+
+**Local Business:**
+1. LocalBusiness
+2. Organization
+
+**Videos:**
+1. VideoObject
+
+**Recipes:**
+1. Recipe
+
+---
+
+## Resources
+
+- [Schema.org Full Documentation](https://schema.org)
+- [Google Search Central - Structured Data](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data)
+- [Rich Results Test](https://search.google.com/test/rich-results)
+- [Schema Markup Generator Tools](https://technicalseo.com/tools/schema-markup-generator/)

--- a/sales-marketing/skills/seo-expert/references/seo_checklist.md
+++ b/sales-marketing/skills/seo-expert/references/seo_checklist.md
@@ -1,0 +1,235 @@
+# Comprehensive SEO Audit Checklist
+
+This checklist provides a systematic approach to evaluating website SEO performance. Use it to ensure thorough coverage during audits.
+
+## Technical SEO
+
+### Crawlability
+- [ ] robots.txt exists and is properly configured
+- [ ] No critical pages blocked by robots.txt
+- [ ] XML sitemap exists and is accessible
+- [ ] Sitemap submitted to Google Search Console
+- [ ] Sitemap includes all important pages
+- [ ] No broken links (404 errors)
+- [ ] No redirect chains (multiple 301s)
+- [ ] Server returns proper HTTP status codes
+- [ ] No orphan pages (pages with no internal links)
+
+### Indexability
+- [ ] Canonical tags properly implemented
+- [ ] No duplicate content issues
+- [ ] Meta robots tags used appropriately
+- [ ] No accidental noindex tags on important pages
+- [ ] Parameter handling configured (for dynamic URLs)
+- [ ] Pagination properly implemented (rel=next/prev or View All)
+- [ ] International targeting configured (hreflang tags)
+
+### Site Architecture
+- [ ] Logical URL structure
+- [ ] URLs are readable and keyword-rich
+- [ ] Maximum 3-4 clicks to reach any page
+- [ ] Internal linking strategy in place
+- [ ] Breadcrumb navigation implemented
+- [ ] HTML sitemap available
+- [ ] Proper use of subdomains vs. subdirectories
+
+### Security & Protocol
+- [ ] HTTPS/SSL certificate installed
+- [ ] All pages served over HTTPS
+- [ ] No mixed content warnings
+- [ ] HSTS header implemented
+- [ ] Security headers configured (CSP, X-Frame-Options)
+
+### Mobile Optimization
+- [ ] Mobile-responsive design
+- [ ] Viewport meta tag configured
+- [ ] Mobile-friendly test passes
+- [ ] No mobile-specific blocking (popups, interstitials)
+- [ ] Touch elements properly sized (48x48px minimum)
+- [ ] Mobile page speed optimized
+
+### Performance
+- [ ] Page load time < 3 seconds
+- [ ] LCP (Largest Contentful Paint) < 2.5s
+- [ ] FID (First Input Delay) < 100ms
+- [ ] CLS (Cumulative Layout Shift) < 0.1
+- [ ] Images optimized (compressed, proper formats)
+- [ ] Lazy loading implemented for images
+- [ ] Critical CSS inlined
+- [ ] JavaScript deferred or async loaded
+- [ ] Browser caching configured
+- [ ] CDN implemented for static assets
+- [ ] Minified CSS and JavaScript
+- [ ] GZIP/Brotli compression enabled
+
+## On-Page SEO
+
+### Title Tags
+- [ ] Unique title for every page
+- [ ] Primary keyword in title
+- [ ] Title length 50-60 characters
+- [ ] Brand name included (usually at end)
+- [ ] Compelling and click-worthy
+- [ ] Matches search intent
+
+### Meta Descriptions
+- [ ] Unique description for every page
+- [ ] Primary keyword in description
+- [ ] Length 150-160 characters
+- [ ] Compelling call-to-action
+- [ ] Matches search intent
+- [ ] Accurate summary of page content
+
+### Header Tags
+- [ ] One H1 tag per page
+- [ ] H1 contains primary keyword
+- [ ] Logical heading hierarchy (H1 → H2 → H3)
+- [ ] No skipped heading levels
+- [ ] Headings describe content structure
+- [ ] Keywords naturally included in subheadings
+
+### Content Quality
+- [ ] Content matches search intent
+- [ ] Comprehensive coverage of topic
+- [ ] Original, not duplicated
+- [ ] Proper grammar and spelling
+- [ ] Readable (Flesch Reading Ease > 60)
+- [ ] E-E-A-T signals present (expertise, authority, trust)
+- [ ] Regular content updates
+- [ ] Adequate content length (1000+ words for competitive topics)
+- [ ] Multimedia content included (images, videos)
+
+### Images
+- [ ] Descriptive, keyword-rich file names
+- [ ] Alt text on all images
+- [ ] Appropriate file formats (WebP, JPEG, PNG)
+- [ ] Compressed file sizes
+- [ ] Responsive images (srcset)
+- [ ] Lazy loading implemented
+- [ ] Image sitemaps for important images
+
+### Internal Links
+- [ ] Strategic internal linking structure
+- [ ] Descriptive anchor text
+- [ ] No broken internal links
+- [ ] Link to important pages from homepage
+- [ ] Related content linked
+- [ ] Reasonable number of internal links per page
+
+### URL Structure
+- [ ] Short, descriptive URLs
+- [ ] Keywords in URL
+- [ ] Hyphens separate words (not underscores)
+- [ ] Lowercase letters only
+- [ ] No unnecessary parameters
+- [ ] Consistent structure across site
+
+## Schema Markup (Structured Data)
+
+- [ ] Organization schema on homepage
+- [ ] Website/SearchAction schema implemented
+- [ ] Article/BlogPosting schema on blog posts
+- [ ] Product schema on product pages
+- [ ] Review/AggregateRating schema where applicable
+- [ ] FAQ schema for FAQ sections
+- [ ] Breadcrumb schema implemented
+- [ ] Local Business schema (if applicable)
+- [ ] Event schema (if applicable)
+- [ ] Recipe schema (if applicable)
+- [ ] Video schema for video content
+- [ ] Schema validates in Google's Rich Results Test
+
+## Local SEO (if applicable)
+
+- [ ] Google Business Profile claimed and optimized
+- [ ] NAP (Name, Address, Phone) consistent across web
+- [ ] Local business schema markup
+- [ ] Location pages for multiple locations
+- [ ] Customer reviews encouraged and responded to
+- [ ] Local citations built (Yelp, industry directories)
+- [ ] Embedded Google Map on contact page
+
+## Social Media Integration
+
+- [ ] Open Graph tags implemented
+- [ ] Twitter Card tags implemented
+- [ ] Appropriate og:image for social sharing
+- [ ] og:title and og:description optimized
+- [ ] Social media profiles linked from website
+
+## Analytics & Tracking
+
+- [ ] Google Analytics installed
+- [ ] Google Search Console configured
+- [ ] Search Console verified
+- [ ] Analytics tracking conversions/goals
+- [ ] Event tracking configured
+- [ ] No duplicate tracking codes
+- [ ] Privacy policy compliant with GDPR
+
+## Content Strategy
+
+- [ ] Target keyword research completed
+- [ ] Keyword map created (keywords → pages)
+- [ ] Content calendar in place
+- [ ] Regular content publishing schedule
+- [ ] Content addresses user questions
+- [ ] Topic clusters and pillar pages strategy
+- [ ] Competitor content analysis completed
+
+## Off-Page SEO Considerations
+
+- [ ] Backlink profile healthy (quality over quantity)
+- [ ] No spammy or toxic backlinks
+- [ ] Disavow file submitted if needed
+- [ ] Brand mentions monitoring
+- [ ] Guest posting opportunities identified
+- [ ] Industry directory submissions
+- [ ] Social signals present
+
+## E-commerce Specific (if applicable)
+
+- [ ] Product descriptions unique and detailed
+- [ ] Product schema markup
+- [ ] Review schema for product ratings
+- [ ] Faceted navigation handled properly
+- [ ] Out-of-stock pages handled correctly
+- [ ] Category pages optimized
+- [ ] Checkout process simple and fast
+
+## Accessibility
+
+- [ ] WCAG 2.1 Level AA compliance
+- [ ] Proper heading structure for screen readers
+- [ ] Alt text on images
+- [ ] ARIA labels where appropriate
+- [ ] Keyboard navigation functional
+- [ ] Sufficient color contrast
+- [ ] Form labels properly associated
+
+## Priority Assessment
+
+When conducting audits, categorize issues by priority:
+
+**Critical (Fix Immediately)**
+- Indexability blocks (noindex, robots.txt blocking)
+- Major technical errors (500s, extensive 404s)
+- Security issues (no HTTPS, mixed content)
+- Mobile usability failures
+- Core Web Vitals failures
+
+**Important (Fix Soon)**
+- Missing or poor meta tags
+- Broken internal links
+- Duplicate content
+- Slow page speed
+- Missing schema markup
+- Poor heading hierarchy
+
+**Enhancement (Optimize When Possible)**
+- Image optimization opportunities
+- Internal linking improvements
+- Content depth expansion
+- Social media tags
+- Additional schema types
+- Advanced technical optimizations

--- a/sales-marketing/skills/seo-expert/references/technical_seo.md
+++ b/sales-marketing/skills/seo-expert/references/technical_seo.md
@@ -1,0 +1,645 @@
+# Technical SEO Reference Guide
+
+This guide covers technical SEO requirements and best practices for ensuring search engines can properly crawl, index, and rank your website.
+
+## Crawlability
+
+### robots.txt
+
+**Purpose:** Control which parts of your site search engines can access.
+
+**Location:** Must be at root domain: `https://example.com/robots.txt`
+
+**Basic Syntax:**
+```
+User-agent: *
+Disallow: /admin/
+Disallow: /private/
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml
+```
+
+**Best Practices:**
+- Always include sitemap reference
+- Test in Google Search Console
+- Don't block CSS/JavaScript (needed for rendering)
+- Use Allow to override Disallow for subdirectories
+- Be cautious with wildcard blocking
+
+**Common Patterns:**
+```
+# Block specific bot
+User-agent: BadBot
+Disallow: /
+
+# Block file types
+User-agent: *
+Disallow: /*.pdf$
+Disallow: /*.doc$
+
+# Crawl delay (non-Google)
+User-agent: *
+Crawl-delay: 10
+```
+
+**Critical Errors:**
+- Blocking important pages
+- Blocking CSS/JS (prevents proper rendering)
+- Syntax errors causing misinterpretation
+- No sitemap reference
+
+---
+
+### XML Sitemaps
+
+**Purpose:** Help search engines discover and prioritize content.
+
+**Location:** Referenced in robots.txt, submitted to Search Console.
+
+**Basic Structure:**
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/page</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>
+```
+
+**Limitations:**
+- Maximum 50,000 URLs per sitemap
+- Maximum 50MB uncompressed
+- Use sitemap index for larger sites
+
+**Sitemap Index:**
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://example.com/sitemap-products.xml</loc>
+    <lastmod>2024-01-15</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://example.com/sitemap-blog.xml</loc>
+    <lastmod>2024-01-15</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+**Best Practices:**
+- Include only canonical URLs
+- Update lastmod when content changes
+- Use priority thoughtfully (not all pages at 1.0)
+- Submit to Google Search Console and Bing Webmaster Tools
+- Create separate sitemaps by content type
+- Include images, videos in specialized sitemaps
+- Keep sitemaps updated (regenerate regularly)
+
+**Optional Elements:**
+- `<changefreq>`: Hint for crawl frequency (often ignored)
+- `<priority>`: Relative importance (0.0 to 1.0)
+- `<lastmod>`: Last modification date (recommended)
+
+---
+
+### Internal Linking
+
+**Purpose:** Help search engines discover pages and distribute link equity.
+
+**Best Practices:**
+- Every page accessible within 3-4 clicks from homepage
+- Use descriptive anchor text
+- Link to important pages from high-authority pages
+- Implement breadcrumb navigation
+- Create topic clusters (pillar pages + supporting content)
+- Avoid excessive links (100-150 per page maximum)
+- Fix broken internal links
+
+**Link Equity Distribution:**
+- Homepage typically has highest authority
+- Strategic internal linking passes authority
+- Deep pages need multiple quality internal links
+- Use dofollow for internal links (default)
+
+**Orphan Pages:**
+- Pages with no internal links pointing to them
+- Won't be discovered by crawlers
+- Must be in sitemap or have direct external links
+
+---
+
+## Indexability
+
+### Canonical Tags
+
+**Purpose:** Specify the preferred version of duplicate or similar pages.
+
+**Implementation:**
+```html
+<link rel="canonical" href="https://example.com/preferred-url">
+```
+
+**Use Cases:**
+- Paginated content
+- Product variations (size, color)
+- HTTP vs HTTPS
+- www vs non-www
+- URL parameters (tracking, sorting)
+- Print versions
+- Mobile vs desktop versions
+
+**Best Practices:**
+- Self-referencing canonical on all pages
+- Point to the most complete version
+- Use absolute URLs, not relative
+- Ensure canonical URL is accessible (not 404)
+- Avoid canonical chains (A→B→C)
+- One canonical per page
+
+**Common Mistakes:**
+- Canonical pointing to 404 or redirect
+- Multiple canonical tags
+- Canonical on paginated pages pointing to page 1
+- Conflicting signals (canonical + noindex)
+
+---
+
+### Meta Robots Tags
+
+**Purpose:** Control how search engines index and follow links on specific pages.
+
+**Implementation:**
+```html
+<meta name="robots" content="noindex, nofollow">
+```
+
+**Directives:**
+- `index` / `noindex`: Allow/prevent indexing
+- `follow` / `nofollow`: Allow/prevent following links
+- `noarchive`: Prevent cached copy
+- `nosnippet`: Prevent snippet in search results
+- `max-snippet:[number]`: Limit snippet length
+- `max-image-preview:[setting]`: Control image preview size
+- `max-video-preview:[number]`: Limit video preview length
+
+**Common Uses:**
+```html
+<!-- Prevent indexing but allow crawling links -->
+<meta name="robots" content="noindex, follow">
+
+<!-- Block specific bot -->
+<meta name="googlebot" content="noindex">
+
+<!-- Prevent all (same as above for most bots) -->
+<meta name="robots" content="none">
+
+<!-- Allow but limit snippet -->
+<meta name="robots" content="max-snippet:100">
+```
+
+**X-Robots-Tag HTTP Header:**
+For non-HTML resources (PDFs, images):
+```
+X-Robots-Tag: noindex, nofollow
+```
+
+**Best Practices:**
+- Don't mix conflicting directives
+- Test with Google Search Console
+- Use noindex for: thin content, duplicate pages, private pages
+- Avoid accidentally noindexing important pages
+- Remove noindex when ready to launch
+
+---
+
+### Duplicate Content
+
+**Problem:** Same/similar content on multiple URLs confuses search engines.
+
+**Solutions:**
+
+1. **Canonical Tags** (preferred method)
+   ```html
+   <link rel="canonical" href="https://example.com/original">
+   ```
+
+2. **301 Redirects**
+   - Permanently redirect duplicates to canonical version
+   - Passes link equity
+   - Best for: URL migration, removing parameters
+
+3. **Parameter Handling** (Google Search Console)
+   - Tell Google how to handle URL parameters
+   - Useful for: faceted navigation, tracking codes
+
+4. **Noindex**
+   - Last resort for thin/low-value variations
+   - Doesn't pass link equity
+
+**Common Duplicate Content Issues:**
+- www vs non-www
+- HTTP vs HTTPS
+- Trailing slash variations
+- URL parameters (tracking, session IDs)
+- Printer-friendly versions
+- Paginated series
+- Product variations
+- Scraped/syndicated content
+
+---
+
+## Site Architecture
+
+### URL Structure
+
+**Best Practices:**
+- Short and descriptive
+- Include target keywords
+- Use hyphens (not underscores)
+- Lowercase only
+- Logical hierarchy
+- Avoid deep nesting (max 4-5 levels)
+
+**Good Examples:**
+```
+https://example.com/products/category/product-name
+https://example.com/blog/seo-tips-2024
+https://example.com/about/team
+```
+
+**Bad Examples:**
+```
+https://example.com/index.php?id=123&cat=45
+https://example.com/this_is_a_very_long_url_with_underscores
+https://example.com/level1/level2/level3/level4/level5/page
+```
+
+**URL Parameters:**
+- Avoid when possible
+- Use for: filtering, sorting, pagination
+- Configure in Search Console
+- Consider canonical tags
+
+---
+
+### Breadcrumbs
+
+**Purpose:** Navigation aid + structured data for search engines.
+
+**HTML Structure:**
+```html
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/">Home</a></li>
+    <li><a href="/category">Category</a></li>
+    <li aria-current="page">Product</li>
+  </ol>
+</nav>
+```
+
+**Schema Markup:**
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [{
+    "@type": "ListItem",
+    "position": 1,
+    "name": "Home",
+    "item": "https://example.com"
+  },{
+    "@type": "ListItem",
+    "position": 2,
+    "name": "Category",
+    "item": "https://example.com/category"
+  },{
+    "@type": "ListItem",
+    "position": 3,
+    "name": "Product"
+  }]
+}
+```
+
+**Benefits:**
+- Better UX
+- Rich results in search
+- Helps search engines understand site structure
+
+---
+
+## Security & Protocol
+
+### HTTPS/SSL
+
+**Why it matters:**
+- Confirmed ranking signal
+- Required for HTTP/2
+- User trust and security
+- Chrome marks HTTP as "Not Secure"
+
+**Implementation Checklist:**
+- [ ] Install valid SSL certificate
+- [ ] Redirect all HTTP to HTTPS (301)
+- [ ] Update internal links to HTTPS
+- [ ] Update canonical tags to HTTPS
+- [ ] Update sitemap to HTTPS
+- [ ] Update Search Console property
+- [ ] Fix mixed content warnings
+- [ ] Update CDN/external resources to HTTPS
+
+**Mixed Content:**
+```html
+<!-- Bad: HTTP resource on HTTPS page -->
+<img src="http://example.com/image.jpg">
+
+<!-- Good: HTTPS or protocol-relative -->
+<img src="https://example.com/image.jpg">
+<img src="//example.com/image.jpg">
+```
+
+---
+
+### HSTS (HTTP Strict Transport Security)
+
+**Purpose:** Force HTTPS connections, prevent downgrade attacks.
+
+**Implementation:**
+```
+Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+```
+
+**Parameters:**
+- `max-age`: Seconds to remember (1 year = 31536000)
+- `includeSubDomains`: Apply to all subdomains
+- `preload`: Eligible for browser preload lists
+
+---
+
+## Mobile Optimization
+
+### Mobile-First Indexing
+
+**What it means:** Google primarily uses mobile version for indexing and ranking.
+
+**Requirements:**
+- Mobile and desktop content should be equivalent
+- Structured data on both versions
+- Images accessible and properly sized
+- Meta tags identical
+
+### Viewport Configuration
+
+**Required Meta Tag:**
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1">
+```
+
+**Common Configurations:**
+```html
+<!-- Basic responsive -->
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<!-- Prevent zoom (not recommended) -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+
+<!-- Fixed width (not recommended for mobile) -->
+<meta name="viewport" content="width=1024">
+```
+
+### Responsive Design
+
+**Best Practices:**
+- Fluid layouts (%, em, rem instead of px)
+- Flexible images (max-width: 100%)
+- CSS media queries for breakpoints
+- Touch-friendly tap targets (48x48px minimum)
+- Readable text without zooming (16px base)
+- No horizontal scrolling
+- Fast mobile page speed
+
+**Testing:**
+- Google Mobile-Friendly Test
+- Chrome DevTools Device Mode
+- Real device testing
+- PageSpeed Insights mobile score
+
+---
+
+### Mobile-Specific Issues
+
+**Problems to Avoid:**
+- Flash content
+- Unplayable videos
+- Faulty redirects (mobile to wrong page)
+- Intrusive interstitials
+- Small font sizes
+- Touch elements too close together
+- Content wider than screen
+
+---
+
+## Rendering & JavaScript
+
+### Client-Side Rendering (CSR) Challenges
+
+**Issue:** Content generated by JavaScript may not be indexed.
+
+**Google's Approach:**
+1. Crawls HTML
+2. Queues page for rendering
+3. Renders JavaScript (when resources available)
+4. Indexes rendered content
+
+**Problems:**
+- Rendering delay
+- Resource-intensive
+- May miss dynamically loaded content
+- Infinite scroll issues
+
+### Server-Side Rendering (SSR)
+
+**Benefits:**
+- Content immediately available to crawlers
+- Faster initial page load
+- Better for SEO
+
+**Implementation:**
+- Next.js (React)
+- Nuxt.js (Vue)
+- Angular Universal
+- Custom Node.js solutions
+
+### Static Site Generation (SSG)
+
+**Benefits:**
+- Pre-rendered HTML
+- Excellent performance
+- Perfect for SEO
+- Reduced server load
+
+**Tools:**
+- Next.js (Static Export)
+- Gatsby
+- Hugo
+- Jekyll
+
+### Dynamic Rendering
+
+**Approach:** Serve pre-rendered HTML to bots, CSR to users.
+
+**Tools:**
+- Rendertron
+- Prerender.io
+- Puppeteer/Playwright
+
+**Considerations:**
+- Cloaking concerns (must be equivalent content)
+- Maintenance overhead
+- Caching strategies
+
+---
+
+## Status Codes & Redirects
+
+### HTTP Status Codes
+
+**2xx Success**
+- `200 OK`: Standard successful response
+
+**3xx Redirection**
+- `301 Moved Permanently`: Permanent redirect (passes link equity)
+- `302 Found`: Temporary redirect (doesn't pass full link equity)
+- `307 Temporary Redirect`: Preserves request method
+- `308 Permanent Redirect`: Like 301 but preserves method
+
+**4xx Client Errors**
+- `404 Not Found`: Page doesn't exist
+- `410 Gone`: Permanently removed
+- `403 Forbidden`: Access denied
+
+**5xx Server Errors**
+- `500 Internal Server Error`: Generic server error
+- `503 Service Unavailable`: Temporary server issue
+
+### Redirect Best Practices
+
+**When to use 301:**
+- Permanent URL changes
+- Site migration
+- HTTPS migration
+- Domain changes
+- URL structure changes
+
+**When to use 302:**
+- A/B testing
+- Temporary maintenance
+- Geographic redirects
+- Time-based redirects
+
+**Avoid:**
+- Redirect chains (A→B→C→D)
+- Redirect loops
+- 302 for permanent changes
+- Broken redirect targets (404)
+
+**Testing:**
+- Check HTTP headers
+- Verify redirect status code
+- Test full redirect chain
+- Ensure target URL is accessible
+
+---
+
+## International & Multi-Regional SEO
+
+### Hreflang Tags
+
+**Purpose:** Indicate language and regional targeting.
+
+**Implementation:**
+```html
+<!-- English for US -->
+<link rel="alternate" hreflang="en-us" href="https://example.com/en-us/" />
+
+<!-- English for UK -->
+<link rel="alternate" hreflang="en-gb" href="https://example.com/en-gb/" />
+
+<!-- Spanish for Spain -->
+<link rel="alternate" hreflang="es-es" href="https://example.com/es-es/" />
+
+<!-- Default fallback -->
+<link rel="alternate" hreflang="x-default" href="https://example.com/" />
+```
+
+**Sitemap Implementation:**
+```xml
+<url>
+  <loc>https://example.com/en-us/</loc>
+  <xhtml:link rel="alternate" hreflang="en-gb" href="https://example.com/en-gb/" />
+  <xhtml:link rel="alternate" hreflang="es-es" href="https://example.com/es-es/" />
+  <xhtml:link rel="alternate" hreflang="x-default" href="https://example.com/" />
+</url>
+```
+
+**Language Codes:**
+- ISO 639-1 for language (en, es, fr)
+- ISO 3166-1 Alpha 2 for region (US, GB, ES)
+
+**Best Practices:**
+- Include self-referencing hreflang
+- Include x-default for fallback
+- Ensure bidirectional links
+- Use absolute URLs
+- One implementation method (HTML or sitemap, not both)
+
+---
+
+## Performance Optimization
+
+See `core_web_vitals.md` for detailed performance optimization strategies.
+
+**Quick Technical Checklist:**
+- [ ] Enable GZIP/Brotli compression
+- [ ] Implement browser caching
+- [ ] Minify HTML, CSS, JavaScript
+- [ ] Optimize images
+- [ ] Use CDN
+- [ ] Enable HTTP/2
+- [ ] Defer non-critical JavaScript
+- [ ] Inline critical CSS
+- [ ] Lazy load images
+- [ ] Preload critical resources
+
+---
+
+## Tools for Technical SEO
+
+### Auditing Tools
+- Screaming Frog SEO Spider
+- Sitebulb
+- SEMrush Site Audit
+- Ahrefs Site Audit
+- DeepCrawl
+
+### Google Tools
+- Google Search Console
+- PageSpeed Insights
+- Mobile-Friendly Test
+- Rich Results Test
+- Structured Data Testing Tool
+
+### Testing Tools
+- Chrome DevTools
+- Lighthouse
+- WebPageTest
+- GTmetrix
+
+### Monitoring
+- Google Search Console Performance
+- Log file analysis
+- Real User Monitoring (RUM)
+- Uptime monitoring

--- a/sales-marketing/skills/seo-expert/scripts/analyze_eeat.py
+++ b/sales-marketing/skills/seo-expert/scripts/analyze_eeat.py
@@ -1,0 +1,743 @@
+#!/usr/bin/env python3
+"""
+E-E-A-T Signal Analyzer
+
+Detects Experience, Expertise, Authoritativeness, and Trustworthiness signals
+in web content. E-E-A-T is critical for both SEO rankings and GEO (AI citation
+likelihood).
+
+Usage:
+    python3 analyze_eeat.py <html_file_or_url>
+
+Checks:
+    1. Author bylines with credentials
+    2. External authoritative links (citations)
+    3. Publish and last-modified dates
+    4. Quoted content and expert attributions
+    5. Trust signals (certifications, affiliations)
+    6. Overall E-E-A-T score
+
+References:
+    - references/geo_best_practices.md section 4
+    - references/seo_checklist.md "Content Quality" section
+"""
+
+import sys
+import re
+import json
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CREDENTIAL_PATTERNS = [
+    r'\bPh\.?D\.?\b', r'\bM\.?D\.?\b', r'\bM\.?B\.?A\.?\b',
+    r'\bM\.?S\.?\b', r'\bB\.?S\.?\b', r'\bB\.?A\.?\b',
+    r'\bJ\.?D\.?\b', r'\bEd\.?D\.?\b', r'\bD\.?O\.?\b',
+    r'\bR\.?N\.?\b', r'\bC\.?P\.?A\.?\b', r'\bP\.?M\.?P\.?\b',
+    r'\bC\.?F\.?P\.?\b', r'\bC\.?F\.?A\.?\b',
+    r'\bDr\.?', r'\bProf\.?', r'\bProfessor\b',
+]
+
+AUTHORITATIVE_TLDS = {'.gov', '.edu', '.mil'}
+
+AUTHORITATIVE_DOMAINS = {
+    'who.int', 'nih.gov', 'cdc.gov', 'fda.gov', 'epa.gov',
+    'nasa.gov', 'nature.com', 'science.org', 'pubmed.ncbi.nlm.nih.gov',
+    'scholar.google.com', 'ieee.org', 'acm.org', 'reuters.com',
+    'apnews.com', 'bbc.com', 'bbc.co.uk',
+}
+
+TRUST_CERT_PATTERNS = [
+    r'\bISO\s*\d{4,5}\b', r'\bSOC\s*[12]\b', r'\bSOC\s*2\b',
+    r'\bHIPAA\b', r'\bGDPR\b', r'\bPCI[\s-]DSS\b', r'\bFedRAMP\b',
+    r'\bCCPA\b', r'\bFERPA\b',
+]
+
+ATTRIBUTION_PATTERNS = [
+    r'according to\s+[A-Z]',
+    r'(?:said|says|stated|noted|explained|reported)\s+[A-Z]',
+    r'(?:—|--|-)\s*[A-Z][a-z]+\s+[A-Z]',  # — Jane Smith
+    r'[""]\s*(?:—|--|-)\s*[A-Z]',           # closing quote — Name
+]
+
+BYLINE_PATTERNS = [
+    r'(?:^|\n)\s*[Bb]y\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)',
+    r'[Ww]ritten\s+by\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)',
+    r'[Aa]uthor:\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)',
+    r'[Rr]eviewed\s+by\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)',
+]
+
+DATE_PATTERNS = [
+    r'\b\d{4}-\d{2}-\d{2}\b',                          # 2024-01-15
+    r'\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{1,2},?\s+\d{4}\b',
+    r'\b\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\.?\s+\d{4}\b',
+    r'\b\d{1,2}/\d{1,2}/\d{4}\b',
+]
+
+
+# ---------------------------------------------------------------------------
+# HTML Parsers
+# ---------------------------------------------------------------------------
+
+class EEATParser(HTMLParser):
+    """Parse HTML for E-E-A-T signals."""
+
+    def __init__(self):
+        super().__init__()
+        # Meta / schema
+        self.meta_tags = []
+        self.json_ld_scripts = []
+        self._in_json_ld = False
+        self._json_ld_buf = []
+
+        # Links
+        self.links = []  # (href, text, is_external)
+
+        # Blockquotes
+        self.blockquotes = []
+        self._in_blockquote = False
+        self._blockquote_buf = []
+
+        # Time elements
+        self.time_elements = []
+
+        # Text content
+        self.text_chunks = []
+        self._skip_depth = 0
+        self._skip_tags = {'script', 'style', 'nav'}
+        self._in_link = False
+        self._link_text = []
+        self._link_href = None
+
+        # Author-related elements
+        self.author_elements = []
+        self._in_author_el = False
+        self._author_el_tag = None
+        self._author_buf = []
+
+        # About / bio sections
+        self.has_about_author = False
+
+    def handle_starttag(self, tag, attrs):
+        attrs_dict = dict(attrs)
+
+        if tag in self._skip_tags:
+            self._skip_depth += 1
+
+        # JSON-LD
+        if tag == 'script' and attrs_dict.get('type') == 'application/ld+json':
+            self._in_json_ld = True
+            self._json_ld_buf = []
+
+        # Meta tags
+        if tag == 'meta':
+            self.meta_tags.append(attrs_dict)
+
+        # Links
+        if tag == 'a':
+            href = attrs_dict.get('href', '')
+            self._in_link = True
+            self._link_text = []
+            self._link_href = href
+
+        # Blockquotes
+        if tag == 'blockquote':
+            self._in_blockquote = True
+            self._blockquote_buf = []
+
+        # Time elements
+        if tag == 'time':
+            dt = attrs_dict.get('datetime', '')
+            if dt:
+                self.time_elements.append(dt)
+
+        # Author-related class/id/rel — use word-boundary check to avoid
+        # false positives on "authority" / "authoritative"
+        cls = attrs_dict.get('class', '')
+        id_attr = attrs_dict.get('id', '')
+        rel = attrs_dict.get('rel', '')
+        combined = f'{cls} {id_attr} {rel}'.lower()
+        # Split on whitespace and non-alphanumeric to get tokens
+        tokens = re.split(r'[^a-z0-9]+', combined)
+        has_author_token = any(
+            t in ('author', 'authors', 'byline') for t in tokens
+        )
+        has_about_token = 'about' in tokens
+        if has_author_token:
+            self._in_author_el = True
+            self._author_el_tag = tag
+            self._author_buf = []
+        if has_author_token and has_about_token:
+            self.has_about_author = True
+
+    def handle_data(self, data):
+        if self._in_json_ld:
+            self._json_ld_buf.append(data)
+            return
+
+        if self._skip_depth > 0:
+            return
+
+        text = data.strip()
+        if text:
+            self.text_chunks.append(text)
+
+        if self._in_link:
+            self._link_text.append(text)
+
+        if self._in_blockquote:
+            self._blockquote_buf.append(text)
+
+        if self._in_author_el:
+            self._author_buf.append(text)
+
+        # Check for "about the author" in visible text
+        if 'about the author' in data.lower():
+            self.has_about_author = True
+
+    def handle_endtag(self, tag):
+        if tag in self._skip_tags and self._skip_depth > 0:
+            self._skip_depth -= 1
+
+        if tag == 'script' and self._in_json_ld:
+            raw = ''.join(self._json_ld_buf)
+            try:
+                self.json_ld_scripts.append(json.loads(raw))
+            except json.JSONDecodeError:
+                pass
+            self._in_json_ld = False
+
+        if tag == 'a' and self._in_link:
+            link_text = ' '.join(self._link_text).strip()
+            self.links.append((self._link_href, link_text))
+            self._in_link = False
+
+        if tag == 'blockquote' and self._in_blockquote:
+            text = ' '.join(self._blockquote_buf).strip()
+            if text:
+                self.blockquotes.append(text)
+            self._in_blockquote = False
+
+        if self._in_author_el and tag == self._author_el_tag:
+            text = ' '.join(self._author_buf).strip()
+            if text:
+                self.author_elements.append(text)
+            self._in_author_el = False
+
+
+# ---------------------------------------------------------------------------
+# Detection Modules
+# ---------------------------------------------------------------------------
+
+def detect_authors(parser):
+    """Detect author bylines and credentials."""
+    authors = []
+    credentials = []
+    full_text = ' '.join(parser.text_chunks)
+
+    # 1. Meta author tag
+    for meta in parser.meta_tags:
+        if meta.get('name', '').lower() == 'author':
+            content = meta.get('content', '').strip()
+            if content:
+                authors.append(('meta_tag', content))
+
+    # 2. JSON-LD author
+    for schema in parser.json_ld_scripts:
+        schemas = schema if isinstance(schema, list) else [schema]
+        for s in schemas:
+            author = s.get('author')
+            if not author:
+                continue
+            if isinstance(author, dict):
+                name = author.get('name', '')
+                if name:
+                    authors.append(('schema', name))
+            elif isinstance(author, str):
+                authors.append(('schema', author))
+            elif isinstance(author, list):
+                for a in author:
+                    name = a.get('name', '') if isinstance(a, dict) else str(a)
+                    if name:
+                        authors.append(('schema', name))
+
+    # 3. Author-class elements
+    for text in parser.author_elements:
+        authors.append(('html_element', text))
+
+    # 4. Byline patterns in visible text
+    for pattern in BYLINE_PATTERNS:
+        for match in re.finditer(pattern, full_text):
+            name = match.group(1) if match.lastindex else match.group(0)
+            authors.append(('byline', name.strip()))
+
+    # Deduplicate by name
+    seen = set()
+    unique_authors = []
+    for source, name in authors:
+        key = name.lower().strip()
+        if key not in seen:
+            seen.add(key)
+            unique_authors.append((source, name))
+
+    # Detect credentials in full text and author names
+    search_text = full_text + ' ' + ' '.join(name for _, name in unique_authors)
+    for pattern in CREDENTIAL_PATTERNS:
+        for match in re.finditer(pattern, search_text):
+            credentials.append(match.group(0))
+
+    return unique_authors, list(set(credentials))
+
+
+def detect_citations(parser, page_url=None):
+    """Count and classify external links."""
+    external_links = []
+    authoritative_links = []
+
+    page_domain = ''
+    if page_url:
+        parsed = urlparse(page_url)
+        page_domain = parsed.netloc.lower()
+        if page_domain.startswith('www.'):
+            page_domain = page_domain[4:]
+
+    for href, text in parser.links:
+        if not href or href.startswith('#') or href.startswith('mailto:'):
+            continue
+
+        # Normalize protocol-relative URLs (//example.com/page)
+        if href.startswith('//'):
+            href = 'https:' + href
+
+        try:
+            parsed = urlparse(href)
+        except Exception:
+            continue
+
+        if not parsed.netloc:
+            continue
+
+        domain = parsed.netloc.lower()
+        if domain.startswith('www.'):
+            domain = domain[4:]
+
+        # Skip same-domain links
+        if page_domain and domain == page_domain:
+            continue
+
+        external_links.append((href, text, domain))
+
+        # Check if authoritative
+        is_auth = False
+        for tld in AUTHORITATIVE_TLDS:
+            if domain.endswith(tld):
+                is_auth = True
+                break
+        if domain in AUTHORITATIVE_DOMAINS:
+            is_auth = True
+
+        if is_auth:
+            authoritative_links.append((href, text, domain))
+
+    return external_links, authoritative_links
+
+
+def detect_dates(parser):
+    """Verify publish and last-modified dates."""
+    dates = {}  # key: type, value: date string
+    full_text = ' '.join(parser.text_chunks)
+
+    # 1. Meta tags
+    date_meta_names = {
+        'article:published_time': 'published',
+        'article:modified_time': 'modified',
+        'datepublished': 'published',
+        'datemodified': 'modified',
+        'date': 'published',
+        'last-modified': 'modified',
+        'dcterms.date': 'published',
+        'dcterms.modified': 'modified',
+    }
+
+    for meta in parser.meta_tags:
+        name = meta.get('name', meta.get('property', '')).lower()
+        content = meta.get('content', '').strip()
+        if name in date_meta_names and content:
+            dates[date_meta_names[name]] = ('meta', content)
+
+    # 2. JSON-LD dates
+    for schema in parser.json_ld_scripts:
+        schemas = schema if isinstance(schema, list) else [schema]
+        for s in schemas:
+            if s.get('datePublished'):
+                dates['published'] = ('schema', s['datePublished'])
+            if s.get('dateModified'):
+                dates['modified'] = ('schema', s['dateModified'])
+
+    # 3. <time> elements
+    for dt in parser.time_elements:
+        if 'published' not in dates:
+            dates['published'] = ('time_element', dt)
+
+    # 4. Visible date patterns
+    visible_dates = []
+    for pattern in DATE_PATTERNS:
+        for match in re.finditer(pattern, full_text):
+            visible_dates.append(match.group(0))
+
+    return dates, visible_dates
+
+
+def detect_quotes(parser):
+    """Detect quoted content and expert attributions."""
+    # Join with single space and normalize whitespace for cross-tag matches
+    full_text = re.sub(r'\s+', ' ', ' '.join(parser.text_chunks))
+
+    # Blockquotes from HTML
+    blockquotes = parser.blockquotes
+
+    # Attribution patterns
+    attributions = []
+    for pattern in ATTRIBUTION_PATTERNS:
+        for match in re.finditer(pattern, full_text, re.IGNORECASE):
+            # Get surrounding context (up to 80 chars)
+            start = max(0, match.start() - 20)
+            end = min(len(full_text), match.end() + 60)
+            context = full_text[start:end].strip()
+            attributions.append(context)
+
+    return blockquotes, attributions
+
+
+def detect_trust_signals(parser):
+    """Check for trust signals: certifications, credentials, affiliations."""
+    full_text = ' '.join(parser.text_chunks)
+    signals = []
+
+    # 1. Certifications/compliance
+    for pattern in TRUST_CERT_PATTERNS:
+        for match in re.finditer(pattern, full_text, re.IGNORECASE):
+            signals.append(('certification', match.group(0)))
+
+    # 2. Privacy policy / terms links
+    for href, text in parser.links:
+        text_lower = text.lower() if text else ''
+        href_lower = (href or '').lower()
+        if 'privacy' in text_lower or 'privacy' in href_lower:
+            signals.append(('policy', 'Privacy Policy'))
+        if 'terms' in text_lower or 'terms-of-service' in href_lower or 'tos' in href_lower:
+            signals.append(('policy', 'Terms of Service'))
+
+    # 3. About the author section
+    if parser.has_about_author:
+        signals.append(('bio', 'About the Author section'))
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for kind, desc in signals:
+        key = f'{kind}:{desc.lower()}'
+        if key not in seen:
+            seen.add(key)
+            unique.append((kind, desc))
+
+    return unique
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def calculate_score(authors, credentials, external_links, authoritative_links,
+                    dates, visible_dates, blockquotes, attributions,
+                    trust_signals, has_about_author):
+    """
+    Score each E-E-A-T dimension 0-25, total 0-100.
+
+    Experience:        Author bylines + first-person presence + expert quotes
+    Expertise:         Credentials + authoritative citations + depth
+    Authoritativeness: External authoritative links + schema + affiliations
+    Trustworthiness:   Dates visible + trust signals + policy links
+    """
+    # Experience (0-25)
+    experience = 0
+    if authors:
+        experience += 10
+    if blockquotes:
+        experience += min(len(blockquotes) * 3, 8)
+    if attributions:
+        experience += min(len(attributions) * 2, 7)
+
+    # Expertise (0-25)
+    expertise = 0
+    if credentials:
+        expertise += min(len(credentials) * 5, 12)
+    if authoritative_links:
+        expertise += min(len(authoritative_links) * 2, 8)
+    if len(external_links) >= 3:
+        expertise += 5
+
+    # Authoritativeness (0-25)
+    authoritativeness = 0
+    if authoritative_links:
+        authoritativeness += min(len(authoritative_links) * 3, 12)
+    if any(s == 'schema' for s, _ in authors):
+        authoritativeness += 5
+    cert_signals = [s for s in trust_signals if s[0] == 'certification']
+    if cert_signals:
+        authoritativeness += min(len(cert_signals) * 3, 8)
+
+    # Trustworthiness (0-25)
+    trustworthiness = 0
+    if 'published' in dates:
+        trustworthiness += 5
+    if 'modified' in dates:
+        trustworthiness += 5
+    if visible_dates:
+        trustworthiness += 3
+    policy_signals = [s for s in trust_signals if s[0] == 'policy']
+    if policy_signals:
+        trustworthiness += min(len(policy_signals) * 3, 6)
+    if has_about_author:
+        trustworthiness += 6
+
+    # Cap each at 25
+    experience = min(experience, 25)
+    expertise = min(expertise, 25)
+    authoritativeness = min(authoritativeness, 25)
+    trustworthiness = min(trustworthiness, 25)
+
+    return {
+        'experience': experience,
+        'expertise': expertise,
+        'authoritativeness': authoritativeness,
+        'trustworthiness': trustworthiness,
+        'total': experience + expertise + authoritativeness + trustworthiness,
+    }
+
+
+def rating_label(total):
+    """Return a human-readable rating."""
+    if total >= 75:
+        return '✅ EXCELLENT'
+    elif total >= 50:
+        return '⚠️  GOOD'
+    elif total >= 25:
+        return '⚠️  NEEDS IMPROVEMENT'
+    else:
+        return '❌ POOR'
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def print_report(authors, credentials, external_links, authoritative_links,
+                 dates, visible_dates, blockquotes, attributions,
+                 trust_signals, scores, has_about_author):
+    """Print structured E-E-A-T analysis report."""
+
+    print('E-E-A-T SIGNAL ANALYSIS')
+    print('=' * 80)
+    print()
+
+    # --- Authors ---
+    print('AUTHOR DETECTION')
+    print('-' * 80)
+    if authors:
+        for source, name in authors:
+            print(f'  ✅ Author found ({source}): {name}')
+    else:
+        print('  ❌ No author byline detected')
+        print('     Recommendation: Add author name with "By [Name]" or <meta name="author">')
+
+    if credentials:
+        print(f'  ✅ Credentials detected: {", ".join(credentials)}')
+    else:
+        print('  ⚠️  No credentials detected')
+        print('     Recommendation: Include author credentials (degrees, certifications, titles)')
+    print()
+
+    # --- Citations ---
+    print('CITATIONS & AUTHORITATIVE LINKS')
+    print('-' * 80)
+    print(f'  External links:      {len(external_links)}')
+    print(f'  Authoritative links: {len(authoritative_links)}')
+
+    if authoritative_links:
+        print()
+        print('  Authoritative sources:')
+        for href, text, domain in authoritative_links[:5]:
+            label = text[:50] if text else domain
+            print(f'    ✅ {label} ({domain})')
+        if len(authoritative_links) > 5:
+            print(f'    ... and {len(authoritative_links) - 5} more')
+    else:
+        print('  ❌ No authoritative (.gov, .edu, .mil, or high-trust) links found')
+        print('     Recommendation: Cite authoritative sources to boost E-E-A-T')
+
+    if len(external_links) < 3:
+        print(f'  ⚠️  Few external links ({len(external_links)})')
+        print('     Recommendation: Add 3+ external citations to credible sources')
+    print()
+
+    # --- Dates ---
+    print('PUBLISH & MODIFIED DATES')
+    print('-' * 80)
+    if 'published' in dates:
+        source, value = dates['published']
+        print(f'  ✅ Published date ({source}): {value}')
+    else:
+        print('  ❌ No published date detected')
+        print('     Recommendation: Add datePublished in Article schema or meta tags')
+
+    if 'modified' in dates:
+        source, value = dates['modified']
+        print(f'  ✅ Modified date ({source}): {value}')
+    else:
+        print('  ⚠️  No modified date detected')
+        print('     Recommendation: Add dateModified to show content freshness')
+
+    if visible_dates:
+        print(f'  ✅ Visible dates found: {", ".join(visible_dates[:3])}')
+    else:
+        print('  ⚠️  No dates visible in page content')
+        print('     Recommendation: Display publish/update dates prominently')
+    print()
+
+    # --- Quotes & Attributions ---
+    print('QUOTED CONTENT & EXPERT ATTRIBUTIONS')
+    print('-' * 80)
+    if blockquotes:
+        print(f'  ✅ Blockquotes found: {len(blockquotes)}')
+        for bq in blockquotes[:2]:
+            preview = bq[:80] + '...' if len(bq) > 80 else bq
+            print(f'     "{preview}"')
+    else:
+        print('  ⚠️  No blockquotes found')
+
+    if attributions:
+        print(f'  ✅ Expert attributions found: {len(attributions)}')
+        for attr in attributions[:3]:
+            print(f'     ...{attr}...')
+    else:
+        print('  ⚠️  No expert attributions detected')
+        print('     Recommendation: Add quotes with "according to [Expert]" or blockquotes')
+    print()
+
+    # --- Trust Signals ---
+    print('TRUST SIGNALS')
+    print('-' * 80)
+    if trust_signals:
+        for kind, desc in trust_signals:
+            print(f'  ✅ {kind.title()}: {desc}')
+    else:
+        print('  ⚠️  No trust signals detected')
+
+    if has_about_author:
+        print('  ✅ "About the Author" section present')
+
+    if not trust_signals and not has_about_author:
+        print('     Recommendation: Add certifications, privacy policy, or author bio section')
+    print()
+
+    # --- Overall Score ---
+    print('OVERALL E-E-A-T SCORE')
+    print('-' * 80)
+    total = scores['total']
+    label = rating_label(total)
+
+    print(f'  Experience:        {scores["experience"]:>2}/25')
+    print(f'  Expertise:         {scores["expertise"]:>2}/25')
+    print(f'  Authoritativeness: {scores["authoritativeness"]:>2}/25')
+    print(f'  Trustworthiness:   {scores["trustworthiness"]:>2}/25')
+    print()
+    print(f'  Total: {total}/100 — {label}')
+    print()
+
+    if total < 50:
+        print('Top recommendations:')
+        if not authors:
+            print('  1. Add visible author byline with credentials')
+        if not authoritative_links:
+            print('  2. Cite authoritative sources (.gov, .edu, established orgs)')
+        if 'published' not in dates:
+            print('  3. Add datePublished in schema or meta tags')
+        if not blockquotes and not attributions:
+            print('  4. Include expert quotes with attributions')
+        if not trust_signals:
+            print('  5. Add trust signals (certifications, privacy policy)')
+        print()
+
+    print('Reference: references/geo_best_practices.md section 4 (E-E-A-T Signals)')
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def analyze_eeat(html_content, page_url=None):
+    """Run full E-E-A-T analysis on HTML content. Returns scores dict."""
+    parser = EEATParser()
+    parser.feed(html_content)
+
+    authors, credentials = detect_authors(parser)
+    external_links, authoritative_links = detect_citations(parser, page_url)
+    dates, visible_dates = detect_dates(parser)
+    blockquotes, attributions = detect_quotes(parser)
+    trust_signals = detect_trust_signals(parser)
+
+    scores = calculate_score(
+        authors, credentials, external_links, authoritative_links,
+        dates, visible_dates, blockquotes, attributions,
+        trust_signals, parser.has_about_author,
+    )
+
+    print_report(
+        authors, credentials, external_links, authoritative_links,
+        dates, visible_dates, blockquotes, attributions,
+        trust_signals, scores, parser.has_about_author,
+    )
+
+    return scores
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: python3 analyze_eeat.py <html_file_or_url>')
+        print('Example: python3 analyze_eeat.py page.html')
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+
+    try:
+        if input_path.startswith('http://') or input_path.startswith('https://'):
+            import urllib.request
+            with urllib.request.urlopen(input_path) as response:
+                html_content = response.read().decode('utf-8')
+            page_url = input_path
+        else:
+            with open(input_path, 'r', encoding='utf-8') as f:
+                html_content = f.read()
+            page_url = None
+
+        scores = analyze_eeat(html_content, page_url)
+
+        # Exit code: 0 if Good or better, 1 if needs improvement
+        sys.exit(0 if scores['total'] >= 50 else 1)
+
+    except FileNotFoundError:
+        print(f"Error: File '{input_path}' not found")
+        sys.exit(1)
+    except Exception as e:
+        print(f'Error: {e}')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/analyze_headings.py
+++ b/sales-marketing/skills/seo-expert/scripts/analyze_headings.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+
+"""
+Heading Hierarchy Analyzer with GEO Question-Based Detection
+
+Analyzes heading structure and detects question-based headers for GEO optimization.
+Long-tail queries of 8+ words are 7x more likely to trigger AI Overviews.
+
+Usage: ./analyze_headings.py <html_file_or_url>
+"""
+
+import sys
+import re
+from html.parser import HTMLParser
+
+class HeadingParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.headings = []
+        self.current_heading = None
+        self.current_tag = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']:
+            self.current_tag = tag
+            self.current_heading = {'tag': tag, 'level': int(tag[1]), 'text': '', 'attrs': dict(attrs)}
+
+    def handle_data(self, data):
+        if self.current_heading is not None:
+            self.current_heading['text'] += data.strip()
+
+    def handle_endtag(self, tag):
+        if tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] and self.current_heading:
+            if self.current_heading['text']:  # Only add if not empty
+                self.headings.append(self.current_heading)
+            self.current_heading = None
+            self.current_tag = None
+
+def analyze_heading_hierarchy(html_content):
+    """Parse and analyze heading hierarchy from HTML content"""
+    parser = HeadingParser()
+    parser.feed(html_content)
+
+    print("Heading Hierarchy Analysis")
+    print("=" * 80)
+    print()
+
+    if not parser.headings:
+        print("✗ No headings found on the page!")
+        print("  Recommendation: Add proper heading structure (H1-H6) for better SEO")
+        return
+
+    print(f"Total headings found: {len(parser.headings)}")
+    print()
+
+    # Count headings by level
+    heading_counts = {}
+    for h in parser.headings:
+        level = h['level']
+        heading_counts[level] = heading_counts.get(level, 0) + 1
+
+    print("HEADING COUNT BY LEVEL")
+    print("-" * 80)
+    for level in range(1, 7):
+        count = heading_counts.get(level, 0)
+        symbol = "✓" if count > 0 else " "
+        print(f"{symbol} H{level}: {count}")
+    print()
+
+    # Check for H1
+    h1_headings = [h for h in parser.headings if h['level'] == 1]
+    print("H1 TAG ANALYSIS")
+    print("-" * 80)
+    if not h1_headings:
+        print("✗ CRITICAL: No H1 tag found!")
+        print("  Recommendation: Every page should have exactly one H1 tag describing the main topic")
+    elif len(h1_headings) == 1:
+        print(f"✓ Correct: One H1 tag found")
+        print(f"  Text: {h1_headings[0]['text']}")
+        print(f"  Length: {len(h1_headings[0]['text'])} characters")
+    else:
+        print(f"⚠ WARNING: Multiple H1 tags found ({len(h1_headings)})")
+        print("  Recommendation: Use only one H1 tag per page")
+        for i, h1 in enumerate(h1_headings, 1):
+            print(f"  {i}. {h1['text']}")
+    print()
+
+    # Check hierarchy
+    print("HIERARCHY VALIDATION")
+    print("-" * 80)
+    issues = []
+    prev_level = 0
+
+    for i, heading in enumerate(parser.headings):
+        level = heading['level']
+
+        # Check for skipped levels
+        if level > prev_level + 1:
+            issues.append({
+                'type': 'skipped_level',
+                'position': i + 1,
+                'heading': heading,
+                'prev_level': prev_level,
+                'message': f"Skipped from H{prev_level} to H{level}"
+            })
+
+        prev_level = level
+
+    if not issues:
+        print("✓ Heading hierarchy is properly structured")
+    else:
+        print(f"⚠ Found {len(issues)} hierarchy issues:")
+        for issue in issues:
+            print(f"  • Position {issue['position']}: {issue['message']}")
+            print(f"    Text: {issue['heading']['text']}")
+    print()
+
+    # Display full hierarchy
+    print("COMPLETE HEADING STRUCTURE")
+    print("-" * 80)
+    for i, heading in enumerate(parser.headings, 1):
+        level = heading['level']
+        indent = "  " * (level - 1)
+        text = heading['text'][:70] + "..." if len(heading['text']) > 70 else heading['text']
+        print(f"{indent}H{level}: {text}")
+    print()
+
+    # Check for empty headings
+    empty_headings = [h for h in parser.headings if not h['text'].strip()]
+    if empty_headings:
+        print("EMPTY HEADINGS")
+        print("-" * 80)
+        print(f"⚠ Found {len(empty_headings)} empty heading(s)")
+        print("  Recommendation: All headings should contain descriptive text")
+        print()
+
+    # GEO: Question-based header analysis
+    print("GEO: QUESTION-BASED HEADER ANALYSIS")
+    print("-" * 80)
+
+    # Question words and patterns
+    question_words = [
+        'what', 'why', 'how', 'when', 'where', 'who', 'which', 'whose',
+        'can', 'could', 'should', 'would', 'will', 'do', 'does', 'did',
+        'is', 'are', 'am', 'was', 'were'
+    ]
+
+    question_headings = []
+    long_tail_headings = []
+
+    for heading in parser.headings:
+        text = heading['text'].strip()
+        text_lower = text.lower()
+        word_count = len(text.split())
+
+        # Check if it's a question (ends with ? or starts with question word)
+        is_question = False
+
+        if text.endswith('?'):
+            is_question = True
+        else:
+            # Check if starts with question word
+            first_word = text_lower.split()[0] if text_lower.split() else ''
+            if first_word in question_words:
+                is_question = True
+
+        if is_question:
+            question_headings.append({
+                'heading': heading,
+                'word_count': word_count,
+                'is_long_tail': word_count >= 8
+            })
+
+        # Check for long-tail (8+ words)
+        if word_count >= 8:
+            long_tail_headings.append({
+                'heading': heading,
+                'word_count': word_count,
+                'is_question': is_question
+            })
+
+    # H2 and H3 headings (primary targets for GEO)
+    h2_h3_headings = [h for h in parser.headings if h['level'] in [2, 3]]
+    h2_h3_questions = [q for q in question_headings if q['heading']['level'] in [2, 3]]
+
+    total_h2_h3 = len(h2_h3_headings)
+    question_count = len(question_headings)
+    h2_h3_question_count = len(h2_h3_questions)
+
+    # Calculate percentages
+    if total_h2_h3 > 0:
+        question_percentage = (h2_h3_question_count / total_h2_h3) * 100
+    else:
+        question_percentage = 0
+
+    print(f"Total headings:           {len(parser.headings)}")
+    print(f"Question-based headings:  {question_count} ({(question_count/len(parser.headings)*100):.1f}%)")
+    print(f"H2/H3 headings:           {total_h2_h3}")
+    print(f"H2/H3 questions:          {h2_h3_question_count} ({question_percentage:.1f}%)")
+    print(f"Long-tail headings (8+):  {len(long_tail_headings)}")
+    print()
+
+    # GEO recommendations
+    if question_percentage < 30:
+        print("⚠️  RECOMMENDATION: Increase question-based H2/H3 headers")
+        print("   Target: 30%+ of H2/H3 headers should be questions")
+        print("   AI Overviews favor question-based content structure")
+        print()
+        print("   Examples of converting headers to questions:")
+        non_question_h2h3 = [h for h in h2_h3_headings if h not in [q['heading'] for q in h2_h3_questions]]
+        for i, heading in enumerate(non_question_h2h3[:3], 1):
+            text = heading['text']
+            print(f"   {i}. \"{text}\"")
+            # Suggest question format
+            if text.lower().startswith(('benefits', 'advantages')):
+                print(f"      → \"What are the {text.lower()}?\"")
+            elif text.lower().startswith(('features', 'characteristics')):
+                print(f"      → \"What {text.lower()} should you know?\"")
+            elif text.lower().startswith(('process', 'steps', 'guide')):
+                print(f"      → \"How to {text.lower().replace('process', '').strip()}?\"")
+            else:
+                print(f"      → \"What is {text.lower()}?\" or \"How does {text.lower()} work?\"")
+        print()
+    else:
+        print(f"✓ Good: {question_percentage:.1f}% of H2/H3 headers are questions")
+        print()
+
+    # Display question headings
+    if question_headings:
+        print("Question-based headings found:")
+        for q in question_headings:
+            h = q['heading']
+            marker = "🎯" if q['is_long_tail'] else "  "
+            print(f"  {marker} H{h['level']}: {h['text']} ({q['word_count']} words)")
+        print()
+        if any(q['is_long_tail'] for q in question_headings):
+            print("🎯 = Long-tail query (8+ words, 7x more likely to trigger AI Overviews)")
+            print()
+
+    # Long-tail analysis
+    if long_tail_headings:
+        print("Long-tail headings (8+ words, optimal for GEO):")
+        for lt in long_tail_headings:
+            h = lt['heading']
+            marker = "?" if lt['is_question'] else " "
+            print(f"  {marker} H{h['level']}: {h['text']} ({lt['word_count']} words)")
+        print()
+
+    # Keyword density check (basic)
+    print("KEYWORD USAGE")
+    print("-" * 80)
+    all_text = ' '.join([h['text'].lower() for h in parser.headings])
+    words = re.findall(r'\b\w+\b', all_text)
+
+    if words:
+        word_freq = {}
+        for word in words:
+            if len(word) > 3:  # Only count words longer than 3 characters
+                word_freq[word] = word_freq.get(word, 0) + 1
+
+        # Get top 10 most common words
+        top_words = sorted(word_freq.items(), key=lambda x: x[1], reverse=True)[:10]
+
+        print("Top keywords in headings:")
+        for word, count in top_words:
+            print(f"  • {word}: {count} occurrence(s)")
+    print()
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: ./analyze_headings.py <html_file_or_url>")
+        print("Example: ./analyze_headings.py page.html")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+
+    try:
+        if input_path.startswith('http://') or input_path.startswith('https://'):
+            import urllib.request
+            with urllib.request.urlopen(input_path) as response:
+                html_content = response.read().decode('utf-8')
+        else:
+            with open(input_path, 'r', encoding='utf-8') as f:
+                html_content = f.read()
+
+        analyze_heading_hierarchy(html_content)
+
+    except FileNotFoundError:
+        print(f"Error: File '{input_path}' not found")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/check_bluf.py
+++ b/sales-marketing/skills/seo-expert/scripts/check_bluf.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+BLUF (Bottom Line Up Front) Detection for GEO Optimization
+
+Checks if content has a 50-70 word direct answer at the top of the page.
+BLUF format is CRITICAL for AI Overview citations.
+
+Usage:
+    python3 check_bluf.py <html_file>
+    python3 check_bluf.py <html_file> --min-words 50 --max-words 70
+
+References:
+    - BLUF format places key information in first 2-3 paragraphs
+    - AI prefers content with immediate, direct answers
+    - 50-70 words is optimal length for citations
+"""
+
+import sys
+import re
+from html.parser import HTMLParser
+
+
+class ContentExtractor(HTMLParser):
+    """Extract main content paragraphs from HTML."""
+
+    def __init__(self):
+        super().__init__()
+        self.paragraphs = []
+        self.current_paragraph = []
+        self.in_content = True
+        self.in_skip_tag = False
+        self.skip_tags = {'script', 'style', 'nav', 'header', 'footer', 'aside', 'form'}
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.skip_tags:
+            self.in_skip_tag = True
+        elif tag == 'p':
+            self.current_paragraph = []
+
+    def handle_endtag(self, tag):
+        if tag in self.skip_tags:
+            self.in_skip_tag = False
+        elif tag == 'p' and self.current_paragraph:
+            text = ' '.join(self.current_paragraph).strip()
+            if text and len(text.split()) > 5:  # Only keep paragraphs with 5+ words
+                self.paragraphs.append(text)
+            self.current_paragraph = []
+
+    def handle_data(self, data):
+        if not self.in_skip_tag and self.in_content:
+            text = data.strip()
+            if text:
+                self.current_paragraph.append(text)
+
+
+def extract_paragraphs(html_content):
+    """Extract paragraphs from HTML content."""
+    parser = ContentExtractor()
+    parser.feed(html_content)
+    return parser.paragraphs
+
+
+def count_words(text):
+    """Count words in text."""
+    words = re.findall(r'\b[a-zA-Z0-9]+\b', text)
+    return len(words)
+
+
+def is_direct_answer(paragraph):
+    """
+    Check if paragraph appears to be a direct answer.
+
+    Heuristics:
+    - Not too short (>20 words) or too long (<150 words)
+    - Contains complete sentences
+    - Not just a list of links
+    """
+    word_count = count_words(paragraph)
+
+    if word_count < 20 or word_count > 150:
+        return False
+
+    # Check for sentence structure (ends with period, question mark, or exclamation)
+    if not re.search(r'[.!?]$', paragraph.strip()):
+        return False
+
+    # Reject if mostly links (heuristic: less than 50% actual content)
+    text_without_tags = re.sub(r'<[^>]+>', '', paragraph)
+    if len(text_without_tags) < len(paragraph) * 0.5:
+        return False
+
+    return True
+
+
+def analyze_bluf(paragraphs, min_words=50, max_words=70):
+    """
+    Analyze content for BLUF format.
+
+    Returns:
+        dict with analysis results
+    """
+    if not paragraphs:
+        return {
+            'has_bluf': False,
+            'first_para_words': 0,
+            'issue': 'No paragraphs found',
+            'recommendation': 'Add content paragraphs to the page'
+        }
+
+    # Analyze first 3 paragraphs
+    first_para = paragraphs[0] if len(paragraphs) > 0 else ''
+    second_para = paragraphs[1] if len(paragraphs) > 1 else ''
+    third_para = paragraphs[2] if len(paragraphs) > 2 else ''
+
+    first_para_words = count_words(first_para)
+    second_para_words = count_words(second_para)
+    third_para_words = count_words(third_para)
+
+    result = {
+        'total_paragraphs': len(paragraphs),
+        'first_para': first_para,
+        'first_para_words': first_para_words,
+        'second_para_words': second_para_words,
+        'third_para_words': third_para_words,
+        'has_bluf': False,
+        'bluf_quality': 'none',
+        'recommendation': []
+    }
+
+    # Check first paragraph for BLUF
+    if first_para_words >= min_words and first_para_words <= max_words:
+        if is_direct_answer(first_para):
+            result['has_bluf'] = True
+            result['bluf_quality'] = 'excellent'
+            result['bluf_location'] = 'first_paragraph'
+            return result
+
+    # Check if BLUF is in first 2 paragraphs combined
+    combined_first_two = first_para_words + second_para_words
+    if combined_first_two >= min_words and combined_first_two <= 100:
+        result['bluf_quality'] = 'acceptable'
+        result['bluf_location'] = 'first_two_paragraphs'
+        result['recommendation'].append(
+            "Consider consolidating first two paragraphs into a single 50-70 word BLUF"
+        )
+        return result
+
+    # Analyze issues
+    if first_para_words == 0:
+        result['issue'] = 'No first paragraph found'
+        result['recommendation'].append('Add an opening paragraph with a direct answer')
+    elif first_para_words < min_words:
+        result['issue'] = f'First paragraph too short ({first_para_words} words, target: {min_words}-{max_words})'
+        result['recommendation'].append(
+            f'Expand first paragraph to {min_words}-{max_words} words with a direct, complete answer'
+        )
+    elif first_para_words > max_words:
+        result['issue'] = f'First paragraph too long ({first_para_words} words, target: {min_words}-{max_words})'
+        result['recommendation'].append(
+            f'Shorten first paragraph to {min_words}-{max_words} words, focusing on the key answer'
+        )
+    else:
+        result['issue'] = 'First paragraph does not appear to be a direct answer'
+        result['recommendation'].append(
+            'Rewrite first paragraph as a direct, concise answer to the main question'
+        )
+
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 check_bluf.py <html_file> [--min-words N] [--max-words N]")
+        sys.exit(1)
+
+    html_file = sys.argv[1]
+    min_words = 50
+    max_words = 70
+
+    # Parse optional parameters
+    if '--min-words' in sys.argv:
+        idx = sys.argv.index('--min-words')
+        if idx + 1 < len(sys.argv):
+            min_words = int(sys.argv[idx + 1])
+
+    if '--max-words' in sys.argv:
+        idx = sys.argv.index('--max-words')
+        if idx + 1 < len(sys.argv):
+            max_words = int(sys.argv[idx + 1])
+
+    # Read HTML file
+    try:
+        with open(html_file, 'r', encoding='utf-8') as f:
+            html_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: File '{html_file}' not found")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        sys.exit(1)
+
+    # Extract paragraphs
+    paragraphs = extract_paragraphs(html_content)
+
+    # Analyze BLUF
+    analysis = analyze_bluf(paragraphs, min_words, max_words)
+
+    # Display results
+    print("=" * 70)
+    print("BLUF (Bottom Line Up Front) Analysis")
+    print("=" * 70)
+    print()
+    print(f"Total paragraphs found: {analysis['total_paragraphs']}")
+    print(f"Target BLUF length:     {min_words}-{max_words} words")
+    print()
+
+    if analysis['total_paragraphs'] == 0:
+        print("❌ CRITICAL: No content paragraphs found")
+        print()
+        print("Recommendation:")
+        print("  • Add main content with clear paragraphs")
+        print("  • Start with a 50-70 word direct answer")
+        sys.exit(1)
+
+    print("First Paragraph Analysis:")
+    print("-" * 70)
+    print(f"Word count: {analysis['first_para_words']}")
+    print()
+
+    if analysis['first_para_words'] > 0:
+        # Show first paragraph (truncated if too long)
+        first_para_display = analysis['first_para']
+        if len(first_para_display) > 300:
+            first_para_display = first_para_display[:300] + "..."
+
+        print(f"Content preview:")
+        print(f'  "{first_para_display}"')
+        print()
+
+    # BLUF status
+    print("BLUF Status:")
+    print("-" * 70)
+
+    if analysis['has_bluf']:
+        print("✅ EXCELLENT: First paragraph follows BLUF format")
+        print(f"   {analysis['first_para_words']} words - optimal for AI citations")
+        print()
+        print("Why this matters:")
+        print("  • AI extracts and cites direct, concise answers")
+        print("  • 50-70 word answers are optimal for AI Overviews")
+        print("  • BLUF format improves user experience and engagement")
+        print()
+        sys.exit(0)
+
+    elif analysis.get('bluf_quality') == 'acceptable':
+        print("⚠️  ACCEPTABLE: BLUF present but split across paragraphs")
+        print(f"   First paragraph: {analysis['first_para_words']} words")
+        print(f"   Second paragraph: {analysis['second_para_words']} words")
+        print()
+    else:
+        print("❌ MISSING: No BLUF format detected")
+        print()
+        if 'issue' in analysis:
+            print(f"Issue: {analysis['issue']}")
+            print()
+
+    # Recommendations
+    if analysis['recommendation']:
+        print("Recommendations:")
+        for i, rec in enumerate(analysis['recommendation'], 1):
+            print(f"  {i}. {rec}")
+        print()
+
+    print("BLUF Best Practices:")
+    print("  • Start with a 50-70 word paragraph that directly answers the main query")
+    print("  • Make it conversational and easy to understand")
+    print("  • Include the key information someone needs to know")
+    print("  • Think 'What would I want to see in an AI Overview?'")
+    print()
+
+    # Example
+    print("Example BLUF format:")
+    print('  "SEO (Search Engine Optimization) is the practice of improving')
+    print('   website visibility in search engine results. It involves optimizing')
+    print('   content, technical elements, and building authority through links.')
+    print('   Good SEO increases organic traffic and helps potential customers')
+    print('   find your business online."')
+    print()
+
+    # Exit code based on status
+    if analysis.get('bluf_quality') == 'acceptable':
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/check_readability.py
+++ b/sales-marketing/skills/seo-expert/scripts/check_readability.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+Readability Checker for GEO Optimization
+
+Implements Flesch-Kincaid Grade Level and Flesch Reading Ease algorithms
+to ensure content meets GEO best practices (target: 8th grade or below).
+
+Usage:
+    python3 check_readability.py <html_file>
+    python3 check_readability.py <html_file> --target-grade 8
+
+References:
+    - Flesch-Kincaid Grade Level: 0.39 * (total words / total sentences) + 11.8 * (total syllables / total words) - 15.59
+    - Flesch Reading Ease: 206.835 - 1.015 * (total words / total sentences) - 84.6 * (total syllables / total words)
+    - AI prefers content with conversational, 8th-grade readability
+"""
+
+import sys
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+class TextExtractor(HTMLParser):
+    """Extract text content from HTML, excluding script/style tags."""
+
+    def __init__(self):
+        super().__init__()
+        self.text = []
+        self.in_script_style = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ['script', 'style', 'nav', 'header', 'footer']:
+            self.in_script_style = True
+
+    def handle_endtag(self, tag):
+        if tag in ['script', 'style', 'nav', 'header', 'footer']:
+            self.in_script_style = False
+
+    def handle_data(self, data):
+        if not self.in_script_style:
+            self.text.append(data)
+
+    def get_text(self):
+        return ' '.join(self.text)
+
+
+def count_syllables(word):
+    """
+    Count syllables in a word using a simple heuristic.
+
+    Rules:
+    - Count vowel groups (consecutive vowels = 1 syllable)
+    - Silent 'e' at end doesn't count
+    - Minimum 1 syllable per word
+    """
+    word = word.lower().strip(".,!?;:")
+
+    if len(word) <= 3:
+        return 1
+
+    # Remove silent e
+    if word.endswith('e'):
+        word = word[:-1]
+
+    # Count vowel groups
+    vowels = 'aeiouy'
+    syllable_count = 0
+    previous_was_vowel = False
+
+    for char in word:
+        is_vowel = char in vowels
+        if is_vowel and not previous_was_vowel:
+            syllable_count += 1
+        previous_was_vowel = is_vowel
+
+    # Ensure at least 1 syllable
+    return max(1, syllable_count)
+
+
+def extract_text_from_html(html_content):
+    """Extract readable text content from HTML."""
+    parser = TextExtractor()
+    parser.feed(html_content)
+    return parser.get_text()
+
+
+def calculate_readability(text):
+    """
+    Calculate readability metrics for the given text.
+
+    Returns:
+        dict: {
+            'total_words': int,
+            'total_sentences': int,
+            'total_syllables': int,
+            'flesch_kincaid_grade': float,
+            'flesch_reading_ease': float,
+            'avg_words_per_sentence': float,
+            'avg_syllables_per_word': float
+        }
+    """
+    # Split into sentences (basic sentence detection)
+    sentences = re.split(r'[.!?]+', text)
+    sentences = [s.strip() for s in sentences if s.strip()]
+    total_sentences = len(sentences)
+
+    if total_sentences == 0:
+        return None
+
+    # Split into words
+    words = re.findall(r'\b[a-zA-Z]+\b', text)
+    total_words = len(words)
+
+    if total_words == 0:
+        return None
+
+    # Count syllables
+    total_syllables = sum(count_syllables(word) for word in words)
+
+    # Calculate metrics
+    avg_words_per_sentence = total_words / total_sentences
+    avg_syllables_per_word = total_syllables / total_words
+
+    # Flesch-Kincaid Grade Level
+    fk_grade = (0.39 * avg_words_per_sentence) + (11.8 * avg_syllables_per_word) - 15.59
+
+    # Flesch Reading Ease
+    fre_score = 206.835 - (1.015 * avg_words_per_sentence) - (84.6 * avg_syllables_per_word)
+
+    return {
+        'total_words': total_words,
+        'total_sentences': total_sentences,
+        'total_syllables': total_syllables,
+        'flesch_kincaid_grade': round(fk_grade, 1),
+        'flesch_reading_ease': round(fre_score, 1),
+        'avg_words_per_sentence': round(avg_words_per_sentence, 1),
+        'avg_syllables_per_word': round(avg_syllables_per_word, 2)
+    }
+
+
+def interpret_fre_score(score):
+    """Interpret Flesch Reading Ease score."""
+    if score >= 90:
+        return "Very Easy (5th grade)"
+    elif score >= 80:
+        return "Easy (6th grade)"
+    elif score >= 70:
+        return "Fairly Easy (7th grade)"
+    elif score >= 60:
+        return "Standard (8th-9th grade)"
+    elif score >= 50:
+        return "Fairly Difficult (10th-12th grade)"
+    elif score >= 30:
+        return "Difficult (College level)"
+    else:
+        return "Very Difficult (College graduate)"
+
+
+def get_recommendations(metrics, target_grade=8):
+    """Generate recommendations based on readability metrics."""
+    recommendations = []
+
+    grade = metrics['flesch_kincaid_grade']
+
+    if grade > target_grade:
+        recommendations.append(f"⚠️  Content is at grade {grade} level, target is grade {target_grade} or below")
+
+        if metrics['avg_words_per_sentence'] > 20:
+            recommendations.append(
+                f"• Shorten sentences: Average {metrics['avg_words_per_sentence']} words per sentence "
+                f"(target: 15-20 words)"
+            )
+
+        if metrics['avg_syllables_per_word'] > 1.6:
+            recommendations.append(
+                f"• Use simpler words: Average {metrics['avg_syllables_per_word']} syllables per word "
+                f"(target: 1.5 or below)"
+            )
+
+        recommendations.append("• Use conversational language and avoid jargon")
+        recommendations.append("• Break complex ideas into multiple sentences")
+        recommendations.append("• Replace complex words with simpler alternatives")
+    else:
+        recommendations.append(f"✅ Content meets target grade level ({grade} ≤ {target_grade})")
+
+    return recommendations
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 check_readability.py <html_file> [--target-grade N]")
+        sys.exit(1)
+
+    html_file = sys.argv[1]
+    target_grade = 8  # Default target for GEO
+
+    # Parse optional target grade
+    if '--target-grade' in sys.argv:
+        idx = sys.argv.index('--target-grade')
+        if idx + 1 < len(sys.argv):
+            target_grade = int(sys.argv[idx + 1])
+
+    # Read HTML file
+    try:
+        with open(html_file, 'r', encoding='utf-8') as f:
+            html_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: File '{html_file}' not found")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error reading file: {e}")
+        sys.exit(1)
+
+    # Extract text
+    text = extract_text_from_html(html_content)
+
+    if not text.strip():
+        print("Error: No readable text found in HTML")
+        sys.exit(1)
+
+    # Calculate readability
+    metrics = calculate_readability(text)
+
+    if not metrics:
+        print("Error: Unable to calculate readability metrics")
+        sys.exit(1)
+
+    # Display results
+    print("=" * 60)
+    print("READABILITY ANALYSIS (GEO Optimization)")
+    print("=" * 60)
+    print()
+    print(f"Content Statistics:")
+    print(f"  Words:              {metrics['total_words']:,}")
+    print(f"  Sentences:          {metrics['total_sentences']:,}")
+    print(f"  Syllables:          {metrics['total_syllables']:,}")
+    print(f"  Avg Words/Sentence: {metrics['avg_words_per_sentence']}")
+    print(f"  Avg Syllables/Word: {metrics['avg_syllables_per_word']}")
+    print()
+    print(f"Readability Scores:")
+    print(f"  Flesch-Kincaid Grade Level: {metrics['flesch_kincaid_grade']}")
+    print(f"  Flesch Reading Ease:        {metrics['flesch_reading_ease']} ({interpret_fre_score(metrics['flesch_reading_ease'])})")
+    print()
+    print(f"GEO Target: Grade {target_grade} or below")
+    print()
+
+    # Get recommendations
+    recommendations = get_recommendations(metrics, target_grade)
+
+    print("Recommendations:")
+    for rec in recommendations:
+        print(rec)
+    print()
+
+    # Exit code based on pass/fail
+    if metrics['flesch_kincaid_grade'] <= target_grade:
+        print("STATUS: ✅ PASS - Content is AI-friendly")
+        sys.exit(0)
+    else:
+        print("STATUS: ⚠️  NEEDS IMPROVEMENT - Content may be too complex for optimal AI citations")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/check_robots.sh
+++ b/sales-marketing/skills/seo-expert/scripts/check_robots.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Robots.txt Checker Script
+# Usage: ./check_robots.sh <url>
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <url>"
+    echo "Example: $0 https://example.com"
+    exit 1
+fi
+
+URL="$1"
+
+# Remove trailing slash if present
+URL="${URL%/}"
+
+# Construct robots.txt URL
+ROBOTS_URL="${URL}/robots.txt"
+
+echo "Checking robots.txt at: $ROBOTS_URL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Fetch robots.txt with HTTP status
+HTTP_STATUS=$(curl -s -o /tmp/robots.txt -w "%{http_code}" "$ROBOTS_URL")
+
+if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "✓ robots.txt found (HTTP $HTTP_STATUS)"
+    echo ""
+    echo "Content:"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    cat /tmp/robots.txt
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    # Check for sitemap references
+    echo ""
+    SITEMAPS=$(grep -i "^Sitemap:" /tmp/robots.txt)
+    if [ -n "$SITEMAPS" ]; then
+        echo "✓ Sitemap references found:"
+        echo "$SITEMAPS"
+    else
+        echo "⚠ No sitemap references found in robots.txt"
+    fi
+
+    # Check for disallow rules
+    echo ""
+    DISALLOWS=$(grep -i "^Disallow:" /tmp/robots.txt | wc -l | tr -d ' ')
+    echo "📋 Found $DISALLOWS Disallow directives"
+
+elif [ "$HTTP_STATUS" -eq 404 ]; then
+    echo "✗ robots.txt not found (HTTP $HTTP_STATUS)"
+    echo ""
+    echo "Recommendation: Create a robots.txt file to guide search engine crawlers."
+    echo "Minimum recommended content:"
+    echo ""
+    echo "User-agent: *"
+    echo "Allow: /"
+    echo "Sitemap: ${URL}/sitemap.xml"
+else
+    echo "⚠ Unexpected HTTP status: $HTTP_STATUS"
+fi
+
+# Cleanup
+rm -f /tmp/robots.txt

--- a/sales-marketing/skills/seo-expert/scripts/check_sitemap.sh
+++ b/sales-marketing/skills/seo-expert/scripts/check_sitemap.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+# Sitemap Checker Script
+# Usage: ./check_sitemap.sh <url>
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <url>"
+    echo "Example: $0 https://example.com"
+    exit 1
+fi
+
+URL="$1"
+
+# Remove trailing slash if present
+URL="${URL%/}"
+
+# Construct sitemap URL
+SITEMAP_URL="${URL}/sitemap.xml"
+
+echo "Checking sitemap at: $SITEMAP_URL"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Fetch sitemap with HTTP status
+HTTP_STATUS=$(curl -s -o /tmp/sitemap.xml -w "%{http_code}" "$SITEMAP_URL")
+
+if [ "$HTTP_STATUS" -eq 200 ]; then
+    echo "✓ sitemap.xml found (HTTP $HTTP_STATUS)"
+    echo ""
+
+    # Check if it's a valid XML file
+    if ! command -v xmllint &> /dev/null; then
+        echo "⚠ xmllint not available for validation (install libxml2)"
+        echo ""
+    else
+        if xmllint --noout /tmp/sitemap.xml 2>/dev/null; then
+            echo "✓ Valid XML structure"
+        else
+            echo "✗ Invalid XML structure detected"
+        fi
+        echo ""
+    fi
+
+    # Count URLs
+    URL_COUNT=$(grep -c "<loc>" /tmp/sitemap.xml)
+    echo "📋 Contains $URL_COUNT URLs"
+
+    # Check for sitemap index (nested sitemaps)
+    if grep -q "<sitemapindex" /tmp/sitemap.xml; then
+        echo "📂 This is a sitemap index (contains nested sitemaps)"
+        SITEMAP_COUNT=$(grep -c "<sitemap>" /tmp/sitemap.xml)
+        echo "   Contains $SITEMAP_COUNT child sitemaps"
+    fi
+
+    # Check for lastmod dates
+    LASTMOD_COUNT=$(grep -c "<lastmod>" /tmp/sitemap.xml)
+    if [ "$LASTMOD_COUNT" -gt 0 ]; then
+        echo "✓ Includes lastmod dates ($LASTMOD_COUNT entries)"
+    else
+        echo "⚠ No lastmod dates found (recommended for better crawl efficiency)"
+    fi
+
+    # Check for priority and changefreq
+    PRIORITY_COUNT=$(grep -c "<priority>" /tmp/sitemap.xml)
+    CHANGEFREQ_COUNT=$(grep -c "<changefreq>" /tmp/sitemap.xml)
+
+    if [ "$PRIORITY_COUNT" -gt 0 ]; then
+        echo "📊 Includes priority hints ($PRIORITY_COUNT entries)"
+    fi
+
+    if [ "$CHANGEFREQ_COUNT" -gt 0 ]; then
+        echo "📊 Includes changefreq hints ($CHANGEFREQ_COUNT entries)"
+    fi
+
+    # File size check
+    FILE_SIZE=$(wc -c < /tmp/sitemap.xml | tr -d ' ')
+    FILE_SIZE_MB=$(echo "scale=2; $FILE_SIZE / 1048576" | bc)
+    echo ""
+    echo "📦 Sitemap size: $FILE_SIZE_MB MB"
+
+    if [ "$FILE_SIZE" -gt 52428800 ]; then
+        echo "⚠ WARNING: Sitemap exceeds 50MB limit!"
+    fi
+
+    if [ "$URL_COUNT" -gt 50000 ]; then
+        echo "⚠ WARNING: Sitemap exceeds 50,000 URL limit!"
+        echo "   Consider splitting into multiple sitemaps with a sitemap index"
+    fi
+
+elif [ "$HTTP_STATUS" -eq 404 ]; then
+    echo "✗ sitemap.xml not found (HTTP $HTTP_STATUS)"
+    echo ""
+    echo "Recommendation: Create an XML sitemap to help search engines discover content."
+    echo ""
+    echo "Also check for sitemap_index.xml or alternative locations:"
+    echo "- ${URL}/sitemap_index.xml"
+    echo "- ${URL}/sitemap-index.xml"
+    echo "- Check robots.txt for sitemap location"
+else
+    echo "⚠ Unexpected HTTP status: $HTTP_STATUS"
+fi
+
+# Cleanup
+rm -f /tmp/sitemap.xml

--- a/sales-marketing/skills/seo-expert/scripts/compare_crawls.py
+++ b/sales-marketing/skills/seo-expert/scripts/compare_crawls.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+compare_crawls.py - Compare two LibreCrawl results for month-over-month analysis
+
+Usage:
+    ./scripts/compare_crawls.py <current.json> <previous.json> [output.md]
+
+Arguments:
+    current  - Current month's crawl results (JSON)
+    previous - Previous month's crawl results (JSON)
+    output   - Optional output file for markdown report (default: stdout)
+
+Example:
+    ./scripts/compare_crawls.py month2.json month1.json comparison-report.md
+"""
+
+import sys
+import json
+from collections import Counter
+from datetime import datetime
+
+def load_crawl(file_path):
+    """Load crawl results from JSON file"""
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: Invalid JSON in: {file_path}", file=sys.stderr)
+        sys.exit(1)
+
+def calculate_change(current, previous):
+    """Calculate change and percentage"""
+    change = current - previous
+    if previous == 0:
+        pct = 100 if current > 0 else 0
+    else:
+        pct = (change / previous) * 100
+    return change, pct
+
+def format_change(change, pct, inverse=False):
+    """Format change with emoji indicator"""
+    # inverse=True means lower is better (like issue count)
+    if change == 0:
+        return f"→ {change:+d} (0%)"
+
+    if inverse:
+        emoji = "⬇️" if change < 0 else "⬆️"
+        sign = "✓" if change < 0 else "⚠️"
+    else:
+        emoji = "⬆️" if change > 0 else "⬇️"
+        sign = "✓" if change > 0 else "⚠️"
+
+    return f"{emoji} {change:+d} ({pct:+.1f}%) {sign}"
+
+def compare_crawls(current_data, previous_data):
+    """Generate comparison report"""
+
+    current_stats = current_data.get('stats', {})
+    previous_stats = previous_data.get('stats', {})
+
+    current_issues = current_data.get('issues', [])
+    previous_issues = previous_data.get('issues', [])
+
+    current_results = current_data.get('results', [])
+    previous_results = previous_data.get('results', [])
+
+    report = []
+
+    # Header
+    report.append("# SEO Crawl Comparison Report")
+    report.append("")
+    report.append(f"**Current Crawl:** {current_data.get('crawl_date', 'Unknown')}")
+    report.append(f"**Previous Crawl:** {previous_data.get('crawl_date', 'Unknown')}")
+    report.append(f"**Site:** {current_data.get('url', 'Unknown')}")
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Executive Summary
+    report.append("## Executive Summary")
+    report.append("")
+
+    total_issues_curr = len(current_issues)
+    total_issues_prev = len(previous_issues)
+    issues_change, issues_pct = calculate_change(total_issues_curr, total_issues_prev)
+
+    report.append(f"**Total Issues:** {total_issues_prev} → {total_issues_curr} {format_change(issues_change, issues_pct, inverse=True)}")
+    report.append("")
+
+    # Issue breakdown by severity
+    curr_errors = len([i for i in current_issues if i.get('type') == 'error'])
+    prev_errors = len([i for i in previous_issues if i.get('type') == 'error'])
+    errors_change, errors_pct = calculate_change(curr_errors, prev_errors)
+
+    curr_warnings = len([i for i in current_issues if i.get('type') == 'warning'])
+    prev_warnings = len([i for i in previous_issues if i.get('type') == 'warning'])
+    warnings_change, warnings_pct = calculate_change(curr_warnings, prev_warnings)
+
+    report.append(f"**Critical Errors:** {prev_errors} → {curr_errors} {format_change(errors_change, errors_pct, inverse=True)}")
+    report.append(f"**Warnings:** {prev_warnings} → {curr_warnings} {format_change(warnings_change, warnings_pct, inverse=True)}")
+    report.append("")
+
+    # Pages crawled
+    pages_curr = current_stats.get('crawled', 0)
+    pages_prev = previous_stats.get('crawled', 0)
+    pages_change, pages_pct = calculate_change(pages_curr, pages_prev)
+
+    report.append(f"**Pages Crawled:** {pages_prev} → {pages_curr} {format_change(pages_change, pages_pct)}")
+    report.append("")
+
+    # Overall assessment
+    if issues_change < 0:
+        report.append("### 🎉 Overall Progress: Improving")
+        report.append(f"Issue count reduced by {abs(issues_change)} ({abs(issues_pct):.1f}%). Good progress!")
+    elif issues_change == 0:
+        report.append("### ➡️ Overall Progress: Stable")
+        report.append("Issue count unchanged. Consider implementing new optimizations.")
+    else:
+        report.append("### ⚠️ Overall Progress: Issues Increased")
+        report.append(f"Issue count increased by {issues_change} ({issues_pct:.1f}%). Review recent changes.")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Detailed Metrics Comparison
+    report.append("## Detailed Metrics")
+    report.append("")
+    report.append("| Metric | Previous | Current | Change |")
+    report.append("|--------|----------|---------|--------|")
+
+    metrics = [
+        ('Pages Discovered', 'discovered'),
+        ('Pages Crawled', 'crawled'),
+        ('Max Depth', 'depth'),
+        ('Avg Speed (URLs/sec)', 'speed'),
+    ]
+
+    for label, key in metrics:
+        curr_val = current_stats.get(key, 0)
+        prev_val = previous_stats.get(key, 0)
+        change, pct = calculate_change(curr_val, prev_val)
+
+        if isinstance(curr_val, float):
+            report.append(f"| {label} | {prev_val:.2f} | {curr_val:.2f} | {change:+.2f} ({pct:+.1f}%) |")
+        else:
+            report.append(f"| {label} | {prev_val} | {curr_val} | {change:+d} ({pct:+.1f}%) |")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Issue Breakdown by Category
+    report.append("## Issues by Category")
+    report.append("")
+
+    curr_categories = Counter(i.get('category', 'Unknown') for i in current_issues)
+    prev_categories = Counter(i.get('category', 'Unknown') for i in previous_issues)
+
+    all_categories = set(curr_categories.keys()) | set(prev_categories.keys())
+
+    report.append("| Category | Previous | Current | Change |")
+    report.append("|----------|----------|---------|--------|")
+
+    for category in sorted(all_categories):
+        prev_count = prev_categories.get(category, 0)
+        curr_count = curr_categories.get(category, 0)
+        change, pct = calculate_change(curr_count, prev_count)
+        change_str = format_change(change, pct, inverse=True) if change != 0 else "→ 0"
+        report.append(f"| {category} | {prev_count} | {curr_count} | {change_str} |")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Top Issue Types
+    report.append("## Top Issue Types")
+    report.append("")
+
+    curr_issue_types = Counter(i.get('issue', 'Unknown') for i in current_issues)
+    prev_issue_types = Counter(i.get('issue', 'Unknown') for i in previous_issues)
+
+    report.append("### Current Top 10")
+    report.append("")
+    for issue_type, count in curr_issue_types.most_common(10):
+        prev_count = prev_issue_types.get(issue_type, 0)
+        change = count - prev_count
+        if change != 0:
+            report.append(f"- **{issue_type}**: {count} occurrences ({change:+d} from previous)")
+        else:
+            report.append(f"- **{issue_type}**: {count} occurrences")
+
+    report.append("")
+
+    # Resolved Issues
+    resolved_issue_types = set(prev_issue_types.keys()) - set(curr_issue_types.keys())
+    if resolved_issue_types:
+        report.append("### ✅ Resolved Issue Types")
+        report.append("")
+        for issue_type in sorted(resolved_issue_types):
+            count = prev_issue_types[issue_type]
+            report.append(f"- **{issue_type}**: {count} instances resolved!")
+        report.append("")
+
+    # New Issues
+    new_issue_types = set(curr_issue_types.keys()) - set(prev_issue_types.keys())
+    if new_issue_types:
+        report.append("### 🆕 New Issue Types")
+        report.append("")
+        for issue_type in sorted(new_issue_types):
+            count = curr_issue_types[issue_type]
+            report.append(f"- **{issue_type}**: {count} new instances")
+        report.append("")
+
+    report.append("---")
+    report.append("")
+
+    # Page-Level Changes
+    report.append("## Page-Level Analysis")
+    report.append("")
+
+    # Build URL sets
+    prev_urls = {p['url'] for p in previous_results if 'url' in p}
+    curr_urls = {p['url'] for p in current_results if 'url' in p}
+
+    new_pages = curr_urls - prev_urls
+    removed_pages = prev_urls - curr_urls
+
+    if new_pages:
+        report.append(f"### 🆕 New Pages Discovered ({len(new_pages)})")
+        report.append("")
+        for url in sorted(list(new_pages)[:10]):  # Show first 10
+            report.append(f"- {url}")
+        if len(new_pages) > 10:
+            report.append(f"- ... and {len(new_pages) - 10} more")
+        report.append("")
+
+    if removed_pages:
+        report.append(f"### 🗑️ Pages No Longer Found ({len(removed_pages)})")
+        report.append("")
+        for url in sorted(list(removed_pages)[:10]):  # Show first 10
+            report.append(f"- {url}")
+        if len(removed_pages) > 10:
+            report.append(f"- ... and {len(removed_pages) - 10} more")
+        report.append("")
+
+    # Recommendations
+    report.append("---")
+    report.append("")
+    report.append("## Recommendations")
+    report.append("")
+
+    if issues_change < 0:
+        report.append("✅ **Good Progress!** Continue current optimization efforts.")
+        report.append("")
+        if curr_errors > 0:
+            report.append(f"- Focus next: Resolve remaining {curr_errors} critical errors")
+        if curr_warnings > 10:
+            report.append(f"- Address high-priority warnings (currently {curr_warnings})")
+    elif issues_change == 0:
+        report.append("⚠️ **Plateau Detected** - Time for new optimizations:")
+        report.append("")
+        report.append("- Review and implement advanced SEO techniques")
+        report.append("- Consider content expansion on thin pages")
+        report.append("- Add structured data where missing")
+    else:
+        report.append("🔴 **Issues Increased** - Investigate recent changes:")
+        report.append("")
+        if new_issue_types:
+            report.append(f"- {len(new_issue_types)} new issue types introduced")
+        if new_pages:
+            report.append(f"- {len(new_pages)} new pages may need optimization")
+        report.append("- Review recent content or template changes")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+    report.append(f"*Report generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*")
+
+    return "\n".join(report)
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    current_file = sys.argv[1]
+    previous_file = sys.argv[2]
+    output_file = sys.argv[3] if len(sys.argv) > 3 else None
+
+    # Load data
+    current_data = load_crawl(current_file)
+    previous_data = load_crawl(previous_file)
+
+    # Generate report
+    report = compare_crawls(current_data, previous_data)
+
+    # Output
+    if output_file:
+        with open(output_file, 'w') as f:
+            f.write(report)
+        print(f"✓ Comparison report saved to: {output_file}")
+    else:
+        print(report)
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/crawl_site.sh
+++ b/sales-marketing/skills/seo-expert/scripts/crawl_site.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+#
+# crawl_site.sh - Wrapper script for LibreCrawl integration with seo-expert skill
+#
+# Usage:
+#   ./scripts/crawl_site.sh <url> [config] [output]
+#
+# Arguments:
+#   url     - Website URL to crawl (required)
+#   config  - Config name: tier1, tier2, tier3, or path to custom JSON (default: tier1)
+#   output  - Output file path (default: crawl-results-TIMESTAMP.json)
+#
+# Examples:
+#   ./scripts/crawl_site.sh https://example.com
+#   ./scripts/crawl_site.sh https://example.com tier2
+#   ./scripts/crawl_site.sh https://example.com tier3 monthly-audit.json
+#   ./scripts/crawl_site.sh https://example.com /path/to/custom-config.json
+#
+
+set -e  # Exit on error
+
+# Get script directory (works even when called from elsewhere)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+CRAWLER_DIR="$SKILL_DIR/tools/LibreCrawl"
+VENV_DIR="$CRAWLER_DIR/venv"
+
+# Parse arguments
+URL="$1"
+CONFIG="${2:-tier1}"
+OUTPUT="${3:-crawl-results-$(date +%Y%m%d-%H%M%S).json}"
+
+# Validation
+if [ -z "$URL" ]; then
+    echo "Error: URL is required"
+    echo ""
+    echo "Usage: $0 <url> [config] [output]"
+    echo ""
+    echo "Arguments:"
+    echo "  url     - Website URL to crawl (required)"
+    echo "  config  - tier1, tier2, tier3, or path to custom JSON (default: tier1)"
+    echo "  output  - Output file path (default: crawl-results-TIMESTAMP.json)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 https://example.com"
+    echo "  $0 https://example.com tier2"
+    echo "  $0 https://example.com tier3 monthly-audit.json"
+    exit 1
+fi
+
+# Check if LibreCrawl submodule exists
+if [ ! -d "$CRAWLER_DIR" ]; then
+    echo "Error: LibreCrawl not found at $CRAWLER_DIR"
+    echo ""
+    echo "Please initialize the submodule:"
+    echo "  cd $SKILL_DIR"
+    echo "  git submodule update --init --recursive"
+    exit 1
+fi
+
+# Check if virtual environment exists, create if not
+if [ ! -d "$VENV_DIR" ]; then
+    echo "Setting up LibreCrawl virtual environment..."
+    python3 -m venv "$VENV_DIR"
+    source "$VENV_DIR/bin/activate"
+    pip install -q -r "$CRAWLER_DIR/requirements.txt"
+    echo "✓ Virtual environment created"
+else
+    source "$VENV_DIR/bin/activate"
+fi
+
+# Determine config file path
+if [ -f "$CONFIG" ]; then
+    # Custom config file path provided
+    CONFIG_FILE="$CONFIG"
+elif [ -f "$SKILL_DIR/templates/${CONFIG}-crawl-config.json" ]; then
+    # Tier config (tier1, tier2, tier3)
+    CONFIG_FILE="$SKILL_DIR/templates/${CONFIG}-crawl-config.json"
+else
+    echo "Error: Config not found: $CONFIG"
+    echo ""
+    echo "Available tier configs:"
+    ls -1 "$SKILL_DIR/templates/"*-crawl-config.json 2>/dev/null || echo "  (none found - run setup first)"
+    exit 1
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "🔍 SEO Expert - Full Site Crawl"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "URL:       $URL"
+echo "Config:    $(basename "$CONFIG_FILE")"
+echo "Output:    $OUTPUT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Create a temporary Python script that uses LibreCrawl's crawler directly
+TEMP_SCRIPT=$(mktemp)
+cat > "$TEMP_SCRIPT" << 'PYTHON_SCRIPT'
+import sys
+import json
+import time
+sys.path.insert(0, sys.argv[1])  # Add LibreCrawl to path
+
+from src.crawler import WebCrawler
+
+def crawl_site(url, config_file, output_file):
+    """Run LibreCrawl with provided config"""
+
+    # Load config
+    with open(config_file, 'r') as f:
+        config = json.load(f)
+
+    print(f"Starting crawl of {url}")
+    print(f"Max depth: {config.get('max_depth', 3)}, Max URLs: {config.get('max_urls', 100)}")
+    print("-" * 60)
+
+    # Create crawler
+    crawler = WebCrawler()
+    crawler.update_config(config)
+
+    # Start crawl
+    crawler.start_crawl(url)
+
+    # Monitor progress
+    last_status = None
+    while crawler.is_running:
+        status = crawler.get_status()
+        stats = status.get('stats', {})
+
+        if stats != last_status:
+            crawled = stats.get('crawled', 0)
+            discovered = stats.get('discovered', 0)
+            depth = stats.get('depth', 0)
+            speed = stats.get('speed', 0)
+            print(f"Progress: {crawled}/{discovered} URLs crawled (depth: {depth}, speed: {speed:.2f} URLs/sec)")
+            last_status = stats
+
+        time.sleep(1)
+
+    # Get final results
+    final_status = crawler.get_status()
+    results = final_status.get('urls', [])
+    stats = final_status.get('stats', {})
+    issues = final_status.get('issues', [])
+
+    print("\n" + "=" * 60)
+    print("CRAWL COMPLETE")
+    print("=" * 60)
+    print(f"URLs discovered: {stats.get('discovered', 0)}")
+    print(f"URLs crawled: {stats.get('crawled', 0)}")
+    print(f"Max depth: {stats.get('depth', 0)}")
+    print(f"Avg speed: {stats.get('speed', 0):.2f} URLs/sec")
+    print(f"SEO issues: {len(issues)}")
+
+    # Save results
+    output_data = {
+        'crawl_date': time.strftime('%Y-%m-%d %H:%M:%S'),
+        'url': url,
+        'config': config,
+        'stats': stats,
+        'results': results,
+        'issues': issues
+    }
+
+    with open(output_file, 'w') as f:
+        json.dump(output_data, f, indent=2)
+
+    print(f"\n✓ Results saved to: {output_file}")
+
+    return len(issues)
+
+if __name__ == '__main__':
+    crawler_dir = sys.argv[1]
+    url = sys.argv[2]
+    config_file = sys.argv[3]
+    output_file = sys.argv[4]
+
+    issue_count = crawl_site(url, config_file, output_file)
+
+    # Exit code = number of issues (capped at 125 for shell compatibility)
+    sys.exit(min(issue_count, 125))
+PYTHON_SCRIPT
+
+# Run the crawl
+python3 "$TEMP_SCRIPT" "$CRAWLER_DIR" "$URL" "$CONFIG_FILE" "$OUTPUT"
+CRAWL_EXIT_CODE=$?
+
+# Cleanup
+rm "$TEMP_SCRIPT"
+deactivate
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ $CRAWL_EXIT_CODE -eq 0 ]; then
+    echo "✓ Crawl completed successfully - No issues found!"
+else
+    echo "✓ Crawl completed - $CRAWL_EXIT_CODE issues detected"
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Generate report:   ./scripts/generate_crawl_report.py $OUTPUT"
+echo "  2. Compare to previous: ./scripts/compare_crawls.py $OUTPUT previous.json"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+exit 0

--- a/sales-marketing/skills/seo-expert/scripts/extract_meta.py
+++ b/sales-marketing/skills/seo-expert/scripts/extract_meta.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+
+"""
+Meta Tag Extraction and Schema Validation Script (GEO Enhanced)
+
+Analyzes meta tags and validates GEO-critical structured data (FAQ, HowTo, Article schemas).
+Google Gemini leverages structured data for AI citations.
+
+Usage: ./extract_meta.py <html_file_or_url>
+"""
+
+import sys
+import re
+import json
+from html.parser import HTMLParser
+
+class MetaTagParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.title = None
+        self.meta_tags = []
+        self.in_title = False
+        self.in_script = False
+        self.script_content = []
+        self.scripts = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'title':
+            self.in_title = True
+        elif tag == 'meta':
+            self.meta_tags.append(dict(attrs))
+        elif tag == 'script':
+            attrs_dict = dict(attrs)
+            # Capture JSON-LD scripts for schema analysis
+            if attrs_dict.get('type') == 'application/ld+json':
+                self.in_script = True
+                self.script_content = []
+
+    def handle_data(self, data):
+        if self.in_title:
+            self.title = data.strip()
+        elif self.in_script:
+            self.script_content.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == 'title':
+            self.in_title = False
+        elif tag == 'script' and self.in_script:
+            self.scripts.append(''.join(self.script_content))
+            self.in_script = False
+            self.script_content = []
+
+def analyze_schema_markup(scripts):
+    """Analyze Schema.org structured data for GEO optimization."""
+    print("GEO: SCHEMA.ORG STRUCTURED DATA (CRITICAL)")
+    print("=" * 80)
+
+    if not scripts:
+        print("❌ CRITICAL: No JSON-LD structured data found!")
+        print()
+        print("Recommendations:")
+        print("  • Add FAQ Schema for Q&A content (CRITICAL for GEO)")
+        print("  • Add HowTo Schema for process/tutorial content")
+        print("  • Add Article Schema with author information")
+        print()
+        print("Why this matters:")
+        print("  • 92.36% of AI citations have proper schema markup")
+        print("  • Google Gemini confirms it leverages structured data")
+        print("  • Schema dramatically improves AI citation rates")
+        print()
+        return
+
+    schemas_found = []
+    faq_schema = None
+    howto_schema = None
+    article_schema = None
+
+    # Parse each JSON-LD script
+    for i, script in enumerate(scripts):
+        try:
+            data = json.loads(script)
+
+            # Handle single schema or array of schemas
+            schemas = data if isinstance(data, list) else [data]
+
+            for schema in schemas:
+                schema_type = schema.get('@type', '')
+
+                if schema_type == 'FAQPage':
+                    faq_schema = schema
+                    schemas_found.append('FAQPage')
+                elif schema_type == 'HowTo':
+                    howto_schema = schema
+                    schemas_found.append('HowTo')
+                elif schema_type in ['Article', 'NewsArticle', 'BlogPosting']:
+                    article_schema = schema
+                    schemas_found.append(schema_type)
+                elif schema_type:
+                    schemas_found.append(schema_type)
+
+        except json.JSONDecodeError as e:
+            print(f"⚠️  Warning: Invalid JSON-LD in script {i+1}: {e}")
+            continue
+
+    # Summary
+    print(f"Schemas found: {len(schemas_found)}")
+    if schemas_found:
+        for schema_type in set(schemas_found):
+            count = schemas_found.count(schema_type)
+            print(f"  • {schema_type}" + (f" ({count})" if count > 1 else ""))
+    print()
+
+    # Analyze FAQ Schema (CRITICAL for GEO)
+    print("FAQ SCHEMA (CRITICAL for GEO)")
+    print("-" * 80)
+    if faq_schema:
+        print("✅ FAQ Schema found!")
+        questions = faq_schema.get('mainEntity', [])
+        if questions:
+            print(f"   Number of Q&A pairs: {len(questions)}")
+            print()
+            print("   Sample questions:")
+            for i, q in enumerate(questions[:3], 1):
+                question_text = q.get('name', 'N/A')
+                print(f"   {i}. {question_text}")
+            if len(questions) > 3:
+                print(f"   ... and {len(questions) - 3} more")
+        else:
+            print("   ⚠️  Warning: FAQ Schema present but no questions found")
+    else:
+        print("❌ MISSING: No FAQ Schema detected")
+        print("   CRITICAL RECOMMENDATION: Add FAQ Schema for Q&A content")
+        print("   FAQ Schema drives 3.2x higher AI citation rates (note: Google removed FAQ rich results for most sites in Aug 2023)")
+    print()
+
+    # Analyze HowTo Schema
+    print("HOWTO SCHEMA")
+    print("-" * 80)
+    if howto_schema:
+        print("✅ HowTo Schema found!")
+        steps = howto_schema.get('step', [])
+        if steps:
+            print(f"   Number of steps: {len(steps)}")
+        print("   Perfect for: Process guides, tutorials, instructions")
+    else:
+        print("⚠️  No HowTo Schema detected")
+        print("   Recommendation: Add HowTo Schema for process/tutorial content")
+    print()
+
+    # Analyze Article Schema
+    print("ARTICLE SCHEMA")
+    print("-" * 80)
+    if article_schema:
+        print("✅ Article Schema found!")
+        author = article_schema.get('author', {})
+        publisher = article_schema.get('publisher', {})
+        date_published = article_schema.get('datePublished', None)
+        date_modified = article_schema.get('dateModified', None)
+
+        # Check for author (E-E-A-T signal)
+        if author:
+            if isinstance(author, dict):
+                author_name = author.get('name', 'N/A')
+                print(f"   Author: {author_name}")
+            else:
+                print(f"   Author: {author}")
+        else:
+            print("   ⚠️  Warning: No author specified (important for E-E-A-T)")
+
+        # Check for dates (freshness signal)
+        if date_published:
+            print(f"   Published: {date_published}")
+        if date_modified:
+            print(f"   Modified: {date_modified}")
+        elif date_published:
+            print("   ⚠️  Recommendation: Add dateModified to show content freshness")
+
+        # Check for publisher
+        if not publisher:
+            print("   ⚠️  Warning: No publisher specified")
+    else:
+        print("⚠️  No Article Schema detected")
+        print("   Recommendation: Add Article Schema for blog posts/articles")
+    print()
+
+    # Overall GEO Schema Score
+    print("GEO SCHEMA OPTIMIZATION SCORE")
+    print("-" * 80)
+    score = 0
+    max_score = 3
+
+    if faq_schema:
+        score += 1
+        print("✅ FAQ Schema: PRESENT (CRITICAL)")
+    else:
+        print("❌ FAQ Schema: MISSING (CRITICAL)")
+
+    if article_schema and article_schema.get('author'):
+        score += 1
+        print("✅ Article Schema with Author: PRESENT")
+    else:
+        print("⚠️  Article Schema with Author: MISSING")
+
+    if howto_schema or len(schemas_found) > 0:
+        score += 1
+        print("✅ Additional Structured Data: PRESENT")
+    else:
+        print("⚠️  Additional Structured Data: MISSING")
+
+    print()
+    print(f"Overall Score: {score}/{max_score}")
+
+    if score == max_score:
+        print("STATUS: ✅ EXCELLENT - Schema optimized for GEO")
+    elif score >= 2:
+        print("STATUS: ⚠️  GOOD - Add FAQ Schema for optimal GEO")
+    else:
+        print("STATUS: ❌ NEEDS IMPROVEMENT - Add GEO-critical schemas")
+
+    print()
+    print("Schema Implementation Resources:")
+    print("  • See references/schema_markup_guide.md for examples")
+    print("  • Test with Google's Rich Results Test")
+    print("  • FAQ Schema is the highest priority for AI citations")
+    print()
+
+
+def analyze_meta_tags(html_content):
+    """Parse and analyze meta tags from HTML content"""
+    parser = MetaTagParser()
+    parser.feed(html_content)
+
+    print("SEO Meta Tag Analysis")
+    print("=" * 80)
+    print()
+
+    # Title Tag
+    print("TITLE TAG")
+    print("-" * 80)
+    if parser.title:
+        title_length = len(parser.title)
+        status = "✓" if 50 <= title_length <= 60 else "⚠"
+        print(f"{status} Title: {parser.title}")
+        print(f"  Length: {title_length} characters")
+        if title_length < 50:
+            print(f"  Warning: Title is too short (recommended: 50-60 characters)")
+        elif title_length > 60:
+            print(f"  Warning: Title may be truncated in search results (recommended: 50-60 characters)")
+    else:
+        print("✗ No title tag found!")
+    print()
+
+    # Meta Description
+    print("META DESCRIPTION")
+    print("-" * 80)
+    description = None
+    for meta in parser.meta_tags:
+        if meta.get('name', '').lower() == 'description':
+            description = meta.get('content', '')
+            break
+
+    if description:
+        desc_length = len(description)
+        status = "✓" if 150 <= desc_length <= 160 else "⚠"
+        print(f"{status} Description: {description}")
+        print(f"  Length: {desc_length} characters")
+        if desc_length < 150:
+            print(f"  Warning: Description is too short (recommended: 150-160 characters)")
+        elif desc_length > 160:
+            print(f"  Warning: Description may be truncated in search results (recommended: 150-160 characters)")
+    else:
+        print("✗ No meta description found!")
+    print()
+
+    # Robots Tag
+    print("META ROBOTS")
+    print("-" * 80)
+    robots = None
+    for meta in parser.meta_tags:
+        if meta.get('name', '').lower() == 'robots':
+            robots = meta.get('content', '')
+            break
+
+    if robots:
+        print(f"✓ Robots: {robots}")
+        if 'noindex' in robots.lower():
+            print(f"  ⚠ WARNING: Page is set to noindex!")
+        if 'nofollow' in robots.lower():
+            print(f"  ⚠ WARNING: Links are set to nofollow!")
+    else:
+        print("  No robots meta tag (default: index, follow)")
+    print()
+
+    # Canonical URL
+    print("CANONICAL URL")
+    print("-" * 80)
+    canonical = None
+    for meta in parser.meta_tags:
+        if meta.get('rel', '') == 'canonical':
+            canonical = meta.get('href', '')
+            break
+
+    if canonical:
+        print(f"✓ Canonical: {canonical}")
+    else:
+        print("⚠ No canonical URL specified")
+        print("  Recommendation: Add <link rel='canonical' href='...'> to prevent duplicate content issues")
+    print()
+
+    # Open Graph Tags
+    print("OPEN GRAPH (Social Media)")
+    print("-" * 80)
+    og_tags = {meta.get('property', ''): meta.get('content', '')
+               for meta in parser.meta_tags
+               if meta.get('property', '').startswith('og:')}
+
+    if og_tags:
+        for prop, content in og_tags.items():
+            print(f"✓ {prop}: {content}")
+    else:
+        print("⚠ No Open Graph tags found")
+        print("  Recommendation: Add OG tags for better social media sharing")
+    print()
+
+    # Twitter Card Tags
+    print("TWITTER CARD")
+    print("-" * 80)
+    twitter_tags = {meta.get('name', ''): meta.get('content', '')
+                    for meta in parser.meta_tags
+                    if meta.get('name', '').startswith('twitter:')}
+
+    if twitter_tags:
+        for name, content in twitter_tags.items():
+            print(f"✓ {name}: {content}")
+    else:
+        print("⚠ No Twitter Card tags found")
+        print("  Recommendation: Add Twitter Card tags for better Twitter sharing")
+    print()
+
+    # Viewport (Mobile)
+    print("VIEWPORT (Mobile)")
+    print("-" * 80)
+    viewport = None
+    for meta in parser.meta_tags:
+        if meta.get('name', '').lower() == 'viewport':
+            viewport = meta.get('content', '')
+            break
+
+    if viewport:
+        print(f"✓ Viewport: {viewport}")
+        if 'width=device-width' not in viewport.lower():
+            print(f"  ⚠ Warning: Viewport should include 'width=device-width' for mobile optimization")
+    else:
+        print("✗ No viewport meta tag found!")
+        print("  Recommendation: Add <meta name='viewport' content='width=device-width, initial-scale=1'>")
+    print()
+
+    # GEO: Schema.org Structured Data Analysis
+    analyze_schema_markup(parser.scripts)
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: ./extract_meta.py <html_file_or_url>")
+        print("Example: ./extract_meta.py page.html")
+        sys.exit(1)
+
+    input_path = sys.argv[1]
+
+    try:
+        if input_path.startswith('http://') or input_path.startswith('https://'):
+            import urllib.request
+            with urllib.request.urlopen(input_path) as response:
+                html_content = response.read().decode('utf-8')
+        else:
+            with open(input_path, 'r', encoding='utf-8') as f:
+                html_content = f.read()
+
+        analyze_meta_tags(html_content)
+
+    except FileNotFoundError:
+        print(f"Error: File '{input_path}' not found")
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/generate_crawl_report.py
+++ b/sales-marketing/skills/seo-expert/scripts/generate_crawl_report.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+generate_crawl_report.py - Generate SEO audit report from LibreCrawl results
+
+Usage:
+    ./scripts/generate_crawl_report.py <crawl-results.json> [output.md]
+
+Arguments:
+    crawl-results - LibreCrawl JSON output file
+    output        - Optional output file for markdown report (default: stdout)
+
+Example:
+    ./scripts/generate_crawl_report.py crawl-results.json audit-report.md
+"""
+
+import sys
+import json
+from collections import Counter
+from datetime import datetime
+
+def load_crawl(file_path):
+    """Load crawl results from JSON file"""
+    try:
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: Invalid JSON in: {file_path}", file=sys.stderr)
+        sys.exit(1)
+
+def priority_emoji(issue_type):
+    """Get priority emoji based on issue type"""
+    if issue_type == 'error':
+        return '🔴'
+    elif issue_type == 'warning':
+        return '🟡'
+    else:
+        return '🟢'
+
+def estimate_effort(issue_count):
+    """Estimate effort hours based on issue count and type"""
+    if issue_count <= 5:
+        return "1-2 hours"
+    elif issue_count <= 15:
+        return "2-4 hours"
+    elif issue_count <= 30:
+        return "4-8 hours"
+    else:
+        return "8-12 hours"
+
+def calculate_roi(category):
+    """Estimate ROI based on issue category"""
+    high_roi = ['SEO', 'Technical', 'Mobile']
+    medium_roi = ['Social', 'Structured Data', 'Performance']
+
+    if category in high_roi:
+        return '🔴 High'
+    elif category in medium_roi:
+        return '🟡 Medium'
+    else:
+        return '🟢 Low'
+
+def generate_report(data):
+    """Generate SEO audit report from crawl data"""
+
+    stats = data.get('stats', {})
+    issues = data.get('issues', [])
+    results = data.get('results', [])
+    url = data.get('url', 'Unknown')
+    crawl_date = data.get('crawl_date', 'Unknown')
+
+    report = []
+
+    # Header
+    report.append("# SEO Health Check Report")
+    site_name = url.replace('https://', '').replace('http://', '').split('/')[0]
+    report.append(f"## {site_name}")
+    report.append("")
+    report.append(f"**Report Date:** {datetime.now().strftime('%B %d, %Y')}")
+    report.append(f"**Crawl Date:** {crawl_date}")
+    report.append(f"**Pages Analyzed:** {stats.get('crawled', 0)}")
+    report.append(f"**Service Tier:** Foundation (Example)")
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Executive Summary
+    report.append("## Executive Summary")
+    report.append("")
+
+    total_issues = len(issues)
+    errors = len([i for i in issues if i.get('type') == 'error'])
+    warnings = len([i for i in issues if i.get('type') == 'warning'])
+
+    if total_issues == 0:
+        report.append("### Overall Score: 🟢 Excellent")
+        report.append("")
+        report.append("Your site has no detected SEO issues. Great work!")
+    elif errors == 0 and warnings < 20:
+        report.append("### Overall Score: 🟡 Good")
+        report.append("")
+        report.append(f"Found {total_issues} minor optimization opportunities. Site is in good shape with room for improvement.")
+    elif errors < 10:
+        report.append("### Overall Score: 🟡 Fair (Needs Improvement)")
+        report.append("")
+        report.append(f"Identified {total_issues} optimization opportunities across {stats.get('crawled', 0)} pages. Priority issues should be addressed soon.")
+    else:
+        report.append("### Overall Score: 🔴 Needs Attention")
+        report.append("")
+        report.append(f"Found {total_issues} issues including {errors} critical errors. Immediate action recommended.")
+
+    report.append("")
+
+    # What's Working
+    pages_with_meta = len([p for p in results if p.get('meta_description')])
+    pages_with_title = len([p for p in results if p.get('title')])
+    pages_with_h1 = len([p for p in results if p.get('h1')])
+    pages_200 = len([p for p in results if p.get('status_code') == 200])
+
+    report.append("**What's Working:**")
+    if pages_200 == stats.get('crawled', 0):
+        report.append("- ✅ All pages load successfully (200 status)")
+    if pages_with_h1 > stats.get('crawled', 0) * 0.8:
+        report.append(f"- ✅ Most pages have H1 tags ({pages_with_h1}/{stats.get('crawled', 0)})")
+    if pages_with_title == stats.get('crawled', 0):
+        report.append("- ✅ All pages have title tags")
+
+    avg_internal_links = sum(p.get('internal_links', 0) for p in results) / max(len(results), 1)
+    if avg_internal_links > 10:
+        report.append(f"- ✅ Good internal linking (avg {avg_internal_links:.0f} links/page)")
+
+    report.append("")
+
+    # Priority Issues
+    report.append("**Priority Issues:**")
+    if errors > 0:
+        report.append(f"- ❌ {errors} critical errors require immediate attention")
+    if warnings > 0:
+        report.append(f"- ⚠️ {warnings} warnings should be addressed")
+
+    missing_meta = len([i for i in issues if 'Meta Description' in i.get('issue', '')])
+    if missing_meta > 0:
+        report.append(f"- ❌ {missing_meta} pages missing meta descriptions")
+
+    missing_social = len([i for i in issues if 'OpenGraph' in i.get('issue', '') or 'Twitter' in i.get('issue', '')])
+    if missing_social > 0:
+        report.append(f"- ❌ Social media tags missing site-wide")
+
+    missing_schema = len([i for i in issues if 'Structured Data' in i.get('issue', '')])
+    if missing_schema > 0:
+        report.append(f"- ❌ {missing_schema} pages missing structured data")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Issue Breakdown
+    report.append("## Issue Breakdown")
+    report.append("")
+
+    categories = Counter(i.get('category', 'Unknown') for i in issues)
+
+    report.append("### By Category")
+    report.append("")
+    report.append("| Category | Count | Priority | Est. Effort | ROI |")
+    report.append("|----------|-------|----------|-------------|-----|")
+
+    for category, count in sorted(categories.items(), key=lambda x: x[1], reverse=True):
+        priority = priority_emoji('error' if count > 10 else 'warning')
+        effort = estimate_effort(count)
+        roi = calculate_roi(category)
+        report.append(f"| {category} | {count} | {priority} | {effort} | {roi} |")
+
+    report.append("")
+
+    # Top Issues
+    report.append("### Top 5 Most Impactful Issues")
+    report.append("")
+
+    issue_types = Counter(i.get('issue', 'Unknown') for i in issues)
+
+    for rank, (issue_type, count) in enumerate(issue_types.most_common(5), 1):
+        # Get category for this issue type
+        category = next((i.get('category', 'Unknown') for i in issues if i.get('issue') == issue_type), 'Unknown')
+        sample_issue = next(i for i in issues if i.get('issue') == issue_type)
+        severity = sample_issue.get('type', 'warning')
+
+        report.append(f"**{rank}. {issue_type}** ({count} pages)")
+        report.append(f"   - **Impact:** {calculate_roi(category)}")
+        report.append(f"   - **Effort:** {estimate_effort(count)}")
+        report.append(f"   - **Category:** {category}")
+
+        # Add specific recommendation
+        if 'Meta Description' in issue_type:
+            report.append(f"   - **Fix:** Write compelling 150-160 character meta descriptions")
+        elif 'OpenGraph' in issue_type or 'Twitter' in issue_type:
+            report.append(f"   - **Fix:** Add social media tags to site template")
+        elif 'Structured Data' in issue_type:
+            report.append(f"   - **Fix:** Implement JSON-LD schema markup")
+        elif 'Title' in issue_type and 'Short' in issue_type:
+            report.append(f"   - **Fix:** Lengthen titles to 30-60 characters")
+        elif 'Thin Content' in issue_type:
+            report.append(f"   - **Fix:** Expand content to 400+ words")
+
+        report.append("")
+
+    report.append("---")
+    report.append("")
+
+    # Detailed Findings
+    report.append("## Detailed Findings")
+    report.append("")
+
+    # Group issues by category
+    for category in sorted(set(i.get('category') for i in issues)):
+        category_issues = [i for i in issues if i.get('category') == category]
+        if not category_issues:
+            continue
+
+        report.append(f"### {category} ({len(category_issues)} issues)")
+        report.append("")
+
+        # Group by issue type within category
+        issue_groups = {}
+        for issue in category_issues:
+            issue_type = issue.get('issue', 'Unknown')
+            if issue_type not in issue_groups:
+                issue_groups[issue_type] = []
+            issue_groups[issue_type].append(issue)
+
+        for issue_type, group in sorted(issue_groups.items(), key=lambda x: len(x[1]), reverse=True):
+            severity = group[0].get('type', 'warning')
+            emoji = priority_emoji(severity)
+
+            report.append(f"**{emoji} {issue_type}** ({len(group)} pages)")
+            report.append("")
+            report.append(f"*{group[0].get('details', 'No details available')}*")
+            report.append("")
+
+            # Show up to 5 affected URLs
+            report.append("**Affected pages:**")
+            for issue in group[:5]:
+                url_path = issue.get('url', 'Unknown').replace(url, '')
+                if not url_path:
+                    url_path = '/'
+                report.append(f"- {url_path}")
+
+            if len(group) > 5:
+                report.append(f"- ... and {len(group) - 5} more pages")
+
+            report.append("")
+
+    report.append("---")
+    report.append("")
+
+    # Page-by-Page Summary
+    report.append("## Page-by-Page Summary")
+    report.append("")
+    report.append("| Page | Status | Word Count | Has Meta? | Issues |")
+    report.append("|------|--------|------------|-----------|--------|")
+
+    for page in results[:20]:  # Show first 20 pages
+        url_path = page.get('url', '').replace(url, '')
+        if not url_path:
+            url_path = '/'
+        status = page.get('status_code', 'N/A')
+        word_count = page.get('word_count', 0)
+        has_meta = '✓' if page.get('meta_description') else '✗'
+
+        # Count issues for this page
+        page_issues = [i for i in issues if i.get('url') == page.get('url')]
+        issue_count = len(page_issues)
+
+        status_emoji = '✅' if status == 200 else '❌'
+        report.append(f"| {url_path[:50]} | {status_emoji} {status} | {word_count} | {has_meta} | {issue_count} |")
+
+    if len(results) > 20:
+        report.append(f"| *... and {len(results) - 20} more pages* | | | | |")
+
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Recommended Action Plan
+    report.append("## Recommended Action Plan")
+    report.append("")
+
+    # Calculate quick wins
+    quick_win_issues = []
+    if missing_meta > 0:
+        quick_win_issues.append(f"Add meta descriptions to {missing_meta} pages")
+    if missing_social > 0:
+        quick_win_issues.append("Add social media tags site-wide")
+
+    short_titles = len([i for i in issues if 'Title Too Short' in i.get('issue', '')])
+    if short_titles > 0:
+        quick_win_issues.append(f"Optimize {short_titles} short title tags")
+
+    report.append("### 🚀 Quick Wins (Week 1-2) - 8-10 hours")
+    report.append("")
+    for idx, task in enumerate(quick_win_issues, 1):
+        report.append(f"{idx}. {task}")
+
+    report.append("")
+    report.append("**Expected Impact:**")
+    report.append("- 📈 15-25% improvement in search click-through rate")
+    report.append("- 📈 Professional social media sharing")
+    report.append("- 📈 Better search result presentation")
+    report.append("")
+
+    # Month 2 recommendations
+    report.append("### 📊 Month 2: Technical SEO (6-8 hours)")
+    report.append("")
+
+    if missing_schema > 0:
+        report.append("- Add structured data (Organization, Service, BreadcrumbList schemas)")
+
+    canonical_issues = len([i for i in issues if 'Canonical' in i.get('issue', '')])
+    if canonical_issues > 0:
+        report.append("- Fix canonical URL issues")
+
+    if len([i for i in issues if i.get('category') == 'Performance']) > 0:
+        report.append("- Address performance optimizations")
+
+    report.append("")
+    report.append("**Expected Impact:**")
+    report.append("- 📈 Eligibility for rich search results")
+    report.append("- 📈 Improved crawl efficiency")
+    report.append("- 📈 Better mobile experience")
+    report.append("")
+
+    # Month 3 recommendations
+    thin_content = len([i for i in issues if 'Thin Content' in i.get('issue', '')])
+    if thin_content > 0:
+        report.append("### 🎯 Month 3: Content Enhancement (8-10 hours)")
+        report.append("")
+        report.append(f"- Expand {thin_content} pages with thin content (250 → 400+ words)")
+        report.append("- Add FAQ sections where appropriate")
+        report.append("- Optimize content structure for readability")
+        report.append("")
+        report.append("**Expected Impact:**")
+        report.append("- 📈 Improved page quality scores")
+        report.append("- 📈 Better user engagement")
+        report.append("- 📈 Higher search rankings")
+        report.append("")
+
+    report.append("---")
+    report.append("")
+
+    # Next Steps
+    report.append("## Next Steps")
+    report.append("")
+    report.append("1. **Review this report** and prioritize which issues to address first")
+    report.append("2. **Schedule a strategy call** to discuss implementation timeline")
+    report.append("3. **Approve Quick Wins action plan** for immediate improvements")
+    report.append("4. **Schedule monthly re-crawl** to track progress")
+    report.append("")
+    report.append("---")
+    report.append("")
+
+    # Footer
+    report.append("## Questions?")
+    report.append("")
+    report.append("Contact your SEO specialist to discuss any findings or prioritization questions.")
+    report.append("")
+    report.append(f"**This report generated by:** LibreCrawl + SEO Expert Skill")
+    report.append(f"**Analysis depth:** {stats.get('depth', 0)} levels, {stats.get('crawled', 0)} pages")
+    report.append(f"**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+
+    return "\n".join(report)
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    crawl_file = sys.argv[1]
+    output_file = sys.argv[2] if len(sys.argv) > 2 else None
+
+    # Load data
+    data = load_crawl(crawl_file)
+
+    # Generate report
+    report = generate_report(data)
+
+    # Output
+    if output_file:
+        with open(output_file, 'w') as f:
+            f.write(report)
+        print(f"✓ SEO audit report saved to: {output_file}")
+    else:
+        print(report)
+
+if __name__ == '__main__':
+    main()

--- a/sales-marketing/skills/seo-expert/scripts/generate_report_pdf.py
+++ b/sales-marketing/skills/seo-expert/scripts/generate_report_pdf.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""
+Combine SEO audit (markdown) and Lighthouse desktop/mobile (JSON) reports
+into a single human-readable PDF. Order: SEO audit first, then Desktop
+Lighthouse, then Mobile Lighthouse.
+
+Usage:
+    python generate_report_pdf.py [options]
+
+Examples:
+    # Use defaults (looks for files in script directory)
+    python generate_report_pdf.py
+
+    # Specify all input files
+    python generate_report_pdf.py --audit report.md --desktop lh-desktop.json --mobile lh-mobile.json
+
+    # Include the Action Plan section (excluded by default)
+    python generate_report_pdf.py --include-action-plan
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+import markdown
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Paragraph,
+    Spacer,
+    Table,
+    TableStyle,
+    PageBreak,
+)
+
+REPORT_DIR = Path(__file__).resolve().parent
+
+# Default file paths (can be overridden via CLI)
+DEFAULT_SEO_AUDIT = REPORT_DIR / "seo-audit-agr-georgia-gov.md"
+DEFAULT_LIGHTHOUSE_DESKTOP = REPORT_DIR / "lighthouse-desktop.json"
+DEFAULT_LIGHTHOUSE_MOBILE = REPORT_DIR / "lighthouse-mobile.json"
+DEFAULT_OUTPUT_PDF = REPORT_DIR / "combined-seo-and-lighthouse-report.pdf"
+
+# Lullabot brand style (from lullabot.com – clean, professional, red accent)
+LULLABOT_RED = colors.HexColor("#E31837")
+LULLABOT_DARK = colors.HexColor("#1a1a1a")
+LULLABOT_GRAY = colors.HexColor("#444444")
+LULLABOT_BORDER = colors.HexColor("#dddddd")
+LULLABOT_TABLE_HEADER = colors.HexColor("#1a1a1a")
+LULLABOT_CODE_BG = colors.HexColor("#f0f0f0")
+LULLABOT_CODE_BORDER = colors.HexColor("#cccccc")
+
+KEY_AUDIT_IDS = {
+    "first-contentful-paint",
+    "largest-contentful-paint",
+    "speed-index",
+    "total-blocking-time",
+    "cumulative-layout-shift",
+    "interactive",
+    "server-response-time",
+    "render-blocking-resources",
+    "uses-responsive-images",
+    "meta-description",
+    "document-title",
+    "link-text",
+    "crawlable-anchors",
+    "html-has-lang",
+    "image-alt",
+    "viewport",
+    "is-on-https",
+}
+
+
+def load_lighthouse_json(path: Path) -> dict:
+    """Load Lighthouse JSON, stripping huge base64 data to avoid memory issues."""
+    with open(path, "r", encoding="utf-8") as f:
+        raw = f.read()
+    raw = re.sub(r'"data": "data:[^"]*"', '"data": ""', raw)
+    return json.loads(raw)
+
+
+def extract_lighthouse_summary(data: dict) -> dict:
+    """Extract category scores and key audits for human-readable summary."""
+    categories = data.get("categories", {})
+    audits = data.get("audits", {})
+
+    category_scores = []
+    for cat_id, cat in categories.items():
+        if isinstance(cat, dict) and "score" in cat:
+            score = cat["score"]
+            title = cat.get("title", cat_id)
+            if score is not None:
+                pct = round(score * 100)
+                category_scores.append({"id": cat_id, "title": title, "score": pct})
+
+    key_audits = []
+    for audit_id in KEY_AUDIT_IDS:
+        a = audits.get(audit_id)
+        if not a or not isinstance(a, dict):
+            continue
+        title = a.get("title", audit_id)
+        score = a.get("score")
+        display_value = a.get("displayValue", "") or ""
+        if score is not None:
+            status = "Pass" if score >= 0.9 else ("Fail" if score < 0.5 else "Needs improvement")
+        else:
+            status = "N/A"
+        key_audits.append({
+            "title": title,
+            "score": score,
+            "displayValue": display_value,
+            "status": status,
+        })
+
+    return {
+        "requestedUrl": data.get("requestedUrl", ""),
+        "fetchTime": data.get("fetchTime", ""),
+        "categoryScores": category_scores,
+        "keyAudits": key_audits,
+    }
+
+
+def _strip_backslash_escapes(s: str) -> str:
+    r"""Remove markdown backslash escapes (e.g. \< becomes <, \- becomes -).
+
+    Google Docs and some editors export markdown with backslash-escaped
+    punctuation like ``\< 2.5s`` which should display as ``< 2.5s``.
+    """
+    return re.sub(r"\\([\\`*_{}[\]()#+\-.!<>~|])", r"\1", s)
+
+
+def _unescape_entities(s: str) -> str:
+    """Replace HTML entities with actual characters so we don't double-encode.
+    PDF should show & " > < not &amp; &quot; &gt; &lt;
+    """
+    return (
+        s.replace("&amp;", "&")
+        .replace("&quot;", '"')
+        .replace("&gt;", ">")
+        .replace("&lt;", "<")
+    )
+
+
+def escape(s: str) -> str:
+    """Escape for ReportLab Paragraph (XML-style)."""
+    if not s:
+        return ""
+    s = _unescape_entities(s)
+    return (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# Placeholders to protect ReportLab-supported tags from escaping
+_PARAPH_PLACEHOLDERS = [
+    ("<b>", "\x01B\x01"),
+    ("</b>", "\x01/B\x01"),
+    ("<i>", "\x01I\x01"),
+    ("</i>", "\x01/I\x01"),
+    ("<br/>", "\x01BR\x01"),
+    ("<br>", "\x01BR\x01"),
+]
+
+
+def escape_for_paragraph(s: str) -> str:
+    """Escape for ReportLab Paragraph but keep <b>, <i>, <br/> so they render as bold/italic/line break.
+    Converts <strong> to <b>. Strips <a> tags (keeps inner text). Renders <code>...</code> as monospace.
+    Unescapes &amp; &quot; &gt; &lt; first so PDF shows & " > < not the entity text.
+    """
+    if not s:
+        return ""
+    s = _unescape_entities(s)
+
+    # Extract <code>...</code> and replace with placeholders; inner content will be escaped once
+    code_blocks = []
+
+    def replace_code(match):
+        inner = match.group(1)
+        inner_escaped = (
+            inner.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+        )
+        idx = len(code_blocks)
+        code_blocks.append(inner_escaped)
+        return f"\x02CODE_{idx}\x02"
+
+    s = re.sub(r"<code>(.*?)</code>", replace_code, s, flags=re.DOTALL | re.IGNORECASE)
+
+    # Protect check/cross so we can color them after escaping
+    s = s.replace("✓", "\x03CHECK\x03").replace("✗", "\x03CROSS\x03")
+
+    s = s.replace("<strong>", "<b>").replace("</strong>", "</b>")
+    s = s.replace("<em>", "<i>").replace("</em>", "</i>")
+    # Strip <a> tags but keep their inner text (ReportLab Paragraph doesn't support links)
+    s = re.sub(r"<a\s[^>]*>(.*?)</a>", r"\1", s, flags=re.DOTALL | re.IGNORECASE)
+    for tag, ph in _PARAPH_PLACEHOLDERS:
+        s = s.replace(tag, ph)
+    s = (
+        s.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+    for tag, ph in _PARAPH_PLACEHOLDERS:
+        s = s.replace(ph, tag)
+
+    # Green ✓ and red ✗
+    s = s.replace("\x03CHECK\x03", '<font color="green">✓</font>').replace(
+        "\x03CROSS\x03", '<font color="red">✗</font>'
+    )
+
+    # Restore code blocks as monospace
+    for i, block in enumerate(code_blocks):
+        s = s.replace(
+            f"\x02CODE_{i}\x02",
+            f'<font face="Courier" size="8">{block}</font>',
+        )
+    return s
+
+
+def md_to_flowables(md_path: Path, styles: dict, skip_action_plan: bool = True) -> list:
+    """Convert markdown file to a list of ReportLab flowables.
+
+    Args:
+        md_path: Path to the markdown file.
+        styles: ReportLab paragraph styles dictionary.
+        skip_action_plan: If True, removes the "## Action Plan" section from output.
+    """
+    with open(md_path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    # Strip markdown backslash escapes (e.g. \< from Google Docs exports)
+    text = _strip_backslash_escapes(text)
+
+    # Optionally remove Action Plan section
+    if skip_action_plan:
+        text = re.sub(
+            r"\n## Action Plan\n\n.*?(?=\n\n---\n\n## Monitoring & Measurement)",
+            "",
+            text,
+            flags=re.DOTALL,
+        )
+
+    # Use markdown to get HTML, then split into blocks for flowables
+    html = markdown.markdown(text, extensions=["tables", "fenced_code", "nl2br"])
+    flowables = []
+
+    # Simple HTML block extraction (split by tags)
+    # Handle h1, h2, h3, p, table, pre/code, ol/ul lists
+    style_map = {"h1": "Heading1", "h2": "Heading2", "h3": "Heading3", "p": "Normal"}
+
+    # Strip outer div and split by block-level tags
+    part = re.sub(r"^<div[^>]*>|</div>\s*$", "", html)
+    # Split by opening tags
+    blocks = re.split(r"(<h[1-3]>|<p>|<table>|<pre>|<[ou]l>|</table>|</pre>|</[ou]l>)", part, flags=re.I)
+
+    i = 0
+    while i < len(blocks):
+        block = blocks[i]
+        if re.match(r"<h1>", block, re.I):
+            i += 1
+            if i < len(blocks):
+                content = re.sub(r"</h1>.*", "", blocks[i], flags=re.DOTALL | re.I)
+                content = re.sub(r"<[^>]+>", "", content).strip()
+                if content:
+                    flowables.append(Paragraph(escape_for_paragraph(content), styles["Heading1"]))
+                    flowables.append(Spacer(1, 0.15 * inch))
+            i += 1
+            continue
+        if re.match(r"<h2>", block, re.I):
+            i += 1
+            if i < len(blocks):
+                content = re.sub(r"</h2>.*", "", blocks[i], flags=re.DOTALL | re.I)
+                content = re.sub(r"<[^>]+>", "", content).strip()
+                if content:
+                    flowables.append(Paragraph(escape_for_paragraph(content), styles["Heading2"]))
+                    flowables.append(Spacer(1, 0.12 * inch))
+            i += 1
+            continue
+        if re.match(r"<h3>", block, re.I):
+            i += 1
+            if i < len(blocks):
+                content = re.sub(r"</h3>.*", "", blocks[i], flags=re.DOTALL | re.I)
+                content = re.sub(r"<[^>]+>", "", content).strip()
+                if content:
+                    flowables.append(Paragraph(escape_for_paragraph(content), styles["Heading3"]))
+                    flowables.append(Spacer(1, 0.1 * inch))
+            i += 1
+            continue
+        if re.match(r"<p>", block, re.I):
+            i += 1
+            if i < len(blocks):
+                content = re.sub(r"</p>.*", "", blocks[i], flags=re.DOTALL | re.I)
+                # Keep <strong>, <em>, <br/> for Paragraph
+                content = content.replace("<br />", "<br/>").replace("<br>", "<br/>").strip()
+                content = escape_for_paragraph(content)
+                # Remove unsupported tags but preserve <b>, <i>, <br/>, <font ...>
+                content = re.sub(r"<(?!b>|/b>|i>|/i>|br/>|font[ >]|/font>)[^>]+>", "", content)
+                if content:
+                    flowables.append(Paragraph(content, styles["Normal"]))
+                    flowables.append(Spacer(1, 0.08 * inch))
+            i += 1
+            continue
+        if re.match(r"<table>", block, re.I):
+            i += 1
+            table_html = []
+            while i < len(blocks) and not re.match(r"</table>", blocks[i], re.I):
+                table_html.append(blocks[i])
+                i += 1
+            if i < len(blocks):
+                i += 1  # skip </table>
+            full_table = "".join(table_html)
+            rows = re.findall(r"<tr[^>]*>(.*?)</tr>", full_table, re.DOTALL | re.I)
+            data = []
+            for row_idx, row in enumerate(rows):
+                cells = re.findall(r"<t[hd][^>]*>(.*?)</t[hd]>", row, re.DOTALL | re.I)
+                cells = [re.sub(r"<[^>]+>", "", c).strip() for c in cells]
+                # Use Paragraph so ✓/✗ get green/red; header row (row 0) gets white text
+                if row_idx == 0:
+                    cells = [
+                        Paragraph(
+                            '<font color="white">' + escape_for_paragraph(c[:80]) + "</font>",
+                            styles["Normal"],
+                        )
+                        for c in cells
+                    ]
+                else:
+                    cells = [
+                        Paragraph(escape_for_paragraph(c[:80]), styles["Normal"])
+                        for c in cells
+                    ]
+                if cells:
+                    data.append(cells)
+            if data:
+                t = Table(data, repeatRows=1)
+                t.setStyle(
+                    TableStyle(
+                        [
+                            ("BACKGROUND", (0, 0), (-1, 0), LULLABOT_TABLE_HEADER),
+                            ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                            ("FONTSIZE", (0, 0), (-1, -1), 9),
+                            ("GRID", (0, 0), (-1, -1), 0.5, LULLABOT_BORDER),
+                            ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                        ]
+                    )
+                )
+                flowables.append(t)
+                flowables.append(Spacer(1, 0.2 * inch))
+            continue
+        if re.match(r"<[ou]l>", block, re.I):
+            is_ordered = block.lower().startswith("<ol")
+            i += 1
+            list_html = []
+            while i < len(blocks) and not re.match(r"</[ou]l>", blocks[i], re.I):
+                list_html.append(blocks[i])
+                i += 1
+            if i < len(blocks):
+                i += 1  # skip </ol> or </ul>
+            full_list = "".join(list_html)
+            items = re.findall(r"<li>(.*?)</li>", full_list, re.DOTALL | re.I)
+            for item_idx, item in enumerate(items):
+                # Keep inline formatting, strip other tags
+                item = item.replace("<br />", "<br/>").replace("<br>", "<br/>").strip()
+                item = escape_for_paragraph(item)
+                item = re.sub(r"<[^/].*?>", "", item)
+                item = re.sub(r"</[^>]+>", "", item)
+                if is_ordered:
+                    prefix = f"{item_idx + 1}. "
+                else:
+                    prefix = "\u2022 "  # bullet
+                if item:
+                    flowables.append(
+                        Paragraph(
+                            f"{prefix}{item}",
+                            styles["ListItem"],
+                        )
+                    )
+            if items:
+                flowables.append(Spacer(1, 0.08 * inch))
+            continue
+        if re.match(r"<pre>", block, re.I):
+            i += 1
+            if i < len(blocks):
+                content = re.sub(r"</pre>.*", "", blocks[i], flags=re.DOTALL | re.I)
+                # Strip <code>...</code> wrapper if present (markdown fenced blocks)
+                content = re.sub(r"</?code>", "", content, flags=re.I)
+                content = re.sub(r"<[^>]+>", "", content).strip()
+                code_flowable = make_code_block_flowable(content, styles)
+                if code_flowable:
+                    flowables.append(code_flowable)
+                    flowables.append(Spacer(1, 0.15 * inch))
+            i += 1
+            continue
+        i += 1
+
+    # If we got nothing from HTML parsing, fall back to raw paragraphs by line
+    if not flowables:
+        for line in text.split("\n"):
+            line = line.strip()
+            if not line:
+                continue
+            if line.startswith("# "):
+                flowables.append(Paragraph(escape_for_paragraph(line[2:]), styles["Heading1"]))
+            elif line.startswith("## "):
+                flowables.append(Paragraph(escape_for_paragraph(line[3:]), styles["Heading2"]))
+            elif line.startswith("### "):
+                flowables.append(Paragraph(escape_for_paragraph(line[4:]), styles["Heading3"]))
+            elif line.startswith("|") and "|" in line[1:]:
+                # Table row - collect following table rows and make one table
+                rows = [line]
+                j = text.split("\n").index(line) + 1
+                lines = text.split("\n")
+                while j < len(lines) and lines[j].strip().startswith("|"):
+                    rows.append(lines[j].strip())
+                    j += 1
+                if rows and not all(re.match(r"^[\s|\-]+$", r) for r in rows):
+                    rows_list = [
+                        row for row in rows if not re.match(r"^[\s|\-]+$", row)
+                    ]
+                    data = []
+                    for row_idx, row in enumerate(rows_list):
+                        raw_cells = [cell.strip() for cell in row.split("|")[1:-1]]
+                        if row_idx == 0:
+                            cells = [
+                                Paragraph(
+                                    '<font color="white">'
+                                    + escape_for_paragraph(c)
+                                    + "</font>",
+                                    styles["Normal"],
+                                )
+                                for c in raw_cells
+                            ]
+                        else:
+                            cells = [
+                                Paragraph(
+                                    escape_for_paragraph(c), styles["Normal"]
+                                )
+                                for c in raw_cells
+                            ]
+                        data.append(cells)
+                    if data:
+                        t = Table(data, repeatRows=1)
+                        t.setStyle(
+                            TableStyle(
+                                [
+                                    ("BACKGROUND", (0, 0), (-1, 0), LULLABOT_TABLE_HEADER),
+                                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                                    ("FONTSIZE", (0, 0), (-1, -1), 8),
+                                    ("GRID", (0, 0), (-1, -1), 0.5, LULLABOT_BORDER),
+                                ]
+                            )
+                        )
+                        flowables.append(t)
+                        flowables.append(Spacer(1, 0.15 * inch))
+                continue
+            else:
+                flowables.append(Paragraph(escape_for_paragraph(line), styles["Normal"]))
+            flowables.append(Spacer(1, 0.06 * inch))
+
+    return flowables
+
+
+# Code blocks use Lullabot palette (see LULLABOT_CODE_* above)
+CODE_BLOCK_BG = LULLABOT_CODE_BG
+CODE_BLOCK_BORDER = LULLABOT_CODE_BORDER
+
+
+def make_code_block_flowable(content: str, styles: dict):
+    """Build a code block flowable: grey background, subtle border, monospace text that wraps."""
+    content = content.strip()[:4000]
+    if not content:
+        return None
+    # Unescape so PDF shows & " < > not &amp; &quot; &gt; &lt;
+    content = _unescape_entities(content)
+    # Escape for ReportLab Paragraph (XML), then newlines -> <br/> so Paragraph wraps long lines
+    content_escaped = (
+        content.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+    content_with_breaks = content_escaped.replace("\n", "<br/>")
+    code_para = Paragraph(
+        f'<font face="Courier" size="8">{content_with_breaks}</font>',
+        styles["Code"],
+    )
+    t = Table([[code_para]], colWidths=[None])
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), CODE_BLOCK_BG),
+                ("BOX", (0, 0), (-1, -1), 0.5, CODE_BLOCK_BORDER),
+                ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 10),
+                ("TOPPADDING", (0, 0), (-1, -1), 8),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 8),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+            ]
+        )
+    )
+    return t
+
+
+def build_styles():
+    """Build paragraph styles with Lullabot brand (lullabot.com)."""
+    styles = getSampleStyleSheet()
+    # Lullabot: clean sans, dark text, red accent for headings
+    styles["Normal"].fontName = "Helvetica"
+    styles["Normal"].fontSize = 10
+    styles["Normal"].textColor = LULLABOT_GRAY
+    styles["Normal"].spaceBefore = 6
+    styles["Normal"].spaceAfter = 6
+    styles["Heading1"].fontName = "Helvetica-Bold"
+    styles["Heading1"].fontSize = 18
+    styles["Heading1"].textColor = LULLABOT_RED
+    styles["Heading1"].spaceBefore = 18
+    styles["Heading1"].spaceAfter = 12
+    styles["Heading2"].fontName = "Helvetica-Bold"
+    styles["Heading2"].fontSize = 14
+    styles["Heading2"].textColor = LULLABOT_DARK
+    styles["Heading2"].spaceBefore = 14
+    styles["Heading2"].spaceAfter = 8
+    styles["Heading3"].fontName = "Helvetica-Bold"
+    styles["Heading3"].fontSize = 12
+    styles["Heading3"].textColor = LULLABOT_DARK
+    styles["Heading3"].spaceBefore = 10
+    styles["Heading3"].spaceAfter = 6
+    styles.add(
+        ParagraphStyle(
+            name="ListItem",
+            parent=styles["Normal"],
+            fontName="Helvetica",
+            fontSize=10,
+            textColor=LULLABOT_GRAY,
+            leftIndent=18,
+            spaceBefore=2,
+            spaceAfter=2,
+        )
+    )
+    try:
+        styles["Code"]
+    except KeyError:
+        styles.add(
+            ParagraphStyle(
+                name="Code",
+                fontName="Courier",
+                fontSize=8,
+                leading=10,
+                leftIndent=0,
+                rightIndent=0,
+                spaceBefore=6,
+                spaceAfter=6,
+                textColor=LULLABOT_DARK,
+                splitLongWords=1,
+                wordWrap="CJK",
+            )
+        )
+    else:
+        styles["Code"].textColor = LULLABOT_DARK
+    return styles
+
+
+def lighthouse_summary_to_flowables(summary: dict, title: str, styles: dict) -> list:
+    """Turn Lighthouse summary dict into ReportLab flowables."""
+    flowables = [
+        Paragraph(escape_for_paragraph(title), styles["Heading1"]),
+        Spacer(1, 0.2 * inch),
+        Paragraph(f'<b>URL:</b> {escape(summary["requestedUrl"])}', styles["Normal"]),
+        Paragraph(f'<b>Fetch time:</b> {escape(summary["fetchTime"])}', styles["Normal"]),
+        Spacer(1, 0.15 * inch),
+        Paragraph("Category scores", styles["Heading2"]),
+        Spacer(1, 0.08 * inch),
+    ]
+    cat_data = [
+        [
+            Paragraph('<font color="white">Category</font>', styles["Normal"]),
+            Paragraph('<font color="white">Score</font>', styles["Normal"]),
+        ]
+    ]
+    for c in summary["categoryScores"]:
+        cat_data.append([_unescape_entities(c["title"]), f'{c["score"]}/100'])
+    t1 = Table(cat_data, repeatRows=1)
+    t1.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), LULLABOT_TABLE_HEADER),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 10),
+                ("GRID", (0, 0), (-1, -1), 0.5, LULLABOT_BORDER),
+            ]
+        )
+    )
+    flowables.append(t1)
+    flowables.append(Spacer(1, 0.2 * inch))
+    flowables.append(Paragraph("Key metrics & audits", styles["Heading2"]))
+    flowables.append(Spacer(1, 0.08 * inch))
+    audit_data = [
+        [
+            Paragraph('<font color="white">Audit</font>', styles["Normal"]),
+            Paragraph('<font color="white">Result</font>', styles["Normal"]),
+            Paragraph('<font color="white">Value</font>', styles["Normal"]),
+        ]
+    ]
+    for a in summary["keyAudits"]:
+        audit_data.append([
+            _unescape_entities(a["title"][:60]),
+            a["status"],
+            _unescape_entities((a["displayValue"] or "-")[:40]),
+        ])
+    t2 = Table(audit_data, repeatRows=1)
+    t2.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), LULLABOT_TABLE_HEADER),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("GRID", (0, 0), (-1, -1), 0.5, LULLABOT_BORDER),
+            ]
+        )
+    )
+    flowables.append(t2)
+    return flowables
+
+
+def make_lullabot_header(styles: dict) -> list:
+    """Lullabot brand header for first page (lullabot.com style)."""
+    # Red accent line (thin bar)
+    line = Table([[" "]], colWidths=[6 * inch], rowHeights=[4])
+    line.setStyle(TableStyle([("BACKGROUND", (0, 0), (-1, -1), LULLABOT_RED)]))
+    return [
+        Paragraph(
+            '<font color="#E31837" size="24" face="Helvetica-Bold">Lullabot</font>',
+            styles["Normal"],
+        ),
+        Spacer(1, 0.08 * inch),
+        Paragraph(
+            '<font color="#444444" size="10">A Strategy, Design, and Development Agency</font>',
+            styles["Normal"],
+        ),
+        Spacer(1, 0.12 * inch),
+        line,
+        Spacer(1, 0.25 * inch),
+    ]
+
+
+def parse_args(argv: list = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Combine SEO audit (Markdown) and Lighthouse (JSON) reports into a PDF.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s
+      Use default file paths in the script directory.
+
+  %(prog)s --audit my-audit.md --desktop desktop.json --mobile mobile.json -o report.pdf
+      Specify all input and output files.
+
+  %(prog)s --include-action-plan
+      Include the Action Plan section in the PDF output.
+""",
+    )
+    parser.add_argument(
+        "--audit", "-a",
+        type=Path,
+        default=DEFAULT_SEO_AUDIT,
+        help=f"Path to SEO audit Markdown file (default: {DEFAULT_SEO_AUDIT.name})",
+    )
+    parser.add_argument(
+        "--desktop", "-d",
+        type=Path,
+        default=DEFAULT_LIGHTHOUSE_DESKTOP,
+        help=f"Path to Lighthouse desktop JSON (default: {DEFAULT_LIGHTHOUSE_DESKTOP.name})",
+    )
+    parser.add_argument(
+        "--mobile", "-m",
+        type=Path,
+        default=DEFAULT_LIGHTHOUSE_MOBILE,
+        help=f"Path to Lighthouse mobile JSON (default: {DEFAULT_LIGHTHOUSE_MOBILE.name})",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        type=Path,
+        default=DEFAULT_OUTPUT_PDF,
+        help=f"Output PDF path (default: {DEFAULT_OUTPUT_PDF.name})",
+    )
+    parser.add_argument(
+        "--include-action-plan",
+        action="store_true",
+        default=False,
+        help="Include the Action Plan section in the PDF (excluded by default)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list = None) -> int:
+    """Main entry point."""
+    args = parse_args(argv)
+
+    # Validate input files exist
+    for path, desc in [
+        (args.audit, "SEO audit"),
+        (args.desktop, "Lighthouse desktop"),
+        (args.mobile, "Lighthouse mobile"),
+    ]:
+        if not path.exists():
+            print(f"Error: {desc} file not found: {path}", file=sys.stderr)
+            return 1
+
+    styles = build_styles()
+    story = []
+
+    # Lullabot brand header
+    story.extend(make_lullabot_header(styles))
+
+    print(f"Loading SEO audit: {args.audit}")
+    try:
+        skip_action_plan = not args.include_action_plan
+        seo_flowables = md_to_flowables(args.audit, styles, skip_action_plan=skip_action_plan)
+        story.extend(seo_flowables)
+    except Exception as e:
+        # Fallback: add raw text
+        with open(args.audit, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    story.append(Paragraph(escape_for_paragraph(line), styles["Normal"]))
+                    story.append(Spacer(1, 0.04 * inch))
+        print(f"Markdown parsing warning: {e}")
+
+    story.append(PageBreak())
+
+    print(f"Loading Lighthouse Desktop: {args.desktop}")
+    lh_desktop = load_lighthouse_json(args.desktop)
+    desktop_summary = extract_lighthouse_summary(lh_desktop)
+    story.extend(lighthouse_summary_to_flowables(desktop_summary, "Lighthouse Report – Desktop", styles))
+
+    story.append(PageBreak())
+
+    print(f"Loading Lighthouse Mobile: {args.mobile}")
+    lh_mobile = load_lighthouse_json(args.mobile)
+    mobile_summary = extract_lighthouse_summary(lh_mobile)
+    story.extend(lighthouse_summary_to_flowables(mobile_summary, "Lighthouse Report – Mobile", styles))
+
+    def add_footer(canvas, doc):
+        """Lullabot brand footer on each page."""
+        canvas.saveState()
+        canvas.setFont("Helvetica", 8)
+        canvas.setFillColor(LULLABOT_GRAY)
+        canvas.drawString(inch, 0.5 * inch, "Lullabot — A Strategy, Design, and Development Agency")
+        canvas.setStrokeColor(LULLABOT_RED)
+        canvas.setLineWidth(1)
+        canvas.line(inch, 0.4 * inch, 7.5 * inch, 0.4 * inch)
+        canvas.restoreState()
+
+    print(f"Writing PDF to {args.output}...")
+    doc = SimpleDocTemplate(
+        str(args.output),
+        pagesize=letter,
+        rightMargin=inch,
+        leftMargin=inch,
+        topMargin=inch,
+        bottomMargin=0.75 * inch,
+    )
+    doc.build(story, onFirstPage=add_footer, onLaterPages=add_footer)
+    print(f"Done. PDF saved: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sales-marketing/skills/seo-expert/scripts/lighthouse_audit.sh
+++ b/sales-marketing/skills/seo-expert/scripts/lighthouse_audit.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Lighthouse SEO Audit Script
+# Usage: ./lighthouse_audit.sh <url>
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <url>"
+    echo "Example: $0 https://example.com"
+    exit 1
+fi
+
+URL="$1"
+
+# Check if Lighthouse CLI is installed
+if ! command -v lighthouse &> /dev/null; then
+    echo "Error: Lighthouse CLI is not installed."
+    echo "Install with: npm install -g lighthouse"
+    exit 1
+fi
+
+echo "Running Lighthouse audit on: $URL"
+echo "This may take 30-60 seconds..."
+echo ""
+
+# Run Lighthouse with SEO, performance, and accessibility categories
+lighthouse "$URL" \
+    --only-categories=performance,seo,accessibility,best-practices \
+    --output=json \
+    --output-path=stdout \
+    --chrome-flags="--headless" \
+    --quiet
+
+echo ""
+echo "Audit complete!"

--- a/sales-marketing/skills/seo-expert/scripts/test_analyze_eeat.py
+++ b/sales-marketing/skills/seo-expert/scripts/test_analyze_eeat.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Unit tests for analyze_eeat.py detection modules."""
+
+import unittest
+
+from analyze_eeat import (
+    EEATParser,
+    calculate_score,
+    detect_authors,
+    detect_citations,
+    detect_dates,
+    detect_quotes,
+    detect_trust_signals,
+    rating_label,
+)
+
+
+def _parse(html):
+    """Helper: parse HTML and return EEATParser."""
+    parser = EEATParser()
+    parser.feed(html)
+    return parser
+
+
+# ---- Minimal HTML (no signals) ----
+MINIMAL_HTML = """
+<html><head><title>Test</title></head>
+<body><p>Hello world.</p></body></html>
+"""
+
+# ---- Rich HTML (all signals) ----
+RICH_HTML = """
+<html>
+<head>
+  <title>Expert Guide to SEO</title>
+  <meta name="author" content="Dr. Jane Smith">
+  <meta property="article:published_time" content="2025-01-15">
+  <meta property="article:modified_time" content="2025-06-01">
+  <script type="application/ld+json">
+  {
+    "@type": "Article",
+    "author": {"@type": "Person", "name": "Dr. Jane Smith"},
+    "datePublished": "2025-01-15",
+    "dateModified": "2025-06-01"
+  }
+  </script>
+</head>
+<body>
+  <div class="author-bio">
+    <p>By Dr. Jane Smith, PhD</p>
+    <p>About the Author: Dr. Smith has 20 years of experience.</p>
+  </div>
+  <article>
+    <p>Published January 15, 2025. Updated June 1, 2025.</p>
+    <p>According to Dr. John Doe, SEO requires consistent effort.</p>
+    <blockquote>Search engine optimization is essential for visibility.</blockquote>
+    <p>We are ISO 27001 certified and HIPAA compliant.</p>
+    <a href="https://www.nih.gov/research">NIH Research</a>
+    <a href="https://example.edu/paper">University Paper</a>
+    <a href="https://www.cdc.gov/data">CDC Data</a>
+    <a href="https://example.com/other">Other Site</a>
+    <a href="/privacy-policy">Privacy Policy</a>
+    <a href="/terms-of-service">Terms of Service</a>
+  </article>
+</body>
+</html>
+"""
+
+
+class TestAuthorDetection(unittest.TestCase):
+    def test_no_authors_in_minimal(self):
+        parser = _parse(MINIMAL_HTML)
+        authors, creds = detect_authors(parser)
+        self.assertEqual(len(authors), 0)
+        self.assertEqual(len(creds), 0)
+
+    def test_meta_author(self):
+        html = '<html><head><meta name="author" content="Alice Jones"></head><body></body></html>'
+        parser = _parse(html)
+        authors, _ = detect_authors(parser)
+        names = [name for _, name in authors]
+        self.assertIn('Alice Jones', names)
+
+    def test_schema_author(self):
+        html = '''<html><head>
+        <script type="application/ld+json">{"@type":"Article","author":{"name":"Bob Lee"}}</script>
+        </head><body></body></html>'''
+        parser = _parse(html)
+        authors, _ = detect_authors(parser)
+        names = [name for _, name in authors]
+        self.assertIn('Bob Lee', names)
+
+    def test_byline_pattern(self):
+        html = '<html><body><p>By Sarah Connor</p></body></html>'
+        parser = _parse(html)
+        authors, _ = detect_authors(parser)
+        names = [name for _, name in authors]
+        self.assertIn('Sarah Connor', names)
+
+    def test_credentials_detected(self):
+        html = '<html><body><p>By Dr. Jane Smith, PhD, MBA</p></body></html>'
+        parser = _parse(html)
+        _, creds = detect_authors(parser)
+        cred_text = ' '.join(creds)
+        self.assertIn('PhD', cred_text)
+
+    def test_author_element_class(self):
+        html = '<html><body><div class="author-info"><span>Mark Twain</span></div></body></html>'
+        parser = _parse(html)
+        authors, _ = detect_authors(parser)
+        self.assertTrue(any('Mark Twain' in name for _, name in authors))
+
+    def test_rich_html_authors(self):
+        parser = _parse(RICH_HTML)
+        authors, creds = detect_authors(parser)
+        self.assertGreaterEqual(len(authors), 1)
+        self.assertGreater(len(creds), 0)
+
+
+class TestCitationDetection(unittest.TestCase):
+    def test_no_external_links_in_minimal(self):
+        parser = _parse(MINIMAL_HTML)
+        ext, auth = detect_citations(parser)
+        self.assertEqual(len(ext), 0)
+        self.assertEqual(len(auth), 0)
+
+    def test_authoritative_gov_link(self):
+        html = '<html><body><a href="https://www.nih.gov/page">NIH</a></body></html>'
+        parser = _parse(html)
+        ext, auth = detect_citations(parser)
+        self.assertEqual(len(ext), 1)
+        self.assertEqual(len(auth), 1)
+
+    def test_edu_link(self):
+        html = '<html><body><a href="https://mit.edu/paper">MIT Paper</a></body></html>'
+        parser = _parse(html)
+        _, auth = detect_citations(parser)
+        self.assertEqual(len(auth), 1)
+
+    def test_regular_external_not_authoritative(self):
+        html = '<html><body><a href="https://random-blog.com/post">Blog</a></body></html>'
+        parser = _parse(html)
+        ext, auth = detect_citations(parser)
+        self.assertEqual(len(ext), 1)
+        self.assertEqual(len(auth), 0)
+
+    def test_same_domain_excluded(self):
+        html = '<html><body><a href="https://mysite.com/page">Internal</a></body></html>'
+        parser = _parse(html)
+        ext, _ = detect_citations(parser, page_url='https://mysite.com/')
+        self.assertEqual(len(ext), 0)
+
+    def test_rich_html_citations(self):
+        parser = _parse(RICH_HTML)
+        ext, auth = detect_citations(parser)
+        self.assertGreaterEqual(len(ext), 3)
+        self.assertGreaterEqual(len(auth), 2)
+
+
+class TestDateDetection(unittest.TestCase):
+    def test_no_dates_in_minimal(self):
+        parser = _parse(MINIMAL_HTML)
+        dates, visible = detect_dates(parser)
+        self.assertEqual(len(dates), 0)
+
+    def test_meta_published_time(self):
+        html = '<html><head><meta property="article:published_time" content="2025-01-15"></head><body></body></html>'
+        parser = _parse(html)
+        dates, _ = detect_dates(parser)
+        self.assertIn('published', dates)
+
+    def test_schema_dates(self):
+        html = '''<html><head>
+        <script type="application/ld+json">{"@type":"Article","datePublished":"2025-01-15","dateModified":"2025-06-01"}</script>
+        </head><body></body></html>'''
+        parser = _parse(html)
+        dates, _ = detect_dates(parser)
+        self.assertIn('published', dates)
+        self.assertIn('modified', dates)
+
+    def test_time_element(self):
+        html = '<html><body><time datetime="2025-03-20">March 20, 2025</time></body></html>'
+        parser = _parse(html)
+        dates, _ = detect_dates(parser)
+        self.assertIn('published', dates)
+
+    def test_visible_date_patterns(self):
+        html = '<html><body><p>Published January 15, 2025</p></body></html>'
+        parser = _parse(html)
+        _, visible = detect_dates(parser)
+        self.assertGreater(len(visible), 0)
+
+    def test_rich_html_dates(self):
+        parser = _parse(RICH_HTML)
+        dates, visible = detect_dates(parser)
+        self.assertIn('published', dates)
+        self.assertIn('modified', dates)
+        self.assertGreater(len(visible), 0)
+
+
+class TestQuoteDetection(unittest.TestCase):
+    def test_no_quotes_in_minimal(self):
+        parser = _parse(MINIMAL_HTML)
+        bq, attr = detect_quotes(parser)
+        self.assertEqual(len(bq), 0)
+        self.assertEqual(len(attr), 0)
+
+    def test_blockquote_detected(self):
+        html = '<html><body><blockquote>This is important.</blockquote></body></html>'
+        parser = _parse(html)
+        bq, _ = detect_quotes(parser)
+        self.assertEqual(len(bq), 1)
+        self.assertIn('This is important.', bq[0])
+
+    def test_attribution_pattern(self):
+        html = '<html><body><p>According to Dr. Smith, SEO matters.</p></body></html>'
+        parser = _parse(html)
+        _, attr = detect_quotes(parser)
+        self.assertGreater(len(attr), 0)
+
+    def test_rich_html_quotes(self):
+        parser = _parse(RICH_HTML)
+        bq, attr = detect_quotes(parser)
+        self.assertGreater(len(bq), 0)
+        self.assertGreater(len(attr), 0)
+
+
+class TestTrustSignalDetection(unittest.TestCase):
+    def test_no_signals_in_minimal(self):
+        parser = _parse(MINIMAL_HTML)
+        signals = detect_trust_signals(parser)
+        self.assertEqual(len(signals), 0)
+
+    def test_iso_certification(self):
+        html = '<html><body><p>We are ISO 27001 certified.</p></body></html>'
+        parser = _parse(html)
+        signals = detect_trust_signals(parser)
+        certs = [s for s in signals if s[0] == 'certification']
+        self.assertGreater(len(certs), 0)
+
+    def test_hipaa_detected(self):
+        html = '<html><body><p>HIPAA compliant systems.</p></body></html>'
+        parser = _parse(html)
+        signals = detect_trust_signals(parser)
+        self.assertTrue(any('HIPAA' in desc for _, desc in signals))
+
+    def test_privacy_policy_link(self):
+        html = '<html><body><a href="/privacy">Privacy Policy</a></body></html>'
+        parser = _parse(html)
+        signals = detect_trust_signals(parser)
+        self.assertTrue(any(desc == 'Privacy Policy' for _, desc in signals))
+
+    def test_terms_link(self):
+        html = '<html><body><a href="/terms-of-service">Terms of Service</a></body></html>'
+        parser = _parse(html)
+        signals = detect_trust_signals(parser)
+        self.assertTrue(any(desc == 'Terms of Service' for _, desc in signals))
+
+    def test_about_author_section(self):
+        html = '<html><body><p>About the Author: Expert in SEO.</p></body></html>'
+        parser = _parse(html)
+        signals = detect_trust_signals(parser)
+        self.assertTrue(any(s[0] == 'bio' for s in signals))
+
+    def test_rich_html_trust_signals(self):
+        parser = _parse(RICH_HTML)
+        signals = detect_trust_signals(parser)
+        self.assertGreater(len(signals), 0)
+
+
+class TestScoring(unittest.TestCase):
+    def test_minimal_html_low_score(self):
+        parser = _parse(MINIMAL_HTML)
+        authors, creds = detect_authors(parser)
+        ext, auth = detect_citations(parser)
+        dates, visible = detect_dates(parser)
+        bq, attr = detect_quotes(parser)
+        trust = detect_trust_signals(parser)
+        scores = calculate_score(
+            authors, creds, ext, auth, dates, visible, bq, attr, trust, False
+        )
+        self.assertLess(scores['total'], 25)
+
+    def test_rich_html_high_score(self):
+        parser = _parse(RICH_HTML)
+        authors, creds = detect_authors(parser)
+        ext, auth = detect_citations(parser)
+        dates, visible = detect_dates(parser)
+        bq, attr = detect_quotes(parser)
+        trust = detect_trust_signals(parser)
+        scores = calculate_score(
+            authors, creds, ext, auth, dates, visible, bq, attr, trust, parser.has_about_author
+        )
+        self.assertGreaterEqual(scores['total'], 50)
+
+    def test_each_dimension_capped_at_25(self):
+        scores = calculate_score(
+            [('meta', 'A')] * 10, ['PhD'] * 10,
+            [('h', 't', 'd')] * 20, [('h', 't', 'd')] * 20,
+            {'published': ('m', 'v'), 'modified': ('m', 'v')},
+            ['2025-01-01'] * 10,
+            ['quote'] * 10, ['attr'] * 10,
+            [('certification', 'ISO'), ('policy', 'Privacy'), ('policy', 'Terms')] * 5,
+            True,
+        )
+        self.assertLessEqual(scores['experience'], 25)
+        self.assertLessEqual(scores['expertise'], 25)
+        self.assertLessEqual(scores['authoritativeness'], 25)
+        self.assertLessEqual(scores['trustworthiness'], 25)
+        self.assertLessEqual(scores['total'], 100)
+
+
+class TestRatingLabel(unittest.TestCase):
+    def test_excellent(self):
+        self.assertIn('EXCELLENT', rating_label(75))
+        self.assertIn('EXCELLENT', rating_label(100))
+
+    def test_good(self):
+        self.assertIn('GOOD', rating_label(50))
+        self.assertIn('GOOD', rating_label(74))
+
+    def test_needs_improvement(self):
+        self.assertIn('NEEDS IMPROVEMENT', rating_label(25))
+        self.assertIn('NEEDS IMPROVEMENT', rating_label(49))
+
+    def test_poor(self):
+        self.assertIn('POOR', rating_label(0))
+        self.assertIn('POOR', rating_label(24))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sales-marketing/skills/seo-expert/scripts/test_generate_report_pdf.py
+++ b/sales-marketing/skills/seo-expert/scripts/test_generate_report_pdf.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Unit tests for generate_report_pdf.py parsing functions."""
+import json
+import tempfile
+from pathlib import Path
+import unittest
+
+from generate_report_pdf import (
+    _unescape_entities,
+    escape,
+    escape_for_paragraph,
+    extract_lighthouse_summary,
+    load_lighthouse_json,
+    parse_args,
+)
+
+
+class TestUnescapeEntities(unittest.TestCase):
+    """Tests for _unescape_entities function."""
+
+    def test_unescapes_amp(self):
+        self.assertEqual(_unescape_entities("foo &amp; bar"), "foo & bar")
+
+    def test_unescapes_quot(self):
+        self.assertEqual(_unescape_entities("&quot;hello&quot;"), '"hello"')
+
+    def test_unescapes_gt_lt(self):
+        self.assertEqual(_unescape_entities("&lt;tag&gt;"), "<tag>")
+
+    def test_handles_plain_text(self):
+        self.assertEqual(_unescape_entities("no entities here"), "no entities here")
+
+    def test_handles_multiple_entities(self):
+        self.assertEqual(
+            _unescape_entities("&lt;a href=&quot;url&quot;&gt;"),
+            '<a href="url">',
+        )
+
+
+class TestEscape(unittest.TestCase):
+    """Tests for escape function."""
+
+    def test_escapes_ampersand(self):
+        self.assertEqual(escape("foo & bar"), "foo &amp; bar")
+
+    def test_escapes_angle_brackets(self):
+        self.assertEqual(escape("<script>"), "&lt;script&gt;")
+
+    def test_handles_empty_string(self):
+        self.assertEqual(escape(""), "")
+
+    def test_handles_none(self):
+        self.assertEqual(escape(None), "")
+
+    def test_round_trip_entities(self):
+        # Input with HTML entities should be unescaped then re-escaped
+        self.assertEqual(escape("&amp;"), "&amp;")
+
+
+class TestEscapeForParagraph(unittest.TestCase):
+    """Tests for escape_for_paragraph function."""
+
+    def test_preserves_bold_tags(self):
+        result = escape_for_paragraph("<b>bold</b>")
+        self.assertIn("<b>", result)
+        self.assertIn("</b>", result)
+
+    def test_preserves_italic_tags(self):
+        result = escape_for_paragraph("<i>italic</i>")
+        self.assertIn("<i>", result)
+        self.assertIn("</i>", result)
+
+    def test_converts_strong_to_bold(self):
+        result = escape_for_paragraph("<strong>text</strong>")
+        self.assertIn("<b>", result)
+        self.assertIn("</b>", result)
+
+    def test_converts_em_to_italic(self):
+        result = escape_for_paragraph("<em>text</em>")
+        self.assertIn("<i>", result)
+        self.assertIn("</i>", result)
+
+    def test_colors_checkmark_green(self):
+        result = escape_for_paragraph("✓")
+        self.assertIn('color="green"', result)
+
+    def test_colors_cross_red(self):
+        result = escape_for_paragraph("✗")
+        self.assertIn('color="red"', result)
+
+    def test_handles_code_tags(self):
+        result = escape_for_paragraph("<code>example</code>")
+        self.assertIn("Courier", result)
+
+    def test_handles_empty_string(self):
+        self.assertEqual(escape_for_paragraph(""), "")
+
+
+class TestExtractLighthouseSummary(unittest.TestCase):
+    """Tests for extract_lighthouse_summary function."""
+
+    def test_extracts_category_scores(self):
+        data = {
+            "categories": {
+                "performance": {"title": "Performance", "score": 0.85},
+                "accessibility": {"title": "Accessibility", "score": 0.92},
+            },
+            "audits": {},
+        }
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(len(summary["categoryScores"]), 2)
+        scores = {c["id"]: c["score"] for c in summary["categoryScores"]}
+        self.assertEqual(scores["performance"], 85)
+        self.assertEqual(scores["accessibility"], 92)
+
+    def test_extracts_key_audits(self):
+        data = {
+            "categories": {},
+            "audits": {
+                "first-contentful-paint": {
+                    "title": "First Contentful Paint",
+                    "score": 0.95,
+                    "displayValue": "1.2 s",
+                },
+                "meta-description": {
+                    "title": "Meta Description",
+                    "score": 1.0,
+                    "displayValue": "",
+                },
+            },
+        }
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(len(summary["keyAudits"]), 2)
+
+    def test_status_pass_for_high_score(self):
+        data = {
+            "categories": {},
+            "audits": {
+                "meta-description": {"title": "Meta", "score": 1.0},
+            },
+        }
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(summary["keyAudits"][0]["status"], "Pass")
+
+    def test_status_fail_for_low_score(self):
+        data = {
+            "categories": {},
+            "audits": {
+                "meta-description": {"title": "Meta", "score": 0.3},
+            },
+        }
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(summary["keyAudits"][0]["status"], "Fail")
+
+    def test_status_needs_improvement_for_mid_score(self):
+        data = {
+            "categories": {},
+            "audits": {
+                "meta-description": {"title": "Meta", "score": 0.7},
+            },
+        }
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(summary["keyAudits"][0]["status"], "Needs improvement")
+
+    def test_handles_missing_fields(self):
+        data = {}
+        summary = extract_lighthouse_summary(data)
+        self.assertEqual(summary["categoryScores"], [])
+        self.assertEqual(summary["keyAudits"], [])
+        self.assertEqual(summary["requestedUrl"], "")
+
+
+class TestLoadLighthouseJson(unittest.TestCase):
+    """Tests for load_lighthouse_json function."""
+
+    def test_loads_valid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"requestedUrl": "https://example.com"}, f)
+            f.flush()
+            result = load_lighthouse_json(Path(f.name))
+            self.assertEqual(result["requestedUrl"], "https://example.com")
+
+    def test_strips_base64_data(self):
+        # Simulate Lighthouse JSON with embedded base64 screenshot data
+        data_with_base64 = '{"audits": {"screenshot": {"data": "data:image/png;base64,iVBOR..."}}}'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(data_with_base64)
+            f.flush()
+            result = load_lighthouse_json(Path(f.name))
+            # The base64 data should be stripped
+            self.assertEqual(result["audits"]["screenshot"]["data"], "")
+
+
+class TestParseArgs(unittest.TestCase):
+    """Tests for argument parsing."""
+
+    def test_defaults(self):
+        args = parse_args([])
+        self.assertIsNotNone(args.audit)
+        self.assertIsNotNone(args.desktop)
+        self.assertIsNotNone(args.mobile)
+        self.assertIsNotNone(args.output)
+        self.assertFalse(args.include_action_plan)
+
+    def test_custom_audit_path(self):
+        args = parse_args(["--audit", "/path/to/audit.md"])
+        self.assertEqual(args.audit, Path("/path/to/audit.md"))
+
+    def test_short_flags(self):
+        args = parse_args(["-a", "a.md", "-d", "d.json", "-m", "m.json", "-o", "out.pdf"])
+        self.assertEqual(args.audit, Path("a.md"))
+        self.assertEqual(args.desktop, Path("d.json"))
+        self.assertEqual(args.mobile, Path("m.json"))
+        self.assertEqual(args.output, Path("out.pdf"))
+
+    def test_include_action_plan_flag(self):
+        args = parse_args(["--include-action-plan"])
+        self.assertTrue(args.include_action_plan)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds three skills from `~/.claude/skills/` (all non-plugin sourced):

- **github-wiki** (`development/skills/`) — Gollum link syntax, sidebar navigation, image handling, troubleshooting
- **seo-expert** (`sales-marketing/skills/`) — Comprehensive SEO + GEO auditing with 10 Python/Bash scripts, 8 reference docs, report templates, and priority matrix
- **slack-markdown-formatter** (`content-strategy/skills/`) — Slack mrkdwn syntax guide covering differences from standard markdown, Block Kit, mentions, and formatting workflow

All three include companion resource directories using the pattern from #114. Also adds `.eleventyignore` to prevent 11ty from processing resource `.md` files as standalone pages.

## Test plan

- [ ] `npm run build` succeeds (99 files, 19 passthrough copies)
- [ ] All three skill pages render with correct content
- [ ] SKILL.md files generated for each skill
- [ ] Resource directories appear in build output with download links
- [ ] Reference `.md` files inside companion dirs are NOT processed as HTML pages
- [ ] Existing skills unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)