### PR TITLE
Fix horizontal scrolling from swiper overflow

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -82,6 +82,7 @@ body {
     transition: var(--theme-transition);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    overflow-x: hidden;
 }
 
 /* Fluid typography */

--- a/index.njk
+++ b/index.njk
@@ -401,14 +401,16 @@ hideSearch: false
   }
   .swiper-button-next, .swiper-button-prev {
     color: var(--primary-color);
-    --swiper-navigation-size: 30px; /* Adjust size of nav arrows */
-    top: 42%; /* Adjust vertical position - try 40-45% range */
+    --swiper-navigation-size: 30px;
+    --swiper-navigation-sides-offset: 0px;
+    top: 50%;
+    transform: translateY(-50%);
   }
   .swiper-button-prev {
-    left: -15px; /* Adjust to move further left */
+    left: -20px !important;
   }
   .swiper-button-next {
-    right: -15px; /* Adjust to move further right */
+    right: -20px !important;
   }
   .swiper-button-next:after, .swiper-button-prev:after {
     font-size: var(--swiper-navigation-size);


### PR DESCRIPTION
## Summary
- Add `overflow-x: hidden` to `body` to prevent horizontal scrollbar caused by swiper nav buttons and peek cards extending beyond the viewport
- Center nav arrows vertically on cards (`top: 50%` + `translateY(-50%)`)
- Position arrows overlapping card edges at `-20px` with `!important` to override Swiper library defaults

Closes #123

## Test plan
- [ ] Open home page — no horizontal scrollbar should appear
- [ ] Faded peek cards still visible beyond left/right arrows
- [ ] Nav arrows are vertically centered on cards and overlap card edges
- [ ] Test at narrow viewport widths (mobile) — no horizontal overflow
- [ ] Swiper navigation still functions correctly (click prev/next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)