### PR TITLE
Add tugboat-cli skill

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -43,7 +43,7 @@ module.exports = function(eleventyConfig) {
   const contentTypes = ['prompts', 'rules', 'project-configs', 'workflow-states', 'resources', 'agents', 'skills'];
 
   // Copy skill resource directories (scripts, configs, templates)
-  const skillResourceExtensions = ['sh', 'yml', 'yaml', 'json', 'py', 'rb', 'js', 'txt', 'cfg', 'conf', 'toml'];
+  const skillResourceExtensions = ['sh', 'yml', 'yaml', 'json', 'py', 'rb', 'js', 'txt', 'cfg', 'conf', 'toml', 'md'];
   disciplines.forEach(discipline => {
     skillResourceExtensions.forEach(ext => {
       eleventyConfig.addPassthroughCopy(`${discipline}/skills/**/*.${ext}`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Resources are automatically:
 - Discovered and displayed on the skill's page with download links
 - Served as static files (no processing)
 
-Supported resource file types: `.sh`, `.yml`, `.yaml`, `.json`, `.py`, `.rb`, `.js`, `.txt`, `.cfg`, `.conf`, `.toml`.
+Supported resource file types: `.sh`, `.yml`, `.yaml`, `.json`, `.py`, `.rb`, `.js`, `.txt`, `.cfg`, `.conf`, `.toml`, `.md`.
 
 ## Key Configuration Files
 

--- a/development/skills/tugboat-cli.md
+++ b/development/skills/tugboat-cli.md
@@ -1,0 +1,167 @@
+---
+title: "Tugboat CLI"
+description: "Manage Tugboat preview environments via the tugboat CLI. Create, list, rebuild, refresh, debug, and administer Tugboat previews, services, and repositories. Includes config file guidance, lifecycle phases, and CLI command reference."
+date: "2026-04-14"
+layout: "markdown.njk"
+discipline: "development"
+contentType: "skills"
+tags:
+  - tugboat
+  - preview-environments
+  - devops
+  - qa
+  - cli
+---
+
+`````
+---
+name: tugboat-cli
+description: This skill should be used when managing Tugboat preview environments via the tugboat CLI. It applies when creating, listing, rebuilding, refreshing, debugging, or administering Tugboat previews, services, and repositories. Triggers on tugboat commands, preview environment management, .tugboat/config.yml editing, and Tugboat QA workflow questions.
+---
+
+# Tugboat CLI
+
+## Overview
+
+Tugboat is a preview environment service (tugboatqa.com) that builds fully functional website previews for branches, tags, commits, and pull requests. This skill provides guidance for using the `tugboat` CLI to manage previews, services, repositories, and related resources.
+
+## Prerequisites
+
+- The `tugboat` CLI must be installed (`brew install tugboatqa/tugboat/tugboat-cli` on macOS)
+- An API access token must be configured (generated at https://dashboard.tugboatqa.com/access-tokens)
+- Token is stored in `~/.tugboat.yml` after first use, or passed via `-t` flag or `TUGBOAT_API_TOKEN` env var
+
+## Quick Start
+
+To list available projects and repos:
+```bash
+tugboat ls projects
+tugboat ls repos
+```
+
+To create a preview from a branch:
+```bash
+tugboat ls repos                                    # Find the repo ID
+tugboat create preview <branch> repo=<repo-id>      # Create preview
+```
+
+To check preview status and open it:
+```bash
+tugboat ls previews repo=<repo-id>
+tugboat ls <preview-id> -b                          # Open in browser
+```
+
+## Common Workflows
+
+### Creating and Managing Previews
+
+```bash
+# Create a preview from a branch or PR
+tugboat create preview <ref> repo=<repo-id>
+tugboat create preview <ref> repo=<repo-id> type=pullrequest
+tugboat create preview <ref> repo=<repo-id> base=false    # Skip base preview
+
+# Preview lifecycle
+tugboat refresh <preview-id>     # Pull latest code, run update+build
+tugboat rebuild <preview-id>     # Full rebuild from scratch
+tugboat reset <preview-id>       # Revert to post-build snapshot
+tugboat redeploy <preview-id>    # Redeploy code
+
+# State management
+tugboat start <preview-id>
+tugboat stop <preview-id>
+tugboat suspend <preview-id>     # Save resources
+tugboat cancel <preview-id>      # Cancel active build
+tugboat delete <preview-id>      # Delete (add -f to skip confirmation)
+```
+
+### Base Previews (Speed Up Builds)
+
+Base previews are snapshots that child previews clone from instead of building from scratch.
+
+```bash
+# Create and anchor a base preview
+tugboat create preview main repo=<repo-id> anchor=true
+
+# Or anchor an existing preview
+tugboat update <preview-id> anchor=true
+
+# List base previews
+tugboat ls previews repo=<repo-id> anchor=true
+
+# Rebuild base to keep it fresh
+tugboat rebuild <base-preview-id>
+```
+
+### Debugging Previews
+
+```bash
+# Check build logs
+tugboat log <preview-id>
+tugboat log <preview-id> -a              # Attach and follow
+
+# List services to find service IDs
+tugboat ls services preview=<preview-id>
+
+# Shell into a preview or service
+tugboat shell <preview-id>               # Default service
+tugboat shell <service-id>               # Specific service
+tugboat shell <id> command="drush status"  # Run a command
+
+# View service output
+tugboat output <service-id>
+```
+
+### Listing and Filtering Resources
+
+```bash
+# Projects, repos, previews
+tugboat ls projects
+tugboat ls repos
+tugboat ls previews repo=<repo-id>
+
+# Services, screenshots, visual diffs
+tugboat ls services preview=<preview-id>
+tugboat ls screenshots service=<service-id>
+tugboat ls visualdiffs preview=<preview-id>
+
+# Git info from repos
+tugboat ls branches <repo-id>
+tugboat ls pulls <repo-id>
+tugboat ls pulls <repo-id> state=all     # Include closed PRs
+tugboat ls tags <repo-id>
+```
+
+### JSON Output for Scripting
+
+Append `-j` or `--json` to any command for JSON output. Combine with `-q` for just IDs.
+
+```bash
+tugboat ls previews repo=<repo-id> -j
+tugboat create preview main repo=<repo-id> -q    # Returns just the preview ID
+```
+
+### Config Validation
+
+Validate a `.tugboat/config.yml` before committing:
+```bash
+tugboat validate .tugboat/config.yml
+tugboat validate <repo-id>              # Validate against a repo
+tugboat validate <repo-id> <git-ref>    # Validate a specific ref
+```
+
+## Config File (.tugboat/config.yml)
+
+The `.tugboat/config.yml` file in a repository defines the Docker services and lifecycle commands for previews. For the full configuration schema including service properties, lifecycle phases (init, update, build, ready, online, start, clone), and environment variables, read `references/cli_reference.md`.
+
+Key concepts:
+- **Services** are Docker containers (e.g., apache, mysql, redis)
+- The `default: true` service receives the preview URL
+- The `checkout: true` service gets the git clone
+- **Lifecycle phases** run commands at different stages (init for fresh builds, update for data imports, build for every build)
+- Services can depend on each other via `depends`
+
+## Reference
+
+For the complete command reference, configuration schema, environment variables, and API details, load `references/cli_reference.md`.
+`````

--- a/development/skills/tugboat-cli/references/cli_reference.md
+++ b/development/skills/tugboat-cli/references/cli_reference.md
@@ -1,0 +1,247 @@
+# Tugboat CLI Command Reference
+
+## Global Options
+
+| Flag | Description |
+|------|-------------|
+| `-V`, `--version` | Output the version number |
+| `-u`, `--api-url <url>` | The URL to the Tugboat API. Default: `https://api.tugboatqa.com` |
+| `-p`, `--proxy <url>` | HTTP/HTTPS proxy URL for API connections |
+| `-t`, `--api-token <token>` | Access token for the Tugboat API |
+| `-k`, `--no-check-certificate` | Skip API certificate verification |
+| `-q`, `--quiet` | No output, just return object ID or status code |
+| `-v`, `--verbose` | Verbose output (ignored if `--quiet`) |
+| `-j`, `--json` | Raw JSON output (ignored if `--quiet` or `--verbose`) |
+| `-w`, `--write [path]` | Write output to file (overrides `--quiet`, `--verbose`, `--json`) |
+| `--debug` | Debug output (not applied if `--quiet`) |
+| `-f`, `--force` | Force an operation to execute |
+| `--no-color` | Disable color output |
+| `-b`, `--browser [browser]` | Open preview URL in default browser |
+| `--tree` | Show output in a tree |
+
+## Commands
+
+### list|ls
+
+List or show details of Tugboat resources.
+
+```bash
+tugboat ls <resource-type>           # List all of a resource type
+tugboat ls <id>                      # Show details of a specific resource
+tugboat ls previews repo=<repo-id>   # Filter previews by repo
+tugboat ls services preview=<id>     # List services in a preview
+tugboat ls pulls <repo-id>           # List pull requests for a repo
+tugboat ls jobs <resource-id>        # List jobs for a resource
+tugboat ls branches <repo-id>        # List branches for a repo
+tugboat ls keys                      # List API keys
+tugboat ls mail                      # List captured mail
+tugboat ls projects                  # List all projects
+tugboat ls repos                     # List all repositories
+```
+
+Listable resource types: `agents`, `keys`, `lighthouse`, `mail`, `previews`, `projects`, `repos`, `screenshots`, `services`, `visualdiffs`
+
+Filter arguments per resource type:
+- **previews**: `preview`, `repo`, `project`, `anchor`
+- **services**: `service`, `preview`, `repo`, `project`
+- **repos**: `repo`, `project`
+- **screenshots**: `screenshot`, `service`, `preview`, `repo`, `project`, `data`, `crop`, `scale`
+- **visualdiffs**: `visualdiff`, `screenshot`, `service`, `preview`, `repo`, `project`, `data`, `crop`, `scale`
+- **pulls**: `state` (GitHub: open/closed/all; GitLab: opened/closed/merged; Bitbucket: OPEN/DECLINED/MERGED/ALL)
+
+### create
+
+Create Tugboat resources.
+
+```bash
+# Create a preview
+tugboat create preview <ref> repo=<repo-id>
+tugboat create preview main repo=<repo-id> anchor=true
+tugboat create preview feature-branch repo=<repo-id> base=false
+tugboat create preview pr-123 repo=<repo-id> type=pullrequest
+tugboat create preview main repo=<repo-id> expires=2024-12-31 name="My Preview"
+
+# Create other resources
+tugboat create key <name>
+tugboat create lighthouse <service-id> [url=/path] [screen=desktop|mobile]
+tugboat create screenshot <service-id> [url=/path] [screen=desktop|tablet|mobile]
+tugboat create visualdiff <screenshot-id> base=<base-screenshot-id>
+tugboat create repo <name> project=<project-id>
+tugboat create registry <repo-id> username=<user> password=<pass>
+```
+
+Preview create arguments:
+- `repo=<id>` (required) - Repository to build from
+- `type=branch|tag|commit|pullrequest|mergerequest` - Ref type disambiguation
+- `base=<id>|false` - Base preview to clone from, or `false` to skip
+- `name=<string>` - Friendly name
+- `config=<path>` - Local YAML config file override
+- `expires=<date>` - Auto-delete date (ISO 8601)
+- `anchor=true` - Anchor as default base preview
+- `anchor_type=repo|preview` - Anchor scope
+
+### update
+
+Update Tugboat resource properties.
+
+```bash
+tugboat update <id> anchor=true       # Set as base preview
+tugboat update <id> anchor=false      # Remove base preview status
+```
+
+### delete|rm
+
+Delete a Tugboat resource.
+
+```bash
+tugboat delete <id>
+tugboat delete <id> -f                # Force delete without confirmation
+```
+
+### Preview Lifecycle Commands
+
+```bash
+tugboat rebuild <id>                  # Full rebuild (pulls images, runs init+update+build)
+tugboat rebuild <id> base=<new-base>  # Rebuild with different base
+tugboat refresh <id>                  # Pull latest code, run update+build (skip init)
+tugboat redeploy <id>                 # Redeploy code on a preview
+tugboat reset <id>                    # Reset to post-build snapshot
+tugboat reset <id> -f                 # Force reset a stuck preview
+tugboat start <id>                    # Start a stopped/suspended preview
+tugboat stop <id>                     # Stop a running preview
+tugboat suspend <id>                  # Suspend a preview (save resources)
+tugboat cancel <id>                   # Cancel a currently building preview
+tugboat clone <id>                    # Clone a preview
+```
+
+### log
+
+View logs for a preview or service.
+
+```bash
+tugboat log <id>                      # View build logs
+tugboat log <id> -a                   # Attach and watch for new entries
+tugboat log <id> --attach             # Same as -a
+```
+
+### shell
+
+Open a shell session in a preview or service.
+
+```bash
+tugboat shell <id>                    # Interactive shell on default service
+tugboat shell <service-id>            # Shell into specific service
+tugboat shell <id> command="cmd"      # Execute a command
+tugboat shell <id> command='["script.sh", "--opt", "arg"]'  # Array form
+```
+
+### Other Commands
+
+```bash
+tugboat find <id>                     # Find a resource by ID
+tugboat grant <id> <args>             # Grant access to a resource
+tugboat revoke <id> <args>            # Revoke access from a resource
+tugboat rekey <id>                    # Rekey a preview
+tugboat validate <id|filename> [ref]  # Validate a config.yml
+tugboat version                       # Show client/server versions
+tugboat output <service-id>           # View output of a service
+tugboat statistics <id> <item>        # Get historical statistics
+```
+
+## Configuration File (.tugboat/config.yml)
+
+The repository config file defines preview infrastructure.
+
+### Service Properties
+
+```yaml
+services:
+  service-name:
+    image: tugboatqa/httpd:2.4       # Docker image
+    default: true                     # Default service (gets preview URL)
+    checkout: true                    # Clone git repo into this service
+    checkout_path: /var/lib/tugboat   # Where to clone
+    expose: 80                        # Port exposed to Tugboat proxy
+    http: false                       # Allow HTTP
+    https: true                       # Allow HTTPS
+    depends:
+      - mysql                         # Service dependencies
+    aliases:
+      - foo
+      - bar.example.com
+    alias_type: default|domain
+    subpath: false
+    domain: tugboatqa.com
+    urls:
+      - /
+      - /about
+    screenshot:
+      enabled: true
+      fullPage: true
+      timeout: 30
+    visualdiff:
+      enabled: true
+      threshold: 0
+    lighthouse:
+      enabled: true
+      screen:
+        - desktop
+        - mobile
+    environment:
+      VAR_NAME: value
+    commands:
+      init: []      # Fresh builds only - install packages
+      update: []    # Fresh builds + refreshes - import data
+      build: []     # Every build/refresh/rebuild - compile, clear caches
+      ready: []     # After build - health checks
+      online: []    # After preview is live - one-time tasks
+      start: []     # Every time preview starts - start daemons
+      clone: []     # When cloning from base - adjust settings
+```
+
+### Lifecycle Phases
+
+| Phase | Runs when | Purpose |
+|-------|-----------|---------|
+| `init` | Fresh builds only | Install packages, configure infrastructure |
+| `update` | Fresh builds + refreshes | Import databases, assets |
+| `build` | Every build/refresh/rebuild | Compile code, run DB updates, clear caches |
+| `ready` | After build completes | Health checks (e.g., wait for TCP port) |
+| `online` | After preview is live | One-time post-launch tasks |
+| `start` | Every time preview starts | Start daemons, background processes |
+| `clone` | Cloning from base preview | Adjust cloned preview settings |
+
+## Environment Variables (Inside Preview Containers)
+
+| Variable | Description |
+|----------|-------------|
+| `$TUGBOAT_PREVIEW_ID` | Current preview ID |
+| `$TUGBOAT_PREVIEW` | Preview ref name (e.g., `pr381`) |
+| `$TUGBOAT_PREVIEW_SHA` | Git SHA used for the build |
+| `$TUGBOAT_REPO` | Repository name |
+| `$TUGBOAT_REPO_ID` | Repository ID |
+| `$TUGBOAT_SERVICE` | Current service name |
+| `$TUGBOAT_SERVICE_ID` | Current service ID |
+| `$TUGBOAT_ROOT` | Git clone location (`/var/lib/tugboat`) |
+| `$TUGBOAT_DEFAULT_SERVICE_URL` | Full URL of default service |
+| `$TUGBOAT_DEFAULT_SERVICE_URL_HOST` | Hostname of default service |
+| `$TUGBOAT_DEFAULT_SERVICE_URL_PROTOCOL` | Protocol (http/https) |
+| `$TUGBOAT_DEFAULT_SERVICE_TOKEN` | Auth token for service |
+| `$TUGBOAT_SMTP` | SMTP server for email capture |
+| `$TUGBOAT_PROJECT_ID` | Project ID |
+| `$TUGBOAT_GITHUB_OWNER` | GitHub repo owner |
+| `$TUGBOAT_GITHUB_REPO` | GitHub repo name |
+| `$TUGBOAT_GITHUB_PR` | GitHub PR number |
+| `$DOCROOT` | Web document root path |
+
+## Authentication
+
+### Access Token Setup
+1. Generate at https://dashboard.tugboatqa.com/access-tokens
+2. Configure via: first run prompt, `~/.tugboat.yml`, `-t` flag, or `TUGBOAT_API_TOKEN` env var
+
+### Config File (~/.tugboat.yml)
+Stores the API token after first configuration.
+
+## API Reference
+Full API docs: https://api.tugboatqa.com/v3


### PR DESCRIPTION
## Summary
- Adds a new `tugboat-cli` skill for managing Tugboat preview environments via the CLI
- Includes a companion CLI reference document in `development/skills/tugboat-cli/references/`
- Covers creating, listing, rebuilding, refreshing, debugging, and administering Tugboat previews, services, and repositories

## Test plan
- [ ] Verify the skill page renders correctly at `/development/skills/tugboat-cli/`
- [ ] Confirm the CLI reference resource file is linked and downloadable
- [ ] Check Tugboat preview environment for visual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)