### PR TITLE
Add versioning capabilities to all content types

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -258,12 +258,14 @@ module.exports = function(eleventyConfig) {
   });
 
   // Filter to check if an item was updated within the last 30 days
+  // Uses UTC for both dates to avoid timezone off-by-one issues
   eleventyConfig.addNunjucksFilter("isRecentlyUpdated", function(item) {
     if (!item || !item.data || !item.data.lastUpdated) return false;
-    const updated = new Date(item.data.lastUpdated);
-    const thirtyDaysAgo = new Date();
-    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
-    return updated > thirtyDaysAgo;
+    const parts = String(item.data.lastUpdated).split('-').map(Number);
+    const updatedUtc = Date.UTC(parts[0], parts[1] - 1, parts[2]);
+    const now = new Date();
+    const thirtyDaysAgoUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - 30);
+    return updatedUtc > thirtyDaysAgoUtc;
   });
 
   // After build: copy raw markdown for skill files as SKILL.md

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const matter = require('gray-matter');
 
 module.exports = function(eleventyConfig) {
   // Copy static assets
@@ -125,7 +126,9 @@ module.exports = function(eleventyConfig) {
         discipline: item.data.discipline || '',
         contentType: item.data.contentType || '',
         tags: item.data.tags || [],
-        date: item.data.date || new Date().toISOString()
+        date: item.data.date || new Date().toISOString(),
+        version: item.data.version || '',
+        lastUpdated: item.data.lastUpdated || ''
       });
     }
 
@@ -188,6 +191,61 @@ module.exports = function(eleventyConfig) {
       ));
     });
     return all.sort((a, b) => new Date(b.date) - new Date(a.date));
+  });
+
+  // Version validation: warn on invalid semver or incomplete version metadata
+  const semverRegex = /^\d+\.\d+\.\d+$/;
+  eleventyConfig.on('eleventy.before', async () => {
+    for (const discipline of disciplines) {
+      for (const type of contentTypes) {
+        const dir = path.join(__dirname, discipline, type);
+        if (!fs.existsSync(dir)) continue;
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') && f !== 'index.md');
+        for (const file of files) {
+          const filePath = path.join(dir, file);
+          const content = fs.readFileSync(filePath, 'utf8');
+          const { data } = matter(content);
+          if (data.version && !semverRegex.test(String(data.version))) {
+            console.warn(`[VERSION] Invalid semver in ${discipline}/${type}/${file}: "${data.version}"`);
+          }
+          if (data.version && !data.lastUpdated) {
+            console.warn(`[VERSION] ${discipline}/${type}/${file} has version but no lastUpdated`);
+          }
+          if (data.changelog && Array.isArray(data.changelog)) {
+            data.changelog.forEach((entry, i) => {
+              if (!entry.version || !entry.date || !entry.summary) {
+                console.warn(`[VERSION] Incomplete changelog entry #${i + 1} in ${discipline}/${type}/${file}`);
+              }
+              if (entry.version && !semverRegex.test(String(entry.version))) {
+                console.warn(`[VERSION] Invalid semver in changelog entry #${i + 1} of ${discipline}/${type}/${file}: "${entry.version}"`);
+              }
+            });
+          }
+        }
+      }
+    }
+  });
+
+  // Add a collection for recently updated content (items with lastUpdated, sorted desc)
+  eleventyConfig.addCollection('recentlyUpdated', function(collection) {
+    let all = [];
+    contentTypes.forEach(type => {
+      all = all.concat(collection.getFilteredByGlob(
+        disciplines.map(discipline => `${discipline}/${type}/**/*.md`)
+      ));
+    });
+    return all
+      .filter(item => item.data.lastUpdated)
+      .sort((a, b) => new Date(b.data.lastUpdated) - new Date(a.data.lastUpdated));
+  });
+
+  // Filter to check if an item was updated within the last 30 days
+  eleventyConfig.addNunjucksFilter("isRecentlyUpdated", function(item) {
+    if (!item || !item.data || !item.data.lastUpdated) return false;
+    const updated = new Date(item.data.lastUpdated);
+    const thirtyDaysAgo = new Date();
+    thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+    return updated > thirtyDaysAgo;
   });
 
   // After build: copy raw markdown for skill files as SKILL.md

--- a/.github/ISSUE_TEMPLATE/agent-submission.yml
+++ b/.github/ISSUE_TEMPLATE/agent-submission.yml
@@ -70,6 +70,15 @@ body:
     validations:
       required: false
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/project-config-submission.yml
+++ b/.github/ISSUE_TEMPLATE/project-config-submission.yml
@@ -45,6 +45,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/prompt-submission.yml
+++ b/.github/ISSUE_TEMPLATE/prompt-submission.yml
@@ -66,6 +66,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/resource-submission.yml
+++ b/.github/ISSUE_TEMPLATE/resource-submission.yml
@@ -84,4 +84,12 @@ body:
         - Design
         - Sales & Marketing
     validations:
-      required: true 
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/rule-submission.yml
+++ b/.github/ISSUE_TEMPLATE/rule-submission.yml
@@ -45,6 +45,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/skill-submission.yml
+++ b/.github/ISSUE_TEMPLATE/skill-submission.yml
@@ -95,6 +95,15 @@ body:
     validations:
       required: false
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/workflow-state-submission.yml
+++ b/.github/ISSUE_TEMPLATE/workflow-state-submission.yml
@@ -45,6 +45,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Semantic version for this contribution (e.g., 1.0.0). Leave blank for initial submissions."
+      placeholder: "1.0.0"
+    validations:
+      required: false
+
   - type: markdown
     attributes:
       value: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,13 @@ contentType: "<matching-immediate-parent>"
 tags:
   - relevant
   - tags
+# Optional versioning fields:
+version: "1.0.0"           # Semantic version (MAJOR.MINOR.PATCH)
+lastUpdated: "YYYY-MM-DD"  # Date of last substantive change
+changelog:                  # Version history, ordered newest-first
+  - version: "1.0.0"
+    date: "YYYY-MM-DD"
+    summary: "Description of changes"
 ---
 ```
 
@@ -74,6 +81,18 @@ Resources are automatically:
 - Served as static files (no processing)
 
 Supported resource file types: `.sh`, `.yml`, `.yaml`, `.json`, `.py`, `.rb`, `.js`, `.txt`, `.cfg`, `.conf`, `.toml`.
+
+### Versioning
+
+All content types support optional version tracking via frontmatter fields:
+
+- **`version`**: Semantic version string (`MAJOR.MINOR.PATCH`, e.g., `"1.2.0"`). Build warns if format is invalid.
+- **`lastUpdated`**: Date of the most recent substantive change, distinct from `date` (creation date). Build warns if `version` is set but `lastUpdated` is missing.
+- **`changelog`**: Array of version history entries, each with `version`, `date`, and `summary`. Ordered newest-first by convention.
+
+All fields are optional. Existing content without versioning builds and renders normally. The build emits `console.warn` for validation issues but never fails.
+
+Content pages display a version badge and "Updated" date when present, plus a collapsible changelog section. Collection listings show an "Updated" badge for items with `lastUpdated` within the last 30 days.
 
 ## Key Configuration Files
 

--- a/_data/search-index.js
+++ b/_data/search-index.js
@@ -53,7 +53,9 @@ function createSearchIndex() {
         discipline: data.discipline || dir,
         contentType: data.contentType || '',
         tags: data.tags || [],
-        date: data.date || new Date().toISOString()
+        date: data.date || new Date().toISOString(),
+        version: data.version || '',
+        lastUpdated: data.lastUpdated || ''
       });
     }
   }

--- a/_layouts/content-type.njk
+++ b/_layouts/content-type.njk
@@ -10,7 +10,11 @@ layout: discipline.njk
 <div class="content-list">
     {% for item in collections[contentType] | filterByDiscipline(discipline) %}
         <article class="content-item fade-up">
-            <h2><a href="{{ item.url }}">{{ item.data.title }}</a></h2>
+            <h2>
+                <a href="{{ item.url }}">{{ item.data.title }}</a>
+                {% if item | isRecentlyUpdated %}<span class="updated-badge">Updated</span>{% endif %}
+                {% if item.data.version %}<span class="version-tag">v{{ item.data.version }}</span>{% endif %}
+            </h2>
             <p>{{ item.data.description }}</p>
             <div class="metadata">
                 <span class="date">{{ item.date | date("yyyy-MM-dd") }}</span>
@@ -24,4 +28,33 @@ layout: discipline.njk
             </div>
         </article>
     {% endfor %}
-</div> 
+</div>
+
+<style>
+  .updated-badge {
+    display: inline-block;
+    background-color: var(--accent-color);
+    color: #12212b;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    vertical-align: middle;
+    margin-left: 0.5rem;
+  }
+
+  .version-tag {
+    display: inline-block;
+    background-color: var(--tag-background);
+    color: var(--text-muted);
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    font-size: 0.7rem;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    vertical-align: middle;
+    margin-left: 0.25rem;
+  }
+</style>

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -114,6 +114,7 @@ layout: base.njk
     gap: 0.75rem;
     flex-shrink: 0;
     white-space: nowrap;
+    margin-left: auto;
   }
 
   .tag {

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -17,13 +17,13 @@ layout: base.njk
       <span class="version-badge">v{{ version }}</span>
     {% endif %}
     {% if lastUpdated %}
-      <span class="last-updated">Updated {{ lastUpdated | date }}</span>
+      <span class="last-updated">Updated {{ lastUpdated }}</span>
     {% endif %}
   </div>
 
   {% if changelog and changelog.length > 0 %}
   <details class="changelog-section">
-    <summary>Changelog ({{ changelog.length }} {{ "version" if changelog.length === 1 else "versions" }})</summary>
+    <summary>Changelog ({{ changelog.length }} {{ "version" if changelog.length == 1 else "versions" }})</summary>
     <ul class="changelog-list">
       {% for entry in changelog %}
         <li class="changelog-entry">

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -13,7 +13,28 @@ layout: base.njk
       {% endfor %}
     </div>
     <time datetime="{{ date }}">{{ date | date }}</time>
+    {% if version %}
+      <span class="version-badge">v{{ version }}</span>
+    {% endif %}
+    {% if lastUpdated %}
+      <span class="last-updated">Updated {{ lastUpdated | date }}</span>
+    {% endif %}
   </div>
+
+  {% if changelog and changelog.length > 0 %}
+  <details class="changelog-section">
+    <summary>Changelog ({{ changelog.length }} {{ "version" if changelog.length === 1 else "versions" }})</summary>
+    <ul class="changelog-list">
+      {% for entry in changelog %}
+        <li class="changelog-entry">
+          <strong class="changelog-version">v{{ entry.version }}</strong>
+          <time class="changelog-date" datetime="{{ entry.date }}">{{ entry.date | date }}</time>
+          <span class="changelog-summary">{{ entry.summary }}</span>
+        </li>
+      {% endfor %}
+    </ul>
+  </details>
+  {% endif %}
 
   {% set resources = page | getSkillResources %}
   {% if resources.length > 0 %}
@@ -80,6 +101,72 @@ layout: base.njk
     padding: 0.25rem 0.5rem;
     border-radius: 0.25rem;
     font-size: 0.875rem;
+  }
+
+  .version-badge {
+    background-color: var(--accent-color);
+    color: #12212b;
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.25rem;
+    font-size: 0.8rem;
+    font-family: var(--font-mono);
+    font-weight: 600;
+  }
+
+  .last-updated {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+  }
+
+  .changelog-section {
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 0;
+  }
+
+  .changelog-section summary {
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-color);
+    font-size: 0.95rem;
+  }
+
+  .changelog-section summary:hover {
+    color: var(--primary-color);
+  }
+
+  .changelog-list {
+    list-style: none;
+    margin: 0;
+    padding: 0 1rem 0.75rem;
+  }
+
+  .changelog-entry {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.4rem 0;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.875rem;
+  }
+
+  .changelog-version {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    white-space: nowrap;
+    color: var(--accent-color);
+  }
+
+  .changelog-date {
+    color: var(--text-muted);
+    white-space: nowrap;
+    font-size: 0.8rem;
+  }
+
+  .changelog-summary {
+    color: var(--text-color);
   }
 
   .content {

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -13,12 +13,13 @@ layout: base.njk
       {% endfor %}
     </div>
     <div class="metadata-right">
-      <time datetime="{{ date }}">{{ date | date }}</time>
       {% if version %}
         <span class="version-badge">v{{ version }}</span>
       {% endif %}
       {% if lastUpdated %}
         <span class="last-updated">Updated {{ lastUpdated }}</span>
+      {% elif not version %}
+        <time datetime="{{ date }}">{{ date | date }}</time>
       {% endif %}
     </div>
   </div>

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -12,13 +12,15 @@ layout: base.njk
         <span class="tag">{{ tag }}</span>
       {% endfor %}
     </div>
-    <time datetime="{{ date }}">{{ date | date }}</time>
-    {% if version %}
-      <span class="version-badge">v{{ version }}</span>
-    {% endif %}
-    {% if lastUpdated %}
-      <span class="last-updated">Updated {{ lastUpdated }}</span>
-    {% endif %}
+    <div class="metadata-right">
+      <time datetime="{{ date }}">{{ date | date }}</time>
+      {% if version %}
+        <span class="version-badge">v{{ version }}</span>
+      {% endif %}
+      {% if lastUpdated %}
+        <span class="last-updated">Updated {{ lastUpdated }}</span>
+      {% endif %}
+    </div>
   </div>
 
   {% if changelog and changelog.length > 0 %}
@@ -93,14 +95,25 @@ layout: base.njk
   .metadata {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 1rem;
     margin-bottom: 2rem;
     color: var(--text-muted);
+    flex-wrap: wrap;
   }
 
   .tags {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
+  }
+
+  .metadata-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .tag {

--- a/development/skills/gws-cli.md
+++ b/development/skills/gws-cli.md
@@ -5,6 +5,15 @@ date: "2026-03-23"
 layout: "markdown.njk"
 discipline: "development"
 contentType: "skills"
+version: "1.1.0"
+lastUpdated: "2026-04-14"
+changelog:
+  - version: "1.1.0"
+    date: "2026-04-14"
+    summary: "Add Gmail +send --draft helper for saving messages as drafts instead of sending"
+  - version: "1.0.0"
+    date: "2026-03-23"
+    summary: "Initial version"
 tags:
   - google-workspace
   - gmail
@@ -78,6 +87,11 @@ gws gmail +send --to alice@example.com --subject 'Hello' --body 'Hi Alice!'
 gws gmail +send --to alice@example.com --subject 'Report' --body 'See attached' -a report.pdf
 gws gmail +send --to alice@example.com --subject 'Hello' --body '<b>Bold</b>' --html
 gws gmail +send --to a@ex.com --subject 'Hi' --cc b@ex.com --bcc c@ex.com --body 'Hello'
+```
+
+**Save as draft (instead of sending):**
+```bash
+gws gmail +send --to alice@example.com --subject 'Hello' --body 'Hi Alice!' --draft
 ```
 
 **Triage inbox (read-only):**

--- a/index.njk
+++ b/index.njk
@@ -25,6 +25,12 @@ hideSearch: false
                 {% if item.data.discipline %}
                   <span class="recent-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
                 {% endif %}
+                {% if item.data.version %}
+                  <span class="recent-version">v{{ item.data.version }}</span>
+                {% endif %}
+                {% if item | isRecentlyUpdated %}
+                  <span class="recent-updated">Updated</span>
+                {% endif %}
               </div>
               <p class="recent-desc">{{ item.data.description }}</p>
             </article>
@@ -362,12 +368,24 @@ hideSearch: false
     gap: 1rem;
     flex-wrap: wrap;
   }
-  .recent-type, .recent-discipline, .recent-date {
+  .recent-type, .recent-discipline, .recent-date, .recent-version, .recent-updated {
     background: var(--tag-background);
     border-radius: 0.25rem;
     padding: 0.1rem 0.5rem;
     margin-right: 0.25rem;
     font-weight: 500;
+  }
+  .recent-version {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+  }
+  .recent-updated {
+    background-color: var(--accent-color);
+    color: #12212b;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.02em;
   }
   .recent-desc {
     color: var(--text-color);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "archiver": "^7.0.1"
+        "archiver": "^7.0.1",
+        "gray-matter": "^4.0.3"
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0"
@@ -972,7 +973,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -1033,7 +1033,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extendable": "^0.1.0"
@@ -1216,7 +1215,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^3.13.1",
@@ -1232,7 +1230,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -1242,7 +1239,6 @@
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
       "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -1392,7 +1388,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1523,7 +1518,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -2087,7 +2081,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
       "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "extend-shallow": "^2.0.1",
@@ -2204,7 +2197,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/ssri": {
@@ -2350,7 +2342,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
       "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@11ty/eleventy": "^3.0.0"
   },
   "dependencies": {
-    "archiver": "^7.0.1"
+    "archiver": "^7.0.1",
+    "gray-matter": "^4.0.3"
   }
 }


### PR DESCRIPTION
## Summary

- Add optional `version`, `lastUpdated`, and `changelog` frontmatter fields to all content types
- Build-time semver validation (warns but never fails) via `eleventy.before` event
- Version badge and "Updated" date on content pages, collapsible changelog section
- "Updated" badge and version tag on collection listing cards and homepage carousel
- `recentlyUpdated` collection and `isRecentlyUpdated` filter (30-day window)
- Search index now includes `version` and `lastUpdated` fields
- All 7 issue templates updated with optional version input
- CLAUDE.md documented with versioning conventions

## Files changed (13)

| File | Changes |
|------|---------|
| `.eleventy.js` | Validation, collection, filter, search index |
| `_data/search-index.js` | version/lastUpdated in index entries |
| `_layouts/markdown.njk` | Version badge, changelog, CSS |
| `_layouts/content-type.njk` | Updated/version badges on cards |
| `index.njk` | Badges in Recently Added carousel |
| 7 issue templates | Optional version input field |
| `CLAUDE.md` | Versioning documentation |

## Test plan

- [ ] `npm run build` succeeds with no versioned content (backward compat)
- [ ] Add a test content file with `version`, `lastUpdated`, `changelog` — verify badge, date, and collapsible changelog render
- [ ] Add a file with `version: "abc"` — verify `[VERSION]` warning in build output
- [ ] Verify "Updated" badge appears only for items with `lastUpdated` within 30 days
- [ ] Check both light and dark themes
- [ ] Inspect `_site/search-index.json` for version/lastUpdated fields

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)