### PR TITLE
Add pencil-designer skill

### DIFF
--- a/design/skills/pencil-designer.md
+++ b/design/skills/pencil-designer.md
@@ -223,7 +223,7 @@ Synchronize design variables between Pencil and CSS files bidirectionally.
 ## Best Practices
 
 1. **Save frequently** -- no auto-save yet (Cmd/Ctrl+S)
-2. **Commit `.pen` files to Git** -- they are text-based JSON and diff cleanly
+2. **Commit `.pen` files to Git** -- they are version-control friendly and diff cleanly, but always use MCP tools to read or edit their contents
 3. **Use variables** instead of hardcoded values for colors, spacing, and fonts
 4. **Create components** for repeated UI elements to maintain consistency
 5. **Use descriptive names** for layers and components (e.g., `dashboard-header`, `user-card`)

--- a/design/skills/pencil-designer.md
+++ b/design/skills/pencil-designer.md
@@ -1,0 +1,234 @@
+---
+title: "Pencil Designer"
+description: "Comprehensive guide for working with Pencil design files (.pen), creating and editing designs via Pencil MCP tools, building UI layouts, managing design systems and libraries, and bridging design-to-code workflows. Covers node types, layout properties, styling, components, variables, theming, and best practices."
+date: "2026-04-15"
+layout: "markdown.njk"
+discipline: "design"
+contentType: "skills"
+version: "1.0.0"
+lastUpdated: "2026-04-15"
+changelog:
+  - version: "1.0.0"
+    date: "2026-04-15"
+    summary: "Initial contribution to prompt library"
+tags:
+  - design
+  - pencil
+  - ui-design
+  - design-systems
+  - mcp
+  - prototyping
+  - components
+  - design-to-code
+---
+
+`````
+---
+name: pencil-designer
+description: This skill should be used when working with Pencil design files (.pen), creating or editing designs in the Pencil editor, using Pencil MCP tools, building UI layouts, managing design systems/libraries, or generating code from Pencil designs. Triggers on "pencil", ".pen file", "design in pencil", "create a design", "design library", "pen file", or when Pencil MCP tools are available and design work is requested.
+---
+
+# Pencil Designer
+
+This skill provides comprehensive guidance for working with Pencil -- a vector design tool that integrates directly into development environments. Pencil bridges design and development by operating within IDEs, enabling designers and developers to collaborate using familiar version control workflows.
+
+## When to Use This Skill
+
+- Creating or editing designs in `.pen` files
+- Working with Pencil MCP tools (batch_design, batch_get, etc.)
+- Building UI layouts, screens, dashboards, or components
+- Managing design libraries and design systems
+- Generating code from Pencil designs or importing code into designs
+- Working with design variables and theming
+- Creating reusable components with slots
+
+## Critical Rules
+
+1. **NEVER use Read, Grep, or cat to read `.pen` files** -- contents are encrypted and only accessible via Pencil MCP tools
+2. **Always start with `get_editor_state()`** to understand the current context before making changes
+3. **Use `get_screenshot`** periodically to validate design changes visually
+4. **Limit `batch_design` to ~25 operations per call** to avoid overwhelming the system
+
+## Workflow
+
+### Starting a Design Task
+
+1. Call `get_editor_state()` to check the active `.pen` file and current selection
+2. If no file is open, call `open_document('new')` for a new file or `open_document(path)` for existing
+3. Call `get_guidelines(topic)` for relevant design rules (topics: `code`, `table`, `tailwind`, `landing-page`, `slides`, `design-system`, `mobile-app`, `web-app`)
+4. Call `get_style_guide_tags` then `get_style_guide(tags)` for design inspiration when not using an existing design system
+5. Use `snapshot_layout` to understand existing layout structure before inserting
+
+### Making Design Changes
+
+Use `batch_design(operations)` with this operation syntax:
+
+```
+# Insert new node
+varName=I("parentId", { type: "frame", width: 200, height: 100, fill: "#FF0000" })
+
+# Copy existing node
+copy=C("sourceId", "parentId", { fill: "#00FF00" })
+
+# Replace node(s)
+R("nodeId1/nodeId2", { fill: "#0000FF" })
+
+# Update node (reference variables from prior operations)
+U(varName+"/childId", { text: "Updated text" })
+
+# Delete node
+D("nodeId")
+
+# Move node to new parent at index
+M("nodeId", "newParentId", 2)
+
+# Generate AI image
+G("nodeId", "ai", "A sunset over mountains")
+```
+
+### Discovering Content
+
+- Use `batch_get(patterns)` to search for nodes by pattern
+- Use `batch_get(nodeIds)` to read specific nodes by ID
+- Use `search_all_unique_properties` to audit property values across the tree
+- Use `snapshot_layout` to see computed layout rectangles
+
+### Validating Changes
+
+After making changes, call `get_screenshot` to render a visual preview. Verify:
+- Layout looks correct (alignment, spacing)
+- Colors and typography match intent
+- Components render properly
+- No overlapping or misaligned elements
+
+## Node Types
+
+| Type | Purpose |
+|------|---------|
+| `frame` | Main container with children and layout (flexbox-like) |
+| `rectangle` | Basic rectangle shape |
+| `ellipse` | Circle/ellipse |
+| `text` | Text element |
+| `line` | Line element |
+| `polygon` | Multi-sided polygon |
+| `path` | SVG-like path |
+| `group` | Unstyled grouping container |
+| `ref` | Instance of a reusable component |
+| `icon_font` | Icon from built-in font libraries |
+
+## Layout Properties
+
+Frames support flexbox-like layout:
+
+| Property | Values |
+|----------|--------|
+| `layout` | `"none"`, `"vertical"`, `"horizontal"` |
+| `gap` | number (space between children) |
+| `padding` | number or `{top, right, bottom, left}` |
+| `justifyContent` | `"start"`, `"center"`, `"end"`, `"space_between"`, `"space_around"` |
+| `alignItems` | `"start"`, `"center"`, `"end"` |
+
+Child sizing: use fixed `width`/`height` or `"fit_content"` / `"fill_container"`.
+
+## Styling Properties
+
+### Fill
+- Solid: `{ fill: "#3B82F6" }` or `{ fill: { type: "solid", color: "#3B82F6" } }`
+- Gradient: `{ fill: { type: "linear_gradient", stops: [...], angle: 0 } }`
+- Image: `{ fill: { type: "image", url: "..." } }`
+
+### Stroke
+```json
+{ "stroke": { "fill": "#000", "thickness": 1, "alignment": "inside" } }
+```
+
+### Effects
+```json
+{ "effect": [{ "type": "shadow", "x": 0, "y": 4, "blur": 8, "color": "#00000020" }] }
+```
+
+### Text
+Key properties: `fontSize`, `fontFamily`, `fontWeight`, `fontStyle`, `letterSpacing`, `lineHeight`, `textAlign` ("left"/"center"/"right"/"justify"), `textAlignVertical` ("top"/"middle"/"bottom"), `textGrowth` ("auto"/"fixed-width"/"fixed-width-height").
+
+### Other
+- `opacity`: 0-1
+- `cornerRadius`: number or per-corner object
+- `rotation`: degrees (counter-clockwise)
+- `enabled`: boolean (visibility)
+
+## Components
+
+### Creating Components
+Set `reusable: true` on any node to make it a component origin (magenta bounding box).
+
+### Creating Instances
+Use `ref` type: `{ type: "ref", ref: "componentId", descendants: { "childId": { overrides } } }`
+
+### Slots
+Frames marked with `slot` property become designated drop zones within components. Only empty frames in component origins can be slots.
+
+## Variables and Theming
+
+### Defining Variables
+Variables act as design tokens -- define once, reference everywhere with `$variable-name` syntax.
+
+Types: `color`, `number`, `string`, `boolean`
+
+### Theme Support
+Variables can have theme-conditional values for light/dark mode or other theme axes.
+
+### Managing Variables
+- `get_variables` -- read current tokens and themes
+- `set_variables` -- add or update variables
+- AI can import variables from CSS (`globals.css`) or Figma
+
+## Design Libraries
+
+### Built-in Libraries
+- **Shadcn UI** -- Modern component library
+- **Halo** -- UI design system
+- **Lunaris** -- Design library
+- **Nitro** -- Design framework
+
+### Custom Libraries
+1. Create a `.pen` file with components
+2. Turn it into a library (creates `.lib.pen` suffix -- irreversible)
+3. Import into other `.pen` files via the Libraries panel
+
+### Built-in Icon Libraries
+Material Symbols (Outlined/Rounded/Sharp), Lucide Icons, Feather, Phosphor
+
+## Design-to-Code / Code-to-Design
+
+### Design to Code
+Select elements, open AI chat (Cmd/Ctrl+K), and request code generation. Supports React, Vue, Next.js, Svelte, Tailwind CSS, CSS Modules, and any framework.
+
+### Code to Design
+Keep `.pen` file in the same workspace as code. AI can recreate code components as Pencil designs.
+
+### Variable Sync
+Synchronize design variables between Pencil and CSS files bidirectionally.
+
+## Import/Export
+
+### Import
+- **Figma**: Full files via toolbar import or individual layers via copy/paste (images must be imported separately)
+- **Images**: Drag-and-drop, clipboard paste, or toolbar import (PNG, JPEG, SVG)
+- **Icons**: Built-in libraries or custom SVG
+
+### Export
+- Elements as PNG, JPEG, WEBP, or PDF via properties panel
+- Code generation via AI chat
+
+## Best Practices
+
+1. **Save frequently** -- no auto-save yet (Cmd/Ctrl+S)
+2. **Commit `.pen` files to Git** -- they are text-based JSON and diff cleanly
+3. **Use variables** instead of hardcoded values for colors, spacing, and fonts
+4. **Create components** for repeated UI elements to maintain consistency
+5. **Use descriptive names** for layers and components (e.g., `dashboard-header`, `user-card`)
+6. **Validate visually** with `get_screenshot` after batch operations
+7. **Use `snapshot_layout`** before inserting to understand spatial relationships
+8. **Iterate progressively** -- start broad, then refine details
+9. **Use style guides** via `get_style_guide` when not working with an existing design system
+`````

--- a/design/skills/pencil-designer/references/mcp-tools-guide.md
+++ b/design/skills/pencil-designer/references/mcp-tools-guide.md
@@ -1,0 +1,117 @@
+# Pencil MCP Tools Guide
+
+## Overview
+
+Pencil exposes design tools via the Model Context Protocol (MCP). The MCP server runs locally and allows AI agents to read, modify, and generate designs in `.pen` files programmatically.
+
+**Critical Rule**: The contents of `.pen` files are encrypted and can only be accessed via Pencil MCP tools. NEVER use `Read`, `Grep`, or `cat` to read `.pen` file contents.
+
+## Tool Reference
+
+### get_editor_state()
+**When to use**: At the start of any task to understand the current context.
+**Returns**: Active `.pen` file path, current user selection, and other editor state info.
+
+### open_document(filePathOrNew)
+**When to use**: When no active editor is open.
+- Pass `'new'` to create an empty `.pen` file
+- Pass a file path to open an existing `.pen` file
+
+### get_guidelines(topic)
+**When to use**: Before designing to get rules and best practices.
+**Available topics**: `code`, `table`, `tailwind`, `landing-page`, `slides`, `design-system`, `mobile-app`, `web-app`
+**Important**: Only use topics defined above. Do not invent topics.
+
+### get_style_guide_tags
+**When to use**: After `get_guidelines` for additional design inspiration.
+**Returns**: Available tags to use with `get_style_guide`.
+
+### get_style_guide(tags, name)
+**When to use**: When designing screens, websites, apps, or dashboards without an existing design system.
+**Parameters**: Relevant tags from `get_style_guide_tags` or a specific style guide name.
+
+### batch_get(patterns, nodeIds)
+**When to use**: To discover and understand `.pen` file contents.
+**Capabilities**:
+- Search for matching patterns in the design tree
+- Read specific nodes by ID in batches
+- Explore the design hierarchy
+
+### batch_design(operations)
+**When to use**: To make design changes -- insert, copy, update, replace, move, delete, or generate images.
+**Max operations**: Aim for 25 operations per call maximum.
+
+**Operation syntax** (each line is one operation):
+
+```
+# Insert a new node under parent
+foo=I("parentId", { type: "frame", width: 200, height: 100, fill: "#FF0000" })
+
+# Copy an existing node under a parent with overrides
+baz=C("sourceNodeId", "parentId", { fill: "#00FF00" })
+
+# Replace a node (or multiple with /)
+foo2=R("nodeId1/nodeId2", { fill: "#0000FF" })
+
+# Update a node (use variable + path)
+U(foo+"/childId", { text: "Updated" })
+
+# Delete a node
+D("nodeId")
+
+# Move a node to a new parent at index
+M("nodeId", "newParentId", 2)
+
+# Generate an AI image on a node
+G("nodeId", "ai", "A beautiful sunset over mountains")
+```
+
+**Variable references**: Assign results to variables (e.g., `foo=I(...)`) and reference them in subsequent operations (e.g., `U(foo+"/child", {...})`).
+
+### snapshot_layout
+**When to use**: To examine computed layout rectangles of each node.
+**Purpose**: Understand spatial relationships and decide where to insert new nodes.
+
+### get_screenshot
+**When to use**: To validate design visually after making changes.
+**Returns**: A rendered screenshot of a node.
+**Best practice**: Use periodically to verify changes look correct.
+
+### get_variables / set_variables
+**When to use**: To read or modify design tokens (colors, spacing, fonts, etc.).
+**Capabilities**: Extract variables, update theme values, sync with CSS.
+
+### find_empty_space_on_canvas
+**When to use**: To find available space for placing new design elements.
+**Parameters**: Direction and desired size.
+
+### search_all_unique_properties
+**When to use**: To audit what property values exist across the design.
+**Parameters**: Parent node IDs to search within.
+
+### replace_all_matching_properties
+**When to use**: For bulk property changes across the design tree.
+**Parameters**: Parent node IDs and property match/replace values.
+
+### export_nodes
+**When to use**: To export design elements as images.
+**Formats**: PNG, JPEG, WEBP, PDF.
+
+## Built-in Design Libraries
+
+Four pre-configured libraries available:
+- **Shadcn UI** -- Modern component library
+- **Halo** -- Design system for UI development
+- **Lunaris** -- Design library
+- **Nitro** -- Design framework
+
+Access via the Assets panel in the layers sidebar.
+
+## Built-in Icon Libraries
+
+- Material Symbols (Outlined, Rounded, Sharp)
+- Lucide Icons
+- Feather
+- Phosphor
+
+Import custom SVG icons as standard images.

--- a/design/skills/pencil-designer/references/pen-format-spec.md
+++ b/design/skills/pencil-designer/references/pen-format-spec.md
@@ -2,6 +2,8 @@
 
 ## Core Structure
 
+> **Note:** This specification describes the logical document structure exposed by Pencil's MCP tools. On disk, `.pen` file contents are encrypted and must only be accessed via MCP -- never with `Read`, `Grep`, or `cat`.
+
 The .pen format stores design documents as JSON describing an object tree. Each object requires:
 - **id**: Unique string identifier (no forward slashes allowed)
 - **type**: Object type from supported set

--- a/design/skills/pencil-designer/references/pen-format-spec.md
+++ b/design/skills/pencil-designer/references/pen-format-spec.md
@@ -1,0 +1,193 @@
+# The .pen Format Specification
+
+## Core Structure
+
+The .pen format stores design documents as JSON describing an object tree. Each object requires:
+- **id**: Unique string identifier (no forward slashes allowed)
+- **type**: Object type from supported set
+- **x, y**: Position coordinates on infinite 2D canvas
+- **name** (optional): Display name
+- **context** (optional): Context information
+
+## Document Root Properties
+
+```json
+{
+  "version": "2.9",
+  "themes": {},
+  "imports": [],
+  "variables": [],
+  "children": []
+}
+```
+
+- **version**: Format version
+- **themes**: Theme axis definitions (e.g., light/dark mode)
+- **imports**: References to external .pen files (design libraries)
+- **variables**: Document-wide design tokens
+- **children**: Array of top-level objects
+
+## Supported Object Types
+
+### Shapes
+- `rectangle` - Basic rectangle shape
+- `ellipse` - Circle/ellipse shape
+- `line` - Line element
+- `polygon` - Multi-sided polygon
+- `path` - SVG-like path
+
+### Containers
+- `frame` - Main container, can have children and layout (flexbox-like)
+- `group` - Unstyled container for grouping
+
+### Content
+- `text` - Text element
+- `note` - Annotation note
+- `prompt` - AI prompt element
+- `context` - Context information element
+- `icon_font` - Icon from font libraries
+
+### Special
+- `ref` - Instance of a reusable component
+
+## Layout System
+
+Parent objects control child sizing/positioning via flexbox-style properties:
+
+| Property | Values | Description |
+|----------|--------|-------------|
+| `layout` | `"none"`, `"vertical"`, `"horizontal"` | Layout direction |
+| `gap` | number | Space between children |
+| `padding` | number or `{top, right, bottom, left}` | Inside edge spacing |
+| `justifyContent` | `"start"`, `"center"`, `"end"`, `"space_between"`, `"space_around"` | Main axis alignment |
+| `alignItems` | `"start"`, `"center"`, `"end"` | Cross axis alignment |
+
+### Child Sizing
+
+Children can have fixed `width`/`height` or use **SizingBehavior** values:
+- `"fit_content"` - Size to content
+- `"fill_container"` - Fill available space in parent
+
+## Graphics Properties
+
+### Fill
+Supports multiple fill types:
+- **Solid color**: `{"type": "solid", "color": "#RRGGBB"}` or with alpha `"#RRGGBBAA"`
+- **Linear gradient**: `{"type": "linear_gradient", "stops": [...], "angle": 0}`
+- **Radial gradient**: `{"type": "radial_gradient", "stops": [...]}`
+- **Angular gradient**: `{"type": "angular_gradient", "stops": [...]}`
+- **Image**: `{"type": "image", "url": "..."}`
+- **Mesh gradient**: `{"type": "mesh_gradient", ...}`
+
+### Stroke
+Single stroke with configurable properties:
+- `fill`: Same fill options as above
+- `alignment`: inside, center, outside
+- `thickness`: number
+- `join`: miter, round, bevel
+- `cap`: butt, round, square
+- `dash`: dash pattern array
+
+### Effects
+Multiple effects applied sequentially:
+- `blur` - Gaussian blur
+- `background_blur` - Backdrop blur
+- `shadow` - Drop shadow with x, y, blur, spread, color
+
+### Other Visual Properties
+- `opacity`: 0-1 range
+- `rotation`: Counter-clockwise degrees
+- `blendMode`: normal, darken, multiply, screen, overlay, etc. (15+ modes)
+- `flipX`, `flipY`: Boolean transformations
+- `cornerRadius`: Border radius (number or per-corner object)
+
+## Text Properties
+
+| Property | Values | Description |
+|----------|--------|-------------|
+| `fontSize` | number | Font size |
+| `fontFamily` | string | Font name |
+| `fontWeight` | number/string | Weight (400, 700, "bold", etc.) |
+| `fontStyle` | `"normal"`, `"italic"` | Font style |
+| `letterSpacing` | number | Character spacing |
+| `lineHeight` | number | Line height |
+| `textAlign` | `"left"`, `"center"`, `"right"`, `"justify"` | Horizontal alignment |
+| `textAlignVertical` | `"top"`, `"middle"`, `"bottom"` | Vertical alignment |
+| `underline` | boolean | Underline decoration |
+| `strikethrough` | boolean | Strikethrough decoration |
+| `href` | string | Link URL |
+| `textGrowth` | `"auto"`, `"fixed-width"`, `"fixed-width-height"` | Text box sizing |
+
+## Components and Instances
+
+### Creating Components
+Set `reusable: true` on any object to make it a component (origin). The origin has a magenta bounding box.
+
+### Creating Instances
+Use the `ref` type to create instances:
+```json
+{
+  "type": "ref",
+  "ref": "component-id",
+  "descendants": {
+    "child-id": { "property": "override-value" }
+  }
+}
+```
+
+**Descendants** support:
+- Property overrides (excluding id, type, children)
+- Complete object replacement (when type is present)
+- Children replacement for container/slot patterns
+- Path syntax: `"parent/child"` for nested customization
+
+## Slots
+
+Frames marked with the `slot` property (array of component IDs) indicate designated drop zones within components. Slots:
+- Display diagonal line patterns on canvas
+- Only empty frames within component origins can become slots
+- Can have "suggested slot components" to guide content placement
+
+## Variables and Theming
+
+### Variable Types
+- `boolean`
+- `color` (HEX codes)
+- `number` (spacing, border radii, sizes)
+- `string` (font names)
+
+### Single Value
+```json
+{ "name": "primary", "type": "color", "value": "#3B82F6" }
+```
+
+### Theme-Conditional Values
+```json
+{
+  "name": "background",
+  "type": "color",
+  "value": [
+    { "value": "#FFFFFF", "theme": { "mode": "light" } },
+    { "value": "#1A1A1A", "theme": { "mode": "dark" } }
+  ]
+}
+```
+
+### Theme Definitions
+```json
+{
+  "themes": {
+    "mode": ["light", "dark"]
+  }
+}
+```
+First value in each axis is the default.
+
+### Referencing Variables
+Use `$variable-name` syntax in property values.
+
+## Additional Properties
+
+- `enabled`: Boolean or variable reference -- controls visibility
+- `layoutPosition`: `"auto"` (flow) or `"absolute"` (positioned)
+- `metadata`: Custom type information for the node


### PR DESCRIPTION
## Summary
- Adds the **Pencil Designer** skill to the design discipline, providing comprehensive guidance for working with Pencil design files (.pen) via MCP tools
- Includes two companion reference resources: `.pen` format specification and MCP tools guide
- Covers workflows, node types, layout/styling properties, components, variables/theming, design libraries, and design-to-code patterns

## Test plan
- [ ] Verify the skill page renders at `/design/skills/pencil-designer/`
- [ ] Confirm resource files appear as download links on the skill page
- [ ] Check "Download All Resources (.zip)" button works
- [ ] Validate the skill appears in the Design > Skills collection listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)