### PR TITLE
Add agent usage instructions to all content pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -357,6 +357,12 @@ module.exports = function(eleventyConfig) {
                 };
                 addFiltered(resourceDir, `${slug}/`);
 
+                // Include the SKILL.md so the zip is self-contained
+                const skillMdPath = path.join(destDir, 'SKILL.md');
+                if (fs.existsSync(skillMdPath)) {
+                  archive.file(skillMdPath, { name: `${slug}/SKILL.md` });
+                }
+
                 archive.finalize();
               });
             }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -162,6 +162,12 @@ module.exports = function(eleventyConfig) {
   const baseUrl = process.env.GITHUB_ACTIONS ? "/prompt_library" : "";
   eleventyConfig.addGlobalData("baseUrl", baseUrl);
 
+  // Site origin for building absolute URLs (e.g. for Claude/ChatGPT links)
+  const siteOrigin = process.env.GITHUB_ACTIONS
+    ? "https://lullabot.github.io"
+    : "http://localhost:8080";
+  eleventyConfig.addGlobalData("siteOrigin", siteOrigin);
+
   // Extract content type from URL path (e.g. /development/rules/code-quality/ -> rules)
   eleventyConfig.addFilter("contentTypeFromUrl", function(url) {
     if (!url) return '';

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -169,9 +169,14 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addGlobalData("siteOrigin", siteOrigin);
 
   // Extract content type from URL path (e.g. /development/rules/code-quality/ -> rules)
+  // Strips baseUrl prefix first so it works on GitHub Pages (/prompt_library/...)
   eleventyConfig.addFilter("contentTypeFromUrl", function(url) {
-    if (!url) return '';
-    const parts = url.replace(/^\//, '').split('/');
+    if (!url || typeof url !== 'string') return '';
+    let normalizedUrl = url;
+    if (baseUrl && normalizedUrl.startsWith(baseUrl)) {
+      normalizedUrl = normalizedUrl.slice(baseUrl.length);
+    }
+    const parts = normalizedUrl.replace(/^\//, '').split('/').filter(Boolean);
     return parts.length > 1 ? parts[1] : '';
   });
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -162,6 +162,13 @@ module.exports = function(eleventyConfig) {
   const baseUrl = process.env.GITHUB_ACTIONS ? "/prompt_library" : "";
   eleventyConfig.addGlobalData("baseUrl", baseUrl);
 
+  // Extract content type from URL path (e.g. /development/rules/code-quality/ -> rules)
+  eleventyConfig.addFilter("contentTypeFromUrl", function(url) {
+    if (!url) return '';
+    const parts = url.replace(/^\//, '').split('/');
+    return parts.length > 1 ? parts[1] : '';
+  });
+
   // Add URL filter that includes base URL
   eleventyConfig.addFilter("fullUrl", function(url) {
     if (url.startsWith(baseUrl)) {
@@ -268,70 +275,92 @@ module.exports = function(eleventyConfig) {
     return updatedUtc > thirtyDaysAgoUtc;
   });
 
-  // After build: copy raw markdown for skill files as SKILL.md
-  // and generate zip archives for skill resource directories
+  // Map content types to their raw markdown filename
+  const rawFilenames = {
+    skills: 'SKILL.md',
+    prompts: 'PROMPT.md',
+    rules: 'RULE.md',
+    agents: 'AGENT.md',
+    'project-configs': 'CONFIG.md',
+    'workflow-states': 'WORKFLOW.md',
+    resources: 'RESOURCE.md'
+  };
+
+  // After build: generate raw markdown files for all content types
+  // and zip archives for skill resource directories
   eleventyConfig.on('eleventy.after', async () => {
     const outputDir = path.join(__dirname, '_site');
 
     for (const discipline of disciplines) {
-      const skillsDir = path.join(__dirname, discipline, 'skills');
-      if (!fs.existsSync(skillsDir)) continue;
+      for (const type of contentTypes) {
+        const typeDir = path.join(__dirname, discipline, type);
+        if (!fs.existsSync(typeDir)) continue;
 
-      const entries = fs.readdirSync(skillsDir);
-      for (const entry of entries) {
-        if (!entry.endsWith('.md') || entry === 'index.md') continue;
+        const entries = fs.readdirSync(typeDir);
+        for (const entry of entries) {
+          if (!entry.endsWith('.md') || entry === 'index.md') continue;
 
-        const slug = entry.replace(/\.md$/, '');
-        const srcFile = path.join(skillsDir, entry);
-        const destDir = path.join(outputDir, discipline, 'skills', slug);
+          const slug = entry.replace(/\.md$/, '');
+          const srcFile = path.join(typeDir, entry);
+          const destDir = path.join(outputDir, discipline, type, slug);
+          const rawFilename = rawFilenames[type] || 'RAW.md';
 
-        // Copy raw SKILL.md
-        const raw = fs.readFileSync(srcFile, 'utf8');
-        const match = raw.match(/`{5}\n([\s\S]*?)\n`{5}/);
-        const skillContent = match ? match[1] : raw;
+          // Extract raw content: for skills, use five-backtick extraction;
+          // for all other types, strip frontmatter
+          const raw = fs.readFileSync(srcFile, 'utf8');
+          let content;
+          if (type === 'skills') {
+            const match = raw.match(/`{5}\n([\s\S]*?)\n`{5}/);
+            content = match ? match[1] : matter(raw).content.trim();
+          } else {
+            content = matter(raw).content.trim();
+          }
 
-        fs.mkdirSync(destDir, { recursive: true });
-        fs.writeFileSync(path.join(destDir, 'SKILL.md'), skillContent);
+          fs.mkdirSync(destDir, { recursive: true });
+          fs.writeFileSync(path.join(destDir, rawFilename), content);
 
-        // Generate zip if skill has a companion resource directory
-        const resourceDir = path.join(skillsDir, slug);
-        if (fs.existsSync(resourceDir) && fs.statSync(resourceDir).isDirectory()) {
-          const zipPath = path.join(destDir, `${slug}-resources.zip`);
-          await new Promise((resolve, reject) => {
-            const output = fs.createWriteStream(zipPath);
-            const archive = archiver('zip', { zlib: { level: 9 } });
+          // Generate zip if skill has a companion resource directory
+          if (type === 'skills') {
+            const resourceDir = path.join(typeDir, slug);
+            if (fs.existsSync(resourceDir) && fs.statSync(resourceDir).isDirectory()) {
+              const zipPath = path.join(destDir, `${slug}-resources.zip`);
+              await new Promise((resolve, reject) => {
+                const output = fs.createWriteStream(zipPath);
+                const archive = archiver('zip', { zlib: { level: 9 } });
 
-            output.on('close', resolve);
-            output.on('error', reject);
-            archive.on('warning', (err) => {
-              if (err.code !== 'ENOENT') {
-                reject(err);
-              }
-            });
-            archive.on('error', reject);
-            archive.pipe(output);
-
-            // Add only whitelisted files, matching getSkillResources behavior
-            const allowedExts = new Set(skillResourceExtensions);
-            const addFiltered = (dir, prefix) => {
-              const items = fs.readdirSync(dir, { withFileTypes: true });
-              for (const item of items) {
-                if (item.name.startsWith('.')) continue;
-                const fullPath = path.join(dir, item.name);
-                if (item.isDirectory()) {
-                  addFiltered(fullPath, `${prefix}${item.name}/`);
-                } else {
-                  const ext = item.name.split('.').pop();
-                  if (allowedExts.has(ext)) {
-                    archive.file(fullPath, { name: `${prefix}${item.name}` });
+                output.on('close', resolve);
+                output.on('error', reject);
+                archive.on('warning', (err) => {
+                  if (err.code !== 'ENOENT') {
+                    reject(err);
                   }
-                }
-              }
-            };
-            addFiltered(resourceDir, `${slug}/`);
+                });
+                archive.on('error', reject);
+                archive.pipe(output);
 
-            archive.finalize();
-          });
+                // Add only whitelisted files, matching getSkillResources behavior
+                const allowedExts = new Set(skillResourceExtensions);
+                const addFiltered = (dir, prefix) => {
+                  const items = fs.readdirSync(dir, { withFileTypes: true });
+                  for (const item of items) {
+                    if (item.name.startsWith('.')) continue;
+                    const fullPath = path.join(dir, item.name);
+                    if (item.isDirectory()) {
+                      addFiltered(fullPath, `${prefix}${item.name}/`);
+                    } else {
+                      const ext = item.name.split('.').pop();
+                      if (allowedExts.has(ext)) {
+                        archive.file(fullPath, { name: `${prefix}${item.name}` });
+                      }
+                    }
+                  }
+                };
+                addFiltered(resourceDir, `${slug}/`);
+
+                archive.finalize();
+              });
+            }
+          }
         }
       }
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,22 @@ Supported resource file types: `.sh`, `.yml`, `.yaml`, `.json`, `.py`, `.rb`, `.
 
 Skills with resource directories automatically get a "Download All Resources (.zip)" button on their page, generated at build time.
 
+### Raw Markdown Endpoints
+
+All content types generate raw markdown files at build time for agent consumption. These files strip frontmatter and serve only the usable content:
+
+| Content Type | Raw File | Example URL |
+|---|---|---|
+| Skills | `SKILL.md` | `/development/skills/cloudflare-tunnel/SKILL.md` |
+| Prompts | `PROMPT.md` | `/development/prompts/adr/PROMPT.md` |
+| Rules | `RULE.md` | `/development/rules/code-quality/RULE.md` |
+| Agents | `AGENT.md` | `/development/agents/code-review-assistant/AGENT.md` |
+| Project Configs | `CONFIG.md` | `/development/project-configs/drupal-setup/CONFIG.md` |
+| Workflow States | `WORKFLOW.md` | `/<discipline>/workflow-states/<slug>/WORKFLOW.md` |
+| Resources | `RESOURCE.md` | `/<discipline>/resources/<slug>/RESOURCE.md` |
+
+Each content page includes a collapsible "Use with your agent" section with copy-pasteable URLs and instructions tailored to the content type.
+
 ### Versioning
 
 All content types support optional version tracking via frontmatter fields:

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -81,62 +81,46 @@ layout: base.njk
   {% set rawFile = rawFileMap[effectiveContentType] %}
   {% if rawFile %}
   {% set rawUrl = page.url | fullUrl + rawFile %}
-  <details class="agent-usage-section">
-    <summary>Use with your agent</summary>
-    <div class="agent-usage-content">
-      {% if effectiveContentType == "skills" %}
-        {% if zipUrl %}
-        <p>This skill includes companion resources. Download the complete package:</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ zipUrl | fullUrl }}</code>
-          <button class="copy-url-button" data-url="{{ zipUrl | fullUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Download <code>{{ zipUrl | fullUrl }}</code>, extract it, and install the skill and its resources"</em></p>
-        {% else %}
-        <p>Point your agent at this URL to install the skill:</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ rawUrl }}</code>
-          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Fetch the skill definition from <code>{{ rawUrl }}</code> and add it to my skills"</em></p>
-        {% endif %}
-      {% elif effectiveContentType == "prompts" %}
-        <p>Copy this prompt and paste it into your agent, or point your agent at this URL:</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ rawUrl }}</code>
-          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Fetch the prompt from <code>{{ rawUrl }}</code> and use it"</em></p>
-      {% elif effectiveContentType == "rules" %}
-        <p>Add this rule to your project's configuration (e.g. <code>CLAUDE.md</code>, <code>.cursorrules</code>):</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ rawUrl }}</code>
-          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Fetch the rules from <code>{{ rawUrl }}</code> and apply them to this project"</em></p>
-      {% elif effectiveContentType == "agents" %}
-        <p>Point your agent at this configuration:</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ rawUrl }}</code>
-          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Fetch the agent configuration from <code>{{ rawUrl }}</code> and use it"</em></p>
-      {% else %}
-        <p>Point your agent at this URL to use this content:</p>
-        <div class="agent-url-block">
-          <code class="agent-url">{{ rawUrl }}</code>
-          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
-        </div>
-        <p class="agent-usage-hint">Tell your agent:<br>
-        <em>"Fetch the content from <code>{{ rawUrl }}</code> and apply it"</em></p>
-      {% endif %}
-    </div>
-  </details>
+  {% set absoluteRawUrl = siteOrigin + rawUrl %}
+  {# For skills with resources, prefer the zip URL #}
+  {% if effectiveContentType == "skills" and zipUrl %}
+    {% set agentTargetUrl = siteOrigin + (zipUrl | fullUrl) %}
+  {% else %}
+    {% set agentTargetUrl = absoluteRawUrl %}
+  {% endif %}
+  {# Build content-type-specific prompt text #}
+  {% if effectiveContentType == "skills" %}
+    {% if zipUrl %}
+      {% set agentPrompt = "Download " + agentTargetUrl + " — it contains a skill definition (SKILL.md) and companion resources. Extract it and install the skill and its resources." %}
+    {% else %}
+      {% set agentPrompt = "Fetch the skill definition from " + agentTargetUrl + " and add it to my skills." %}
+    {% endif %}
+  {% elif effectiveContentType == "prompts" %}
+    {% set agentPrompt = "Fetch the prompt from " + agentTargetUrl + " and use it." %}
+  {% elif effectiveContentType == "rules" %}
+    {% set agentPrompt = "Fetch the rules from " + agentTargetUrl + " and apply them to this project." %}
+  {% elif effectiveContentType == "agents" %}
+    {% set agentPrompt = "Fetch the agent configuration from " + agentTargetUrl + " and use it." %}
+  {% elif effectiveContentType == "project-configs" %}
+    {% set agentPrompt = "Fetch the project configuration from " + agentTargetUrl + " and apply it to this project." %}
+  {% elif effectiveContentType == "workflow-states" %}
+    {% set agentPrompt = "Fetch the workflow definition from " + agentTargetUrl + " and apply it." %}
+  {% else %}
+    {% set agentPrompt = "Fetch the content from " + agentTargetUrl + " and use it." %}
+  {% endif %}
+  {% set claudeUrl = "https://claude.ai/new?q=" + agentPrompt | urlencode %}
+  {% set chatgptUrl = "https://chatgpt.com/?q=" + agentPrompt | urlencode %}
+  <div class="agent-buttons">
+    <a href="{{ claudeUrl }}" class="agent-button agent-button--claude" target="_blank" rel="noopener">
+      <span class="agent-button-label">Read with Claude</span>
+    </a>
+    <a href="{{ chatgptUrl }}" class="agent-button agent-button--chatgpt" target="_blank" rel="noopener">
+      <span class="agent-button-label">Read with ChatGPT</span>
+    </a>
+    <button class="agent-button agent-button--copy" data-prompt="{{ agentPrompt }}">
+      <span class="agent-button-label">Copy for agent</span>
+    </button>
+  </div>
   {% endif %}
 
   <div class="content">
@@ -343,85 +327,49 @@ layout: base.njk
     font-size: 1rem;
   }
 
-  /* Agent usage section */
-  .agent-usage-section {
-    margin-bottom: 1.5rem;
-    border: 1px solid var(--border-color);
-    border-radius: 0.5rem;
-  }
-
-  .agent-usage-section summary {
-    padding: 0.75rem 1rem;
-    cursor: pointer;
-    font-weight: 600;
-    background-color: var(--surface-color);
-    border-radius: 0.5rem;
-  }
-
-  .agent-usage-section[open] summary {
-    border-bottom: 1px solid var(--border-color);
-    border-radius: 0.5rem 0.5rem 0 0;
-  }
-
-  .agent-usage-content {
-    padding: 0.75rem 1rem;
-  }
-
-  .agent-usage-content p {
-    margin: 0 0 0.5rem;
-    font-size: 0.9rem;
-  }
-
-  .agent-url-block {
+  /* Agent action buttons */
+  .agent-buttons {
     display: flex;
-    align-items: center;
     gap: 0.5rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
   }
 
-  .agent-url {
-    flex: 1;
-    padding: 0.5rem 0.75rem;
-    background-color: var(--code-background);
-    border: 1px solid var(--code-border);
-    border-radius: 0.25rem;
+  .agent-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.85rem;
+    font-size: 0.8rem;
     font-family: var(--font-mono);
-    font-size: 0.8rem;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  .copy-url-button {
-    padding: 0.4rem 0.75rem;
-    font-size: 0.8rem;
-    color: var(--text-muted);
-    background-color: var(--surface-color);
     border: 1px solid var(--border-color);
-    border-radius: 0.25rem;
+    border-radius: 0.375rem;
+    text-decoration: none;
     cursor: pointer;
-    white-space: nowrap;
     transition: all 0.2s;
+    background-color: var(--surface-color);
+    color: var(--text-muted);
   }
 
-  .copy-url-button:hover {
-    color: var(--primary-color);
+  .agent-button:hover {
     border-color: var(--primary-color);
+    color: var(--primary-color);
   }
 
-  .copy-url-button.copied {
+  .agent-button--claude:hover {
+    border-color: #d97706;
+    color: #d97706;
+  }
+
+  .agent-button--chatgpt:hover {
+    border-color: #10a37f;
+    color: #10a37f;
+  }
+
+  .agent-button--copy.copied {
     background-color: var(--accent-color);
     border-color: var(--accent-color);
     color: #12212b;
-  }
-
-  .agent-usage-hint {
-    color: var(--text-muted);
-    font-size: 0.85rem !important;
-    margin-top: 0.5rem !important;
-  }
-
-  .agent-usage-hint em {
-    color: var(--text-color);
   }
 
   /* Code block styling */
@@ -515,15 +463,16 @@ layout: base.njk
       }
     });
 
-    // Copy URL buttons for agent usage section
-    document.querySelectorAll('.copy-url-button').forEach(button => {
+    // "Copy for agent" button
+    document.querySelectorAll('.agent-button--copy').forEach(button => {
       button.addEventListener('click', async () => {
         try {
-          await navigator.clipboard.writeText(button.dataset.url);
-          button.textContent = 'Copied!';
+          await navigator.clipboard.writeText(button.dataset.prompt);
+          const label = button.querySelector('.agent-button-label');
+          label.textContent = 'Copied!';
           button.classList.add('copied');
           setTimeout(() => {
-            button.textContent = 'Copy';
+            label.textContent = 'Copy for agent';
             button.classList.remove('copied');
           }, 2000);
         } catch (err) {

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -67,12 +67,66 @@ layout: base.njk
   </details>
   {% endif %}
 
-  {% if contentType == "skills" %}
-  <div class="skill-raw-download">
-    <a href="{{ page.url | fullUrl }}SKILL.md" class="raw-download-link" title="Raw markdown for agent consumption">
-      <i class="fas fa-file-code"></i> Raw SKILL.md
-    </a>
-  </div>
+  {% set rawFileMap = {
+    "skills": "SKILL.md",
+    "prompts": "PROMPT.md",
+    "rules": "RULE.md",
+    "agents": "AGENT.md",
+    "project-configs": "CONFIG.md",
+    "workflow-states": "WORKFLOW.md",
+    "resources": "RESOURCE.md"
+  } %}
+  {# Derive contentType from URL path when not set in frontmatter #}
+  {% set effectiveContentType = contentType if contentType else page.url | contentTypeFromUrl %}
+  {% set rawFile = rawFileMap[effectiveContentType] %}
+  {% if rawFile %}
+  {% set rawUrl = page.url | fullUrl + rawFile %}
+  <details class="agent-usage-section">
+    <summary>Use with your agent</summary>
+    <div class="agent-usage-content">
+      {% if effectiveContentType == "skills" %}
+        <p>Point your agent at this URL to install the skill:</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ rawUrl }}</code>
+          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Or tell your agent:<br>
+        <em>"Fetch the skill definition from <code>{{ rawUrl }}</code> and add it to my skills"</em></p>
+      {% elif effectiveContentType == "prompts" %}
+        <p>Copy this prompt and paste it into your agent, or point your agent at this URL:</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ rawUrl }}</code>
+          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Tell your agent:<br>
+        <em>"Fetch the prompt from <code>{{ rawUrl }}</code> and use it"</em></p>
+      {% elif effectiveContentType == "rules" %}
+        <p>Add this rule to your project's configuration (e.g. <code>CLAUDE.md</code>, <code>.cursorrules</code>):</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ rawUrl }}</code>
+          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Tell your agent:<br>
+        <em>"Fetch the rules from <code>{{ rawUrl }}</code> and apply them to this project"</em></p>
+      {% elif effectiveContentType == "agents" %}
+        <p>Point your agent at this configuration:</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ rawUrl }}</code>
+          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Tell your agent:<br>
+        <em>"Fetch the agent configuration from <code>{{ rawUrl }}</code> and use it"</em></p>
+      {% else %}
+        <p>Point your agent at this URL to use this content:</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ rawUrl }}</code>
+          <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Tell your agent:<br>
+        <em>"Fetch the content from <code>{{ rawUrl }}</code> and apply it"</em></p>
+      {% endif %}
+    </div>
+  </details>
   {% endif %}
 
   <div class="content">
@@ -279,28 +333,85 @@ layout: base.njk
     font-size: 1rem;
   }
 
-  /* Raw SKILL.md download link */
-  .skill-raw-download {
+  /* Agent usage section */
+  .agent-usage-section {
     margin-bottom: 1.5rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
   }
 
-  .raw-download-link {
-    display: inline-flex;
+  .agent-usage-section summary {
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    font-weight: 600;
+    background-color: var(--surface-color);
+    border-radius: 0.5rem;
+  }
+
+  .agent-usage-section[open] summary {
+    border-bottom: 1px solid var(--border-color);
+    border-radius: 0.5rem 0.5rem 0 0;
+  }
+
+  .agent-usage-content {
+    padding: 0.75rem 1rem;
+  }
+
+  .agent-usage-content p {
+    margin: 0 0 0.5rem;
+    font-size: 0.9rem;
+  }
+
+  .agent-url-block {
+    display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .agent-url {
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    background-color: var(--code-background);
+    border: 1px solid var(--code-border);
+    border-radius: 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+
+  .copy-url-button {
     padding: 0.4rem 0.75rem;
     font-size: 0.8rem;
     color: var(--text-muted);
+    background-color: var(--surface-color);
     border: 1px solid var(--border-color);
     border-radius: 0.25rem;
-    text-decoration: none;
-    font-family: var(--font-mono);
+    cursor: pointer;
+    white-space: nowrap;
     transition: all 0.2s;
   }
 
-  .raw-download-link:hover {
+  .copy-url-button:hover {
     color: var(--primary-color);
     border-color: var(--primary-color);
+  }
+
+  .copy-url-button.copied {
+    background-color: var(--accent-color);
+    border-color: var(--accent-color);
+    color: #12212b;
+  }
+
+  .agent-usage-hint {
+    color: var(--text-muted);
+    font-size: 0.85rem !important;
+    margin-top: 0.5rem !important;
+  }
+
+  .agent-usage-hint em {
+    color: var(--text-color);
   }
 
   /* Code block styling */
@@ -392,6 +503,23 @@ layout: base.njk
 
         pre.appendChild(button);
       }
+    });
+
+    // Copy URL buttons for agent usage section
+    document.querySelectorAll('.copy-url-button').forEach(button => {
+      button.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(button.dataset.url);
+          button.textContent = 'Copied!';
+          button.classList.add('copied');
+          setTimeout(() => {
+            button.textContent = 'Copy';
+            button.classList.remove('copied');
+          }, 2000);
+        } catch (err) {
+          console.error('Failed to copy:', err);
+        }
+      });
     });
   });
 </script>

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -85,13 +85,23 @@ layout: base.njk
     <summary>Use with your agent</summary>
     <div class="agent-usage-content">
       {% if effectiveContentType == "skills" %}
+        {% if zipUrl %}
+        <p>This skill includes companion resources. Download the complete package:</p>
+        <div class="agent-url-block">
+          <code class="agent-url">{{ zipUrl | fullUrl }}</code>
+          <button class="copy-url-button" data-url="{{ zipUrl | fullUrl }}" title="Copy URL">Copy</button>
+        </div>
+        <p class="agent-usage-hint">Tell your agent:<br>
+        <em>"Download <code>{{ zipUrl | fullUrl }}</code>, extract it, and install the skill and its resources"</em></p>
+        {% else %}
         <p>Point your agent at this URL to install the skill:</p>
         <div class="agent-url-block">
           <code class="agent-url">{{ rawUrl }}</code>
           <button class="copy-url-button" data-url="{{ rawUrl }}" title="Copy URL">Copy</button>
         </div>
-        <p class="agent-usage-hint">Or tell your agent:<br>
+        <p class="agent-usage-hint">Tell your agent:<br>
         <em>"Fetch the skill definition from <code>{{ rawUrl }}</code> and add it to my skills"</em></p>
+        {% endif %}
       {% elif effectiveContentType == "prompts" %}
         <p>Copy this prompt and paste it into your agent, or point your agent at this URL:</p>
         <div class="agent-url-block">


### PR DESCRIPTION
## Summary

- Generates raw markdown files at build time for **all content types** (not just skills), stripping frontmatter for clean agent consumption: `PROMPT.md`, `RULE.md`, `AGENT.md`, `CONFIG.md`, `WORKFLOW.md`, `RESOURCE.md`
- Adds a collapsible **"Use with your agent"** section to every content page with copy-pasteable URL and content-type-specific instructions
- Derives `contentType` from URL path for older content files missing the frontmatter field
- Adds `contentTypeFromUrl` Nunjucks filter for path-based content type detection

## Details

Each content page now shows a collapsed section explaining how to use the content with an AI agent. The instructions vary by type:

| Content Type | Raw Endpoint | Instruction |
|---|---|---|
| Skills | `SKILL.md` | "Fetch and add to my skills" |
| Prompts | `PROMPT.md` | "Fetch and use as a prompt" |
| Rules | `RULE.md` | "Fetch and apply to project config" |
| Agents | `AGENT.md` | "Fetch and use as agent config" |
| Project Configs | `CONFIG.md` | "Fetch and apply to project" |
| Workflow States | `WORKFLOW.md` | "Fetch and apply" |
| Resources | `RESOURCE.md` | "Fetch and apply" |

## Test plan

- [ ] `npm run build` succeeds
- [ ] Raw markdown files generated for all content types (40 files across 6 types)
- [ ] "Use with your agent" section appears on all content pages (collapsed by default)
- [ ] Section shows correct raw URL per content type
- [ ] Copy button works (copies URL to clipboard)
- [ ] Pages without `contentType` in frontmatter still show the section (derived from URL)
- [ ] Existing SKILL.md generation and zip archives still work
- [ ] Tugboat preview renders correctly

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)