### PR TITLE
Add lullabot-skills install banner + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Lullabot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/_includes/skills-bundle-banner.njk
+++ b/_includes/skills-bundle-banner.njk
@@ -11,8 +11,8 @@
     </p>
   </div>
   <div class="skills-bundle-banner__cmd">
-    <pre><code id="skills-bundle-cmd">git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills</code></pre>
-    <button type="button" class="skills-bundle-banner__copy" data-copy-target="skills-bundle-cmd" aria-label="Copy install command">
+    <pre><code>git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills</code></pre>
+    <button type="button" class="skills-bundle-banner__copy" aria-label="Copy install command">
       <i class="fas fa-copy" aria-hidden="true"></i>
       <span class="skills-bundle-banner__copy-label">Copy</span>
     </button>
@@ -120,24 +120,62 @@
     background: var(--accent-color, #2da44e);
     color: #12212b;
   }
+  .skills-bundle-banner__copy.is-copy-failed {
+    background: #c0392b;
+    color: white;
+  }
 </style>
 
 <script>
   (function() {
+    function flashLabel(btn, text, stateClass) {
+      var label = btn.querySelector('.skills-bundle-banner__copy-label');
+      var original = btn.getAttribute('data-original-label');
+      if (!original) {
+        original = label ? label.textContent : '';
+        btn.setAttribute('data-original-label', original);
+      }
+      if (label) label.textContent = text;
+      btn.classList.remove('is-copied', 'is-copy-failed');
+      if (stateClass) btn.classList.add(stateClass);
+      setTimeout(function() {
+        if (label) label.textContent = original;
+        btn.classList.remove('is-copied', 'is-copy-failed');
+      }, 1500);
+    }
+
+    function fallbackCopy(text) {
+      var ta = document.createElement('textarea');
+      ta.value = text;
+      ta.setAttribute('readonly', '');
+      ta.style.position = 'absolute';
+      ta.style.left = '-9999px';
+      document.body.appendChild(ta);
+      ta.select();
+      var ok = false;
+      try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+      document.body.removeChild(ta);
+      return ok;
+    }
+
     document.querySelectorAll('.skills-bundle-banner__copy').forEach(function(btn) {
       btn.addEventListener('click', function() {
-        var target = document.getElementById(btn.dataset.copyTarget);
+        var banner = btn.closest('.skills-bundle-banner');
+        var target = banner ? banner.querySelector('.skills-bundle-banner__cmd code') : null;
         if (!target) return;
-        navigator.clipboard.writeText(target.textContent.trim()).then(function() {
-          var label = btn.querySelector('.skills-bundle-banner__copy-label');
-          var original = label ? label.textContent : '';
-          if (label) label.textContent = 'Copied!';
-          btn.classList.add('is-copied');
-          setTimeout(function() {
-            if (label) label.textContent = original;
-            btn.classList.remove('is-copied');
-          }, 1500);
-        });
+        var text = target.textContent.trim();
+
+        function onSuccess() { flashLabel(btn, 'Copied!', 'is-copied'); }
+        function onFailure() {
+          if (fallbackCopy(text)) { onSuccess(); return; }
+          flashLabel(btn, 'Copy failed', 'is-copy-failed');
+        }
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(onSuccess).catch(onFailure);
+        } else {
+          onFailure();
+        }
       });
     });
   })();

--- a/_includes/skills-bundle-banner.njk
+++ b/_includes/skills-bundle-banner.njk
@@ -1,0 +1,144 @@
+{# Promotes the lullabot-skills Claude Code bundle install command. #}
+{# Variant via `compact` — `false` (default) for /skills, `true` for home. #}
+<aside class="skills-bundle-banner{% if compact %} skills-bundle-banner--compact{% endif %}">
+  <div class="skills-bundle-banner__text">
+    <h3 class="skills-bundle-banner__title">
+      <span class="skills-bundle-banner__icon" aria-hidden="true">🛠️</span>
+      Install all skills at once
+    </h3>
+    <p class="skills-bundle-banner__desc">
+      Every skill below is bundled in <a href="https://github.com/Lullabot/lullabot-skills" target="_blank" rel="noopener">Lullabot/lullabot-skills</a>. Clone it into <code>.claude/skills/</code> and Claude Code picks them all up automatically.
+    </p>
+  </div>
+  <div class="skills-bundle-banner__cmd">
+    <pre><code id="skills-bundle-cmd">git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills</code></pre>
+    <button type="button" class="skills-bundle-banner__copy" data-copy-target="skills-bundle-cmd" aria-label="Copy install command">
+      <i class="fas fa-copy" aria-hidden="true"></i>
+      <span class="skills-bundle-banner__copy-label">Copy</span>
+    </button>
+  </div>
+</aside>
+
+<style>
+  .skills-bundle-banner {
+    background: var(--card-background);
+    border: 1px solid var(--border-color);
+    border-radius: 0.5rem;
+    padding: 1.5rem;
+    margin: 2rem auto;
+    max-width: 1200px;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    align-items: start;
+  }
+  .skills-bundle-banner--compact {
+    margin: 1rem auto 2rem auto;
+    padding: 1rem 1.25rem;
+  }
+  @media (min-width: 768px) {
+    .skills-bundle-banner {
+      grid-template-columns: 1fr auto;
+      align-items: center;
+      gap: 2rem;
+    }
+  }
+  .skills-bundle-banner__title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-color);
+    margin: 0 0 0.5rem 0;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .skills-bundle-banner--compact .skills-bundle-banner__title {
+    font-size: 1.1rem;
+    margin-bottom: 0.25rem;
+  }
+  .skills-bundle-banner__icon { font-size: 1.4rem; }
+  .skills-bundle-banner__desc {
+    color: var(--text-muted);
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+  }
+  .skills-bundle-banner__desc a {
+    color: var(--primary-color);
+    text-decoration: none;
+    font-weight: 500;
+  }
+  .skills-bundle-banner__desc a:hover { text-decoration: underline; }
+  .skills-bundle-banner__desc code {
+    background: var(--tag-background);
+    padding: 0.1rem 0.35rem;
+    border-radius: 0.25rem;
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+  }
+  .skills-bundle-banner__cmd {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  .skills-bundle-banner__cmd pre {
+    background: var(--code-background, #1e1e1e);
+    color: var(--code-color, #d4d4d4);
+    padding: 0.6rem 0.9rem;
+    border-radius: 0.375rem;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    overflow-x: auto;
+    flex: 1;
+    min-width: 0;
+  }
+  .skills-bundle-banner__cmd code {
+    background: none;
+    color: inherit;
+    padding: 0;
+    white-space: pre;
+  }
+  .skills-bundle-banner__copy {
+    background: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-shrink: 0;
+    transition: background-color 0.2s;
+  }
+  .skills-bundle-banner__copy:hover { background: var(--secondary-color); }
+  .skills-bundle-banner__copy.is-copied {
+    background: var(--accent-color, #2da44e);
+    color: #12212b;
+  }
+</style>
+
+<script>
+  (function() {
+    document.querySelectorAll('.skills-bundle-banner__copy').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var target = document.getElementById(btn.dataset.copyTarget);
+        if (!target) return;
+        navigator.clipboard.writeText(target.textContent.trim()).then(function() {
+          var label = btn.querySelector('.skills-bundle-banner__copy-label');
+          var original = label ? label.textContent : '';
+          if (label) label.textContent = 'Copied!';
+          btn.classList.add('is-copied');
+          setTimeout(function() {
+            if (label) label.textContent = original;
+            btn.classList.remove('is-copied');
+          }, 1500);
+        });
+      });
+    });
+  })();
+</script>

--- a/index.njk
+++ b/index.njk
@@ -45,6 +45,9 @@ hideSearch: false
     </div>
   </div>
   
+  {% set compact = true %}
+  {% include "skills-bundle-banner.njk" %}
+
   <h2 class="recently-added-title">By Type</h2>
   <div class="by-type-nav">
     {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}

--- a/index.njk
+++ b/index.njk
@@ -45,9 +45,6 @@ hideSearch: false
     </div>
   </div>
   
-  {% set compact = true %}
-  {% include "skills-bundle-banner.njk" %}
-
   <h2 class="recently-added-title">By Type</h2>
   <div class="by-type-nav">
     {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
@@ -74,6 +71,9 @@ hideSearch: false
       {% endif %}
     {% endfor %}
   </div>
+
+  {% set compact = true %}
+  {% include "skills-bundle-banner.njk" %}
 
   <h2 class="recently-added-title">By Discipline</h2>
   <div class="discipline-grid">

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "11ty"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0"
   },

--- a/skills/index.njk
+++ b/skills/index.njk
@@ -8,6 +8,9 @@ layout: "base.njk"
   <h1 class="page-title">🛠️ All Skills</h1>
   <p class="page-description">{{ description }}</p>
 
+  {% set compact = false %}
+  {% include "skills-bundle-banner.njk" %}
+
   <div class="content-list">
     {% for item in collections.skills %}
       <article class="content-item fade-up">


### PR DESCRIPTION
## Summary

- Adds a copy-button install banner promoting the [Lullabot/lullabot-skills](https://github.com/Lullabot/lullabot-skills) bundle to the homepage (compact variant) and the `/skills` index (full variant)
- Shared partial at `_includes/skills-bundle-banner.njk` so copy lives in one place
- Adds MIT `LICENSE` (matches lullabot-skills) and updates `package.json` license field from ISC → MIT

## Why

Now that lullabot-skills is the canonical source, surface the one-line install path so anyone browsing the library can grab all skills at once for their project.

## Test plan

- [x] `npm run build` produces banner on `/` and `/skills/`
- [ ] Verify banner renders correctly on Tugboat preview
- [ ] Click "Copy" — confirms command goes to clipboard
- [ ] Banner doesn't crowd existing layout (compact variant on home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)