### PR TITLE
Add auto-bump workflow for lullabot-skills submodule

### DIFF
--- a/.github/workflows/bump-skills.yml
+++ b/.github/workflows/bump-skills.yml
@@ -5,7 +5,8 @@ name: Bump lullabot-skills submodule
 # pointer, commits, and pushes — which fires deploy.yml on the new commit
 # and rebuilds the site.
 #
-# Manual trigger is also exposed for ad-hoc bumps.
+# Manual trigger (workflow_dispatch) is also exposed for ad-hoc bumps;
+# the job-level guard restricts it to the main branch.
 
 on:
   repository_dispatch:
@@ -15,10 +16,32 @@ on:
 permissions:
   contents: write
 
+# Serialize bump runs so rapid upstream pushes can't race on `git push`
+# and produce non-fast-forward errors or redundant commits.
+concurrency:
+  group: bump-skills-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   bump:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
     steps:
+      - name: Validate dispatch shared secret
+        if: github.event_name == 'repository_dispatch'
+        env:
+          SHARED_SECRET: ${{ secrets.SKILLS_DISPATCH_SECRET }}
+          CLIENT_SECRET: ${{ github.event.client_payload.secret }}
+        run: |
+          if [ -z "$SHARED_SECRET" ]; then
+            echo "::error::SKILLS_DISPATCH_SECRET is not configured."
+            exit 1
+          fi
+          if [ "$CLIENT_SECRET" != "$SHARED_SECRET" ]; then
+            echo "::error::Invalid shared secret in client_payload."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -42,7 +65,14 @@ jobs:
             cd ..
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
-            echo "msg=$NEW_MSG" >> "$GITHUB_OUTPUT"
+            # Use a heredoc-style multi-line output to safely carry an
+            # arbitrary commit subject (which may contain quotes, $, etc.)
+            DELIM="EOF_$(uuidgen)"
+            {
+              echo "msg<<$DELIM"
+              echo "$NEW_MSG"
+              echo "$DELIM"
+            } >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push
@@ -54,6 +84,13 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add _skills-vendor
-          git commit -m "chore: bump _skills-vendor to ${NEW_SHA}" \
-            -m "Upstream: ${NEW_MSG}"
+          # Build the commit message in a temp file so quoting / special
+          # characters in the upstream subject can't break the shell.
+          MSG_FILE="$(mktemp)"
+          {
+            printf 'chore: bump _skills-vendor to %s\n\n' "$NEW_SHA"
+            printf 'Upstream: %s\n' "$NEW_MSG"
+          } > "$MSG_FILE"
+          git commit -F "$MSG_FILE"
+          rm -f "$MSG_FILE"
           git push

--- a/.github/workflows/bump-skills.yml
+++ b/.github/workflows/bump-skills.yml
@@ -1,0 +1,59 @@
+name: Bump lullabot-skills submodule
+
+# Triggered by Lullabot/lullabot-skills via repository_dispatch on every
+# push to its main branch. Pulls the latest commit into the submodule
+# pointer, commits, and pushes — which fires deploy.yml on the new commit
+# and rebuilds the site.
+#
+# Manual trigger is also exposed for ad-hoc bumps.
+
+on:
+  repository_dispatch:
+    types: [skills-updated]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          # Use the PAT so the resulting push triggers deploy.yml
+          # (pushes made with the default GITHUB_TOKEN don't fire other
+          # workflow runs by design).
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+      - name: Pull latest skills
+        id: bump
+        run: |
+          git submodule update --remote --recursive _skills-vendor
+          if git diff --quiet _skills-vendor; then
+            echo "No changes to _skills-vendor — skipping commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            cd _skills-vendor
+            NEW_SHA=$(git rev-parse --short HEAD)
+            NEW_MSG=$(git log -1 --pretty=format:'%s')
+            cd ..
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "sha=$NEW_SHA" >> "$GITHUB_OUTPUT"
+            echo "msg=$NEW_MSG" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.bump.outputs.changed == 'true'
+        env:
+          NEW_SHA: ${{ steps.bump.outputs.sha }}
+          NEW_MSG: ${{ steps.bump.outputs.msg }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add _skills-vendor
+          git commit -m "chore: bump _skills-vendor to ${NEW_SHA}" \
+            -m "Upstream: ${NEW_MSG}"
+          git push


### PR DESCRIPTION
## Summary

Adds `.github/workflows/bump-skills.yml` that listens for a `repository_dispatch` event (type: `skills-updated`) fired by [Lullabot/lullabot-skills](https://github.com/Lullabot/lullabot-skills) on every push to its `main`. The workflow pulls the new commit into `_skills-vendor/`, commits the bump, and pushes back — which fires `deploy.yml` and rebuilds the site automatically.

Also exposes `workflow_dispatch` for ad-hoc manual bumps from the Actions tab.

## Auth note

Reuses the existing `PERSONAL_ACCESS_TOKEN` secret (already used by `slack_submit.yml`). Pushing with the PAT is required because GitHub intentionally suppresses workflow-on-workflow chains when pushes use the default `GITHUB_TOKEN`.

The dispatch sender (the lullabot-skills repo) needs the same PAT stored as a secret on its side — that's a separate small change in that repo, see follow-up.

## Test plan

- [ ] Merge this PR
- [ ] Add `PERSONAL_ACCESS_TOKEN` secret to `Lullabot/lullabot-skills`
- [ ] Add the dispatch workflow on `lullabot-skills`
- [ ] Push a trivial change to `lullabot-skills` (e.g., README typo) and confirm:
  - [ ] `bump-skills.yml` runs in prompt_library
  - [ ] A new commit appears bumping `_skills-vendor`
  - [ ] `deploy.yml` fires and the site rebuilds
- [ ] Manually trigger `bump-skills` from Actions tab to verify `workflow_dispatch` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)