### PR TITLE
Use dedicated SKILLS_BUMP_TOKEN for skills auto-bump

### DIFF
--- a/.github/workflows/bump-skills.yml
+++ b/.github/workflows/bump-skills.yml
@@ -46,10 +46,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
-          # Use the PAT so the resulting push triggers deploy.yml
-          # (pushes made with the default GITHUB_TOKEN don't fire other
-          # workflow runs by design).
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          # Use a dedicated PAT (Contents: write on this repo only) so
+          # the resulting push triggers deploy.yml — pushes made with
+          # the default GITHUB_TOKEN don't fire other workflow runs by
+          # design. Distinct from PERSONAL_ACCESS_TOKEN (used by
+          # slack_submit.yml) so the two flows can be rotated
+          # independently.
+          token: ${{ secrets.SKILLS_BUMP_TOKEN }}
 
       - name: Pull latest skills
         id: bump


### PR DESCRIPTION
## Summary

Renames the secret used by `bump-skills.yml` from `PERSONAL_ACCESS_TOKEN` to `SKILLS_BUMP_TOKEN`. The existing PAT (used by `slack_submit.yml`) stays untouched — the two flows now have independent credentials that can be rotated separately.

## Setup needed before this works

1. Create a new fine-grained PAT: GitHub → Settings → Developer settings → Fine-grained personal access tokens → Generate new token
   - Resource owner: `Lullabot`
   - Repository access: only `Lullabot/prompt_library`
   - Repository permissions: **Contents: Read and write** (only)
2. Add as `SKILLS_BUMP_TOKEN` secret in both:
   - `Lullabot/prompt_library` (this repo)
   - `Lullabot/lullabot-skills` (paired update on lullabot-skills#1)

Pairs with lullabot-skills#1 which uses the same secret name on the sender side.

## Test plan

- [ ] Merge this PR
- [ ] Create the fine-grained PAT
- [ ] Add `SKILLS_BUMP_TOKEN` to both repos
- [ ] Add `SKILLS_DISPATCH_SECRET` to both repos (any random ≥32-char string)
- [ ] Merge lullabot-skills#1
- [ ] Push a trivial change to lullabot-skills main and confirm the chain runs (notify → bump → deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)