### PR TITLE
Harden skill generator with file-aware validation errors

### DIFF
--- a/scripts/generate-skill-pages.js
+++ b/scripts/generate-skill-pages.js
@@ -55,8 +55,22 @@ function readSkill(skillName, vendorDir = VENDOR_DIR) {
   }
 
   const skillRaw = fs.readFileSync(skillMdPath, 'utf8');
-  const skillFm = matter(skillRaw);
-  const meta = yaml.load(fs.readFileSync(metaPath, 'utf8')) || {};
+  let skillFm;
+  try {
+    skillFm = matter(skillRaw);
+  } catch (err) {
+    fail(
+      `Invalid YAML frontmatter in ${rel}/SKILL.md — ${err.reason || err.message}. ` +
+      `Multi-line description values must be quoted or use YAML folded scalar (>-).`
+    );
+  }
+
+  let meta;
+  try {
+    meta = yaml.load(fs.readFileSync(metaPath, 'utf8')) || {};
+  } catch (err) {
+    fail(`Invalid YAML in ${rel}/meta.yml — ${err.reason || err.message}.`);
+  }
 
   if (!meta.discipline || !VALID_DISCIPLINES.has(meta.discipline)) {
     fail(
@@ -66,6 +80,8 @@ function readSkill(skillName, vendorDir = VENDOR_DIR) {
   }
   if (!meta.title) fail(`Missing title in ${rel}/meta.yml`);
   if (!meta.date) fail(`Missing date in ${rel}/meta.yml`);
+  if (!skillFm.data.name) fail(`Missing 'name' in ${rel}/SKILL.md frontmatter (Claude Code requires it).`);
+  if (!skillFm.data.description) fail(`Missing 'description' in ${rel}/SKILL.md frontmatter (Claude Code requires it).`);
 
   return {
     name: skillName,

--- a/scripts/generate-skill-pages.test.js
+++ b/scripts/generate-skill-pages.test.js
@@ -138,6 +138,63 @@ test('readSkill rejects missing required meta fields', () => {
   }
 });
 
+test('readSkill names the offending file when SKILL.md frontmatter YAML is broken', () => {
+  // Description split across lines without quoting — gray-matter rejects it.
+  // Without hardening, the user got a raw YAMLException stack trace; with
+  // hardening, they get "Invalid YAML frontmatter in <file>".
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md':
+      '---\nname: x\ndescription: line one\nline two without quotes\n---\n# x\n',
+    'meta.yml': 'title: x\ndiscipline: development\ndate: "2025-01-01"\n',
+  });
+  try {
+    assert.throws(
+      () => readSkill('bad-skill', vendorDir),
+      (err) =>
+        err instanceof GenerateSkillsError &&
+        /Invalid YAML frontmatter in .*SKILL\.md/.test(err.message)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill names the offending file when meta.yml is malformed', () => {
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: x\ndescription: x\n---\n# x\n',
+    'meta.yml': 'title: ok\ndiscipline: development\ndate: "2025-01-01"\n  bogus: indent\n\t- mixed\n',
+  });
+  try {
+    assert.throws(
+      () => readSkill('bad-skill', vendorDir),
+      (err) =>
+        err instanceof GenerateSkillsError &&
+        /Invalid YAML in .*meta\.yml/.test(err.message)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill rejects SKILL.md missing Claude Code required fields', () => {
+  // SKILL.md must have name + description in its frontmatter — Claude Code
+  // refuses to load skills without them.
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: x\n---\n# x\n',
+    'meta.yml': 'title: x\ndiscipline: development\ndate: "2025-01-01"\n',
+  });
+  try {
+    assert.throws(
+      () => readSkill('bad-skill', vendorDir),
+      (err) =>
+        err instanceof GenerateSkillsError &&
+        /Missing 'description' in .*SKILL\.md/.test(err.message)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
 test('readSkill preserves SKILL.md content verbatim', () => {
   // Trailing two-space hard line break must survive — markdown semantic
   const body = '---\nname: x\ndescription: x\n---\n# x\n\nline one  \nline two\n';


### PR DESCRIPTION
## Summary

Yesterday's deploy failure after lullabot-skills#2 surfaced a poor error: gray-matter threw a raw YAMLException with no indication of which skill file was broken. The fix had to be reverse-engineered from the buffer in the stack trace.

This PR makes such failures point at the offending file with an actionable hint.

## Changes

- Wrap `matter()` and `yaml.load()` in try/catch; rethrow as `GenerateSkillsError` with the file path and a "quote your multi-line values" hint
- Validate that `SKILL.md` frontmatter declares `name` and `description` (Claude Code requires both)
- Add 3 tests covering: malformed SKILL.md YAML, malformed meta.yml YAML, and missing required SKILL.md fields (13 tests total, all green)
- Bump `_skills-vendor` to pick up `1afe646` upstream — the new validation surfaced that `resolve-composer-conflicts/SKILL.md` was missing `name`, fixed in lullabot-skills

## Test plan

- [x] `npm test` — 13 pass
- [x] `npm run build` — clean
- [ ] Tugboat preview matches production
- [ ] Smoke test: introduce a broken SKILL.md locally and confirm the new error names the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)