### PR TITLE
Auto-derive lastUpdated + changelog from git history

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -254,8 +254,9 @@ module.exports = function(eleventyConfig) {
           }
           if (data.changelog && Array.isArray(data.changelog)) {
             data.changelog.forEach((entry, i) => {
-              if (!entry.version || !entry.date || !entry.summary) {
-                console.warn(`[VERSION] Incomplete changelog entry #${i + 1} in ${discipline}/${type}/${file}`);
+              // version is optional (git-derived entries omit it). date + summary required.
+              if (!entry.date || !entry.summary) {
+                console.warn(`[VERSION] Incomplete changelog entry #${i + 1} in ${discipline}/${type}/${file} (date and summary are required)`);
               }
               if (entry.version && !semverRegex.test(String(entry.version))) {
                 console.warn(`[VERSION] Invalid semver in changelog entry #${i + 1} of ${discipline}/${type}/${file}: "${entry.version}"`);

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          # Full history needed so generate-skill-pages.js can derive
+          # lastUpdated + changelog from git log of _skills-vendor/.
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,9 +77,27 @@ To bump manually (e.g. while developing locally): `git submodule update --remote
 **Build flow:**
 1. `npm start` / `npm run build` triggers `prestart` / `prebuild` → `node scripts/generate-skill-pages.js`
 2. Generator walks `_skills-vendor/*/`, reads `SKILL.md` + `meta.yml`, writes `<discipline>/skills/<name>.md` (prompt-library frontmatter wrapping the SKILL.md body in five backticks) and copies resource files to `<discipline>/skills/<name>/`
-3. Eleventy renders pages and (post-build) extracts raw `SKILL.md` + zip archives, same as before
+3. For each skill, generator queries `git log` of the submodule to derive `lastUpdated` (most recent commit touching the folder) and `changelog` entries from `User-Facing-Change:` commit trailers (see below). `meta.yml` values always win.
+4. Eleventy renders pages and (post-build) extracts raw `SKILL.md` + zip archives, same as before
 
 Generated skill files are gitignored. Don't edit them — the next build wipes and regenerates.
+
+**Changelog convention.** Commits to `lullabot-skills` that should surface on the public site include a `User-Facing-Change:` trailer:
+
+```
+Add gollum link reference
+
+User-Facing-Change: Added gollum link syntax reference for handling broken wiki links
+```
+
+For commits that touch multiple skills, scope the trailer:
+
+```
+User-Facing-Change[github-wiki]: Added gollum link reference
+User-Facing-Change[gws-cli]: Reformatted description for clarity
+```
+
+Cosmetic / internal commits (typo fixes, refactors, hygiene) omit the trailer and don't appear in the public changelog. Manual `changelog` entries in `meta.yml` override git-derived ones.
 
 **Initial submodule setup:** new clones need `git submodule update --init --recursive` (or `git clone --recurse-submodules`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ Cosmetic / internal commits (typo fixes, refactors, hygiene) omit the trailer an
 
 **Initial submodule setup:** new clones need `git submodule update --init --recursive` (or `git clone --recurse-submodules`).
 
+**CI history requirement:** because `lastUpdated` and `changelog` are derived from `git log` inside `_skills-vendor/`, CI must check out the submodule with full history. `actions/checkout` defaults to `fetch-depth: 1` (shallow), which makes `git log -- <skill>/` return nothing for many skills. The `deploy.yml` workflow sets `fetch-depth: 0` for this reason — preserve that if you fork. The Tugboat config also relies on the default full clone.
+
 ### Skill Resources
 
 Resources are automatically:

--- a/_layouts/markdown.njk
+++ b/_layouts/markdown.njk
@@ -26,11 +26,11 @@ layout: base.njk
 
   {% if changelog and changelog.length > 0 %}
   <details class="changelog-section">
-    <summary>Changelog ({{ changelog.length }} {{ "version" if changelog.length == 1 else "versions" }})</summary>
+    <summary>Changelog ({{ changelog.length }} {{ "entry" if changelog.length == 1 else "entries" }})</summary>
     <ul class="changelog-list">
       {% for entry in changelog %}
         <li class="changelog-entry">
-          <strong class="changelog-version">v{{ entry.version }}</strong>
+          {% if entry.version %}<strong class="changelog-version">v{{ entry.version }}</strong>{% endif %}
           <time class="changelog-date" datetime="{{ entry.date }}">{{ entry.date | date }}</time>
           <span class="changelog-summary">{{ entry.summary }}</span>
         </li>

--- a/scripts/generate-skill-pages.js
+++ b/scripts/generate-skill-pages.js
@@ -58,40 +58,57 @@ function isSkillDir(entry) {
 // `{ lastUpdated: null, changelog: [] }` so the rest of the build can
 // continue. meta.yml values always win over git-derived values.
 function gitMetaForSkill(skillName, vendorDir) {
+  // Cheap: just the last commit's date.
+  let lastUpdated = null;
+  try {
+    const out = execFileSync(
+      'git',
+      ['-C', vendorDir, 'log', '-1', '--format=%cs', '--', `${skillName}/`],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }
+    ).trim();
+    if (out) lastUpdated = out;
+  } catch {
+    return { lastUpdated: null, changelog: [] };
+  }
+
+  if (!lastUpdated) {
+    return { lastUpdated: null, changelog: [] };
+  }
+
+  // Targeted: only commits whose message contains the trailer marker.
+  // --grep filters server-side so we don't buffer commit bodies for noisy histories.
   const FIELD_SEP = '\x1f';
   const RECORD_SEP = '\x1e';
-
-  let raw;
+  let raw = '';
   try {
     raw = execFileSync(
       'git',
       [
         '-C', vendorDir,
         'log',
-        '--reverse',
-        `--pretty=format:%H${FIELD_SEP}%cs${FIELD_SEP}%B${RECORD_SEP}`,
+        '--grep=^User-Facing-Change',
+        '--extended-regexp',
+        `--pretty=format:%cs${FIELD_SEP}%B${RECORD_SEP}`,
         '--',
         `${skillName}/`,
       ],
-      { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] }
+      { encoding: 'utf8', maxBuffer: 10 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] }
     );
   } catch {
-    return { lastUpdated: null, changelog: [] };
+    // History too shallow or git unavailable for the second query — return
+    // what we have. lastUpdated alone is still useful.
+    return { lastUpdated, changelog: [] };
   }
-  if (!raw) return { lastUpdated: null, changelog: [] };
 
-  const records = raw.split(RECORD_SEP).map(s => s.replace(/^\n+/, '')).filter(Boolean);
-  const changelog = [];
-  let lastUpdated = null;
+  if (!raw) return { lastUpdated, changelog: [] };
 
   const scopedRe = /^User-Facing-Change\[([^\]]+)\]:\s*(.+)$/;
   const bareRe = /^User-Facing-Change:\s*(.+)$/;
-
-  for (const record of records) {
-    const [, date, body] = record.split(FIELD_SEP);
-    if (!date) continue;
-    lastUpdated = date; // --reverse means oldest first, so the loop's last iteration is newest
-    if (!body) continue;
+  const changelog = [];
+  // git log default order is newest-first; iterate in that order and append.
+  for (const record of raw.split(RECORD_SEP).map(s => s.replace(/^\n+/, '')).filter(Boolean)) {
+    const [date, body] = record.split(FIELD_SEP);
+    if (!date || !body) continue;
     for (const line of body.split('\n')) {
       const scoped = line.match(scopedRe);
       if (scoped) {
@@ -107,8 +124,6 @@ function gitMetaForSkill(skillName, vendorDir) {
     }
   }
 
-  // Newest first
-  changelog.reverse();
   return { lastUpdated, changelog };
 }
 

--- a/scripts/generate-skill-pages.js
+++ b/scripts/generate-skill-pages.js
@@ -13,6 +13,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 const yaml = require('js-yaml');
 const matter = require('gray-matter');
 
@@ -41,6 +42,76 @@ function isSkillDir(entry) {
   return fs.existsSync(skillMd);
 }
 
+// Walk git history of a skill folder and collect:
+//   - lastUpdated: commit date (YYYY-MM-DD) of the most recent commit that
+//     touched any file in <skillDir>/
+//   - changelog:   array of { date, summary } entries, one per
+//     `User-Facing-Change:` (or `User-Facing-Change[<name>]:`) trailer line
+//     in commit messages of commits that touched this skill folder.
+//     Newest first.
+//
+// Unscoped trailers apply to this skill. Scoped trailers apply only when
+// the bracketed name matches `skillName`. This lets multi-skill commits
+// emit one trailer per skill.
+//
+// If the directory isn't a git repo, or git isn't available, returns
+// `{ lastUpdated: null, changelog: [] }` so the rest of the build can
+// continue. meta.yml values always win over git-derived values.
+function gitMetaForSkill(skillName, vendorDir) {
+  const FIELD_SEP = '\x1f';
+  const RECORD_SEP = '\x1e';
+
+  let raw;
+  try {
+    raw = execFileSync(
+      'git',
+      [
+        '-C', vendorDir,
+        'log',
+        '--reverse',
+        `--pretty=format:%H${FIELD_SEP}%cs${FIELD_SEP}%B${RECORD_SEP}`,
+        '--',
+        `${skillName}/`,
+      ],
+      { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'] }
+    );
+  } catch {
+    return { lastUpdated: null, changelog: [] };
+  }
+  if (!raw) return { lastUpdated: null, changelog: [] };
+
+  const records = raw.split(RECORD_SEP).map(s => s.replace(/^\n+/, '')).filter(Boolean);
+  const changelog = [];
+  let lastUpdated = null;
+
+  const scopedRe = /^User-Facing-Change\[([^\]]+)\]:\s*(.+)$/;
+  const bareRe = /^User-Facing-Change:\s*(.+)$/;
+
+  for (const record of records) {
+    const [, date, body] = record.split(FIELD_SEP);
+    if (!date) continue;
+    lastUpdated = date; // --reverse means oldest first, so the loop's last iteration is newest
+    if (!body) continue;
+    for (const line of body.split('\n')) {
+      const scoped = line.match(scopedRe);
+      if (scoped) {
+        if (scoped[1].trim() === skillName) {
+          changelog.push({ date, summary: scoped[2].trim() });
+        }
+        continue;
+      }
+      const bare = line.match(bareRe);
+      if (bare) {
+        changelog.push({ date, summary: bare[1].trim() });
+      }
+    }
+  }
+
+  // Newest first
+  changelog.reverse();
+  return { lastUpdated, changelog };
+}
+
 function readSkill(skillName, vendorDir = VENDOR_DIR) {
   const skillDir = path.join(vendorDir, skillName);
   const skillMdPath = path.join(skillDir, 'SKILL.md');
@@ -66,6 +137,15 @@ function readSkill(skillName, vendorDir = VENDOR_DIR) {
   }
   if (!meta.title) fail(`Missing title in ${rel}/meta.yml`);
   if (!meta.date) fail(`Missing date in ${rel}/meta.yml`);
+
+  // Derive lastUpdated + changelog from git history. meta.yml values win.
+  const gitMeta = gitMetaForSkill(skillName, vendorDir);
+  if (!meta.lastUpdated && gitMeta.lastUpdated) {
+    meta.lastUpdated = gitMeta.lastUpdated;
+  }
+  if (!meta.changelog && gitMeta.changelog.length > 0) {
+    meta.changelog = gitMeta.changelog;
+  }
 
   return {
     name: skillName,
@@ -194,4 +274,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { readSkill, buildPageContent, VALID_DISCIPLINES, GenerateSkillsError };
+module.exports = { readSkill, buildPageContent, gitMetaForSkill, VALID_DISCIPLINES, GenerateSkillsError };

--- a/scripts/generate-skill-pages.test.js
+++ b/scripts/generate-skill-pages.test.js
@@ -4,7 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { readSkill, buildPageContent, VALID_DISCIPLINES, GenerateSkillsError } = require('./generate-skill-pages');
+const { execFileSync } = require('child_process');
+
+const { readSkill, buildPageContent, gitMetaForSkill, VALID_DISCIPLINES, GenerateSkillsError } = require('./generate-skill-pages');
 
 // These tests rely on the lullabot-skills submodule being initialized.
 // They exercise the real fixtures rather than synthesizing fake ones,
@@ -62,12 +64,21 @@ test('buildPageContent preserves optional version fields when present', { skip: 
   assert.match(page, /changelog:/);
 });
 
-test('buildPageContent omits version fields when absent', { skip: !vendorAvailable() }, () => {
-  const skill = readSkill('cloudflare-tunnel');
-  const page = buildPageContent(skill);
-  assert.doesNotMatch(page, /^version:/m);
-  assert.doesNotMatch(page, /^lastUpdated:/m);
-  assert.doesNotMatch(page, /^changelog:/m);
+test('buildPageContent omits version fields when absent (and no git history)', () => {
+  // Use a non-git fixture so neither meta.yml nor git provide values.
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: x\ndescription: y\n---\n# x\n',
+    'meta.yml': 'title: X\ndiscipline: development\ndate: "2025-01-01"\n',
+  });
+  try {
+    const skill = readSkill('bad-skill', vendorDir);
+    const page = buildPageContent(skill);
+    assert.doesNotMatch(page, /^version:/m);
+    assert.doesNotMatch(page, /^lastUpdated:/m);
+    assert.doesNotMatch(page, /^changelog:/m);
+  } finally {
+    cleanup();
+  }
 });
 
 function makeFixture(files) {
@@ -133,6 +144,163 @@ test('readSkill rejects missing required meta fields', () => {
       () => readSkill('bad-skill', vendorDir),
       (err) => err instanceof GenerateSkillsError && /Missing title/.test(err.message)
     );
+  } finally {
+    cleanup();
+  }
+});
+
+// Git-backed fixtures: initialize a tmp directory as a git repo, create
+// skill folders, and make commits with controlled author dates and
+// User-Facing-Change trailers. Used to test gitMetaForSkill end-to-end.
+function makeGitFixture() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-git-test-'));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'Test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+  };
+  execFileSync('git', ['init', '--quiet', '-b', 'main', tmp], { env });
+  execFileSync('git', ['-C', tmp, 'config', 'commit.gpgsign', 'false'], { env });
+
+  function commit({ files, message, date }) {
+    for (const [filePath, content] of Object.entries(files)) {
+      const abs = path.join(tmp, filePath);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+      execFileSync('git', ['-C', tmp, 'add', filePath], { env });
+    }
+    execFileSync('git', ['-C', tmp, 'commit', '-q', '-m', message], {
+      env: { ...env, GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date },
+    });
+  }
+
+  return {
+    vendorDir: tmp,
+    commit,
+    cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }),
+  };
+}
+
+test('gitMetaForSkill returns nulls when not a git repo', () => {
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: x\ndescription: x\n---\n# x\n',
+    'meta.yml': 'title: x\ndiscipline: development\ndate: "2025-01-01"\n',
+  });
+  try {
+    const result = gitMetaForSkill('bad-skill', vendorDir);
+    assert.equal(result.lastUpdated, null);
+    assert.deepEqual(result.changelog, []);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gitMetaForSkill derives lastUpdated from most recent commit', () => {
+  const { vendorDir, commit, cleanup } = makeGitFixture();
+  try {
+    commit({
+      files: { 'mine/SKILL.md': '---\nname: mine\ndescription: x\n---\n# m\n' },
+      message: 'Initial',
+      date: '2026-01-15T12:00:00Z',
+    });
+    commit({
+      files: { 'mine/SKILL.md': '---\nname: mine\ndescription: y\n---\n# m\n\nupdated\n' },
+      message: 'Tweak description',
+      date: '2026-03-20T12:00:00Z',
+    });
+    const result = gitMetaForSkill('mine', vendorDir);
+    assert.equal(result.lastUpdated, '2026-03-20');
+  } finally {
+    cleanup();
+  }
+});
+
+test('gitMetaForSkill builds changelog from User-Facing-Change trailers, newest first', () => {
+  const { vendorDir, commit, cleanup } = makeGitFixture();
+  try {
+    commit({
+      files: { 'mine/SKILL.md': '---\nname: mine\ndescription: x\n---\n# m\n' },
+      message: 'Initial commit\n\nUser-Facing-Change: Initial release of the mine skill\n',
+      date: '2026-01-15T12:00:00Z',
+    });
+    commit({
+      files: { 'mine/SKILL.md': '---\nname: mine\ndescription: x\n---\n# m\n\nv2\n' },
+      message: 'Cosmetic typo fix', // no trailer — should not appear
+      date: '2026-02-01T12:00:00Z',
+    });
+    commit({
+      files: { 'mine/SKILL.md': '---\nname: mine\ndescription: x\n---\n# m\n\nv3\n' },
+      message: 'Add new section\n\nUser-Facing-Change: Added quickstart section\n',
+      date: '2026-03-10T12:00:00Z',
+    });
+
+    const result = gitMetaForSkill('mine', vendorDir);
+    assert.equal(result.lastUpdated, '2026-03-10');
+    assert.deepEqual(result.changelog, [
+      { date: '2026-03-10', summary: 'Added quickstart section' },
+      { date: '2026-01-15', summary: 'Initial release of the mine skill' },
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('gitMetaForSkill respects scoped User-Facing-Change[<name>] trailers', () => {
+  const { vendorDir, commit, cleanup } = makeGitFixture();
+  try {
+    // One commit touches two skills with two scoped trailers
+    commit({
+      files: {
+        'a/SKILL.md': '---\nname: a\ndescription: x\n---\n# a\n',
+        'b/SKILL.md': '---\nname: b\ndescription: x\n---\n# b\n',
+      },
+      message:
+        'Sync skills\n\n' +
+        'User-Facing-Change[a]: Added autocomplete to a\n' +
+        'User-Facing-Change[b]: Renamed b helper script\n',
+      date: '2026-04-01T12:00:00Z',
+    });
+
+    const a = gitMetaForSkill('a', vendorDir);
+    assert.deepEqual(a.changelog, [
+      { date: '2026-04-01', summary: 'Added autocomplete to a' },
+    ]);
+
+    const b = gitMetaForSkill('b', vendorDir);
+    assert.deepEqual(b.changelog, [
+      { date: '2026-04-01', summary: 'Renamed b helper script' },
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill prefers meta.yml lastUpdated/changelog over git-derived values', () => {
+  const { vendorDir, commit, cleanup } = makeGitFixture();
+  try {
+    commit({
+      files: {
+        'mine/SKILL.md': '---\nname: mine\ndescription: x\n---\n# m\n',
+        'mine/meta.yml':
+          'title: Mine\n' +
+          'discipline: development\n' +
+          'date: "2025-01-01"\n' +
+          'lastUpdated: "2024-06-01"\n' +
+          'changelog:\n' +
+          '  - version: "1.0.0"\n' +
+          '    date: "2024-06-01"\n' +
+          '    summary: Manual entry\n',
+      },
+      message:
+        'Initial\n\nUser-Facing-Change: Auto entry that should be ignored\n',
+      date: '2026-04-01T12:00:00Z',
+    });
+    const skill = readSkill('mine', vendorDir);
+    assert.equal(skill.meta.lastUpdated, '2024-06-01', 'manual lastUpdated wins');
+    assert.equal(skill.meta.changelog.length, 1);
+    assert.equal(skill.meta.changelog[0].summary, 'Manual entry');
   } finally {
     cleanup();
   }


### PR DESCRIPTION
## Summary

After yesterday's github-wiki sync, the public skill page didn't show any indication that the skill had been updated — neither the "Updated" badge nor a changelog entry. This wires the generator to derive both from git history of the lullabot-skills submodule.

## What changes

- **`lastUpdated`** is set to the date of the most recent commit touching `_skills-vendor/<skill>/`. Drives the "Updated" badge that already exists on collection listings.
- **`changelog`** is built from `User-Facing-Change:` trailers in commit messages of commits that touched the skill folder. Each trailer becomes one `{date, summary}` entry, newest first.
- Manual `lastUpdated` / `changelog` in `meta.yml` always win — auto-derivation is a fallback.

## The trailer convention

```
Add gollum link reference

User-Facing-Change: Added gollum link syntax reference for handling broken wiki links
```

Multi-skill commits scope:

```
User-Facing-Change[github-wiki]: Added gollum link reference
User-Facing-Change[gws-cli]: Reformatted description for clarity
```

Cosmetic/internal commits omit the trailer — they don't appear in the public changelog.

## What this PR does NOT do

- Does not auto-write changelogs for *past* commits (none of them have trailers yet). Older skills will get accurate `lastUpdated` immediately and changelog entries only as new commits with trailers land.
- Does not add an LLM-driven "propose trailer" helper — that's the next PR on lullabot-skills, which will add `scripts/propose-changelog.sh` plus an AGENTS.md / CLAUDE.md telling agents to run it before committing.

## Tests

15 tests pass (5 new):
- gitMetaForSkill returns nulls outside a git repo
- derives lastUpdated from latest commit
- builds changelog from trailers, ignores commits without
- respects scoped trailers across a multi-skill commit
- meta.yml manual values override git-derived

🤖 Generated with [Claude Code](https://claude.com/claude-code)