### PR TITLE
Fix skills bump validation

### DIFF
--- a/.github/workflows/bump-skills.yml
+++ b/.github/workflows/bump-skills.yml
@@ -78,6 +78,21 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Setup Node.js
+        if: steps.bump.outputs.changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        if: steps.bump.outputs.changed == 'true'
+        run: npm ci
+
+      - name: Validate build
+        if: steps.bump.outputs.changed == 'true'
+        run: npm run build
+
       - name: Commit and push
         if: steps.bump.outputs.changed == 'true'
         env:


### PR DESCRIPTION
## Summary
- Roll back _skills-vendor from 9b45a41 to d1612e3, the last valid skills commit before the missing meta.yml failure.
- Add install + build validation to the skills bump workflow before it commits and pushes submodule updates.

## Failure
The deploy run failed in npm run build during scripts/generate-skill-pages.js because _skills-vendor/improve-test-quality/SKILL.md exists without the required _skills-vendor/improve-test-quality/meta.yml.

## Testing
- npm test
- npm run build

## ADR
- Followed Lullabot ADR: Main branch always deployable.