### PR TITLE
Tolerate skills with extra/unsupported disciplines

### DIFF
--- a/scripts/generate-skill-pages.js
+++ b/scripts/generate-skill-pages.js
@@ -158,12 +158,25 @@ function readSkill(skillName, vendorDir = VENDOR_DIR) {
     fail(`Invalid YAML in ${rel}/meta.yml — ${err.reason || err.message}.`);
   }
 
-  if (!meta.discipline || !VALID_DISCIPLINES.has(meta.discipline)) {
+  // A skill may declare one discipline or a list of them. The skill bundle is
+  // shared across consumers, so it's free to use categories this site doesn't
+  // model (e.g. "security", "admin"). We file the skill under the first
+  // declared value we recognize and ignore the rest. We only fail if NONE of
+  // the declared disciplines is one this site supports.
+  const declared = (Array.isArray(meta.discipline) ? meta.discipline : [meta.discipline])
+    .filter((d) => typeof d === 'string' && d.trim())
+    .map((d) => d.trim());
+  const resolved = declared.find((d) => VALID_DISCIPLINES.has(d));
+  if (!resolved) {
+    const got = declared.length ? declared.map((d) => `"${d}"`).join(', ') : '(none)';
     fail(
-      `Invalid discipline "${meta.discipline}" in ${rel}/meta.yml. ` +
-      `Must be one of: ${[...VALID_DISCIPLINES].join(', ')}`
+      `No supported discipline in ${rel}/meta.yml — declared ${got}. ` +
+      `At least one must be: ${[...VALID_DISCIPLINES].join(', ')}`
     );
   }
+  // Collapse to the single resolved value for everything downstream
+  // (frontmatter, output path, cleanup) which assumes a scalar discipline.
+  meta.discipline = resolved;
   if (!meta.title) fail(`Missing title in ${rel}/meta.yml`);
   if (!meta.date) fail(`Missing date in ${rel}/meta.yml`);
   if (!skillFm.data.name) fail(`Missing 'name' in ${rel}/SKILL.md frontmatter (Claude Code requires it).`);

--- a/scripts/generate-skill-pages.test.js
+++ b/scripts/generate-skill-pages.test.js
@@ -91,7 +91,7 @@ function makeFixture(files) {
   return { vendorDir: tmp, skillDir, cleanup: () => fs.rmSync(tmp, { recursive: true, force: true }) };
 }
 
-test('readSkill rejects unknown discipline', () => {
+test('readSkill rejects discipline with no supported value', () => {
   const { vendorDir, cleanup } = makeFixture({
     'SKILL.md': '---\nname: bad-skill\ndescription: x\n---\n# x\n',
     'meta.yml': 'title: Bad\ndiscipline: not-real\ndate: "2025-01-01"\n',
@@ -99,7 +99,49 @@ test('readSkill rejects unknown discipline', () => {
   try {
     assert.throws(
       () => readSkill('bad-skill', vendorDir),
-      (err) => err instanceof GenerateSkillsError && /Invalid discipline "not-real"/.test(err.message)
+      (err) => err instanceof GenerateSkillsError && /No supported discipline.*"not-real"/.test(err.message)
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill accepts a list of disciplines and resolves the first supported one', () => {
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: bad-skill\ndescription: x\n---\n# x\n',
+    'meta.yml': 'title: Multi\ndiscipline:\n  - security\n  - development\n  - admin\ndate: "2025-01-01"\n',
+  });
+  try {
+    const skill = readSkill('bad-skill', vendorDir);
+    // "security" and "admin" aren't supported; "development" is, so it wins.
+    assert.equal(skill.meta.discipline, 'development');
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill resolves the first supported discipline in declared order', () => {
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: bad-skill\ndescription: x\n---\n# x\n',
+    'meta.yml': 'title: Multi\ndiscipline:\n  - quality-assurance\n  - development\ndate: "2025-01-01"\n',
+  });
+  try {
+    const skill = readSkill('bad-skill', vendorDir);
+    assert.equal(skill.meta.discipline, 'quality-assurance');
+  } finally {
+    cleanup();
+  }
+});
+
+test('readSkill rejects a list with no supported discipline', () => {
+  const { vendorDir, cleanup } = makeFixture({
+    'SKILL.md': '---\nname: bad-skill\ndescription: x\n---\n# x\n',
+    'meta.yml': 'title: Bad\ndiscipline:\n  - security\n  - admin\ndate: "2025-01-01"\n',
+  });
+  try {
+    assert.throws(
+      () => readSkill('bad-skill', vendorDir),
+      (err) => err instanceof GenerateSkillsError && /No supported discipline.*"security", "admin"/.test(err.message)
     );
   } finally {
     cleanup();


### PR DESCRIPTION
## What

The skill-page generator (`scripts/generate-skill-pages.js`) previously required a skill's `meta.yml` `discipline` to be exactly one of the six disciplines this site models, and hard-failed the build otherwise. The shared [lullabot-skills](https://github.com/Lullabot/lullabot-skills) bundle is consumed by multiple tools, so skills legitimately use categories this site doesn't model (e.g. `security`, `admin`).

This change makes the generator **tolerant**:

- `discipline` may be a single value **or a list**.
- The generator files the skill under the **first declared value it recognizes** and ignores the rest.
- It only fails when **none** of the declared disciplines is one of the six supported here.

No new disciplines, no nav/IA changes — a skill just needs *one* supported discipline to render; extra categories are ignored.

## Why

A new upstream skill (`lullabot-saas-security-review`) declared `discipline: security` (now `admin`), neither of which this site models, which [broke the downstream build](https://github.com/Lullabot/prompt_library/actions/runs/27839718057/job/82395798394). Rather than force every skill into exactly our six buckets, we let skills carry whatever categories they need as long as one is supported here.

## Companion change

Requires the upstream skill to declare at least one supported discipline (PR against `Lullabot/lullabot-skills` adds `development` alongside `admin`). This generator change is backward-compatible on its own — all existing single-string skills resolve unchanged.

## Testing

`node --test scripts/generate-skill-pages.test.js` — 21 pass, including new cases for list-valued disciplines, declared-order resolution, and the all-unsupported failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)