### PR TITLE
Fix blank cards in Recently Added section

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -119,7 +119,7 @@ module.exports = function(eleventyConfig) {
   contentTypes.forEach(type => {
     eleventyConfig.addCollection(type, function(collection) {
       return collection.getFilteredByGlob(
-        disciplines.map(discipline => `${discipline}/${type}/**/*.md`)
+        disciplines.map(discipline => `${discipline}/${type}/*.md`)
       ).map(item => {
         // Ensure URLs have the correct base URL
         if (process.env.GITHUB_ACTIONS && !item.url.startsWith('/prompt_library')) {
@@ -228,7 +228,7 @@ module.exports = function(eleventyConfig) {
     let all = [];
     contentTypes.forEach(type => {
       all = all.concat(collection.getFilteredByGlob(
-        disciplines.map(discipline => `${discipline}/${type}/**/*.md`)
+        disciplines.map(discipline => `${discipline}/${type}/*.md`)
       ));
     });
     return all.sort((a, b) => new Date(b.date) - new Date(a.date));
@@ -273,7 +273,7 @@ module.exports = function(eleventyConfig) {
     let all = [];
     contentTypes.forEach(type => {
       all = all.concat(collection.getFilteredByGlob(
-        disciplines.map(discipline => `${discipline}/${type}/**/*.md`)
+        disciplines.map(discipline => `${discipline}/${type}/*.md`)
       ));
     });
     return all


### PR DESCRIPTION
## Problem

The **Recently Added** section on the homepage showed blank cards (26 of them).

## Cause

The \`recentlyAdded\`, \`recentlyUpdated\`, and per-content-type collections globbed \`\${discipline}/\${type}/**/*.md\`. The recursive \`**\` swept in skill resource/reference files (e.g. \`skills/<name>/references/*.md\`, \`README.md\`) that have no frontmatter — rendering them as blank cards and inflating the per-type counts in the "By Type" nav.

## Fix

Every legitimate content page is a direct child of its type directory, so the glob is narrowed to \`*.md\` to exclude nested resource files. Verified: nothing with a title lives deeper than \`discipline/type/*.md\`. After the fix the homepage shows 48 cards, 0 blank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)