### PR TITLE
Redesign homepage from Framer (dual-theme, search-first)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -231,7 +231,57 @@ module.exports = function(eleventyConfig) {
         disciplines.map(discipline => `${discipline}/${type}/**/*.md`)
       ));
     });
-    return all.sort((a, b) => new Date(b.date) - new Date(a.date));
+    // Exclude nested skill resource files (README.md, references/*.md, etc.)
+    // which have no title frontmatter — keep only real content pages.
+    return all
+      .filter(item => item.data && item.data.title)
+      .sort((a, b) => new Date(b.date) - new Date(a.date));
+  });
+
+  // --- Homepage redesign data layer: live counts for stats / type cards / matrix ---
+  const normalizeTypeName = (t) => String(t).toLowerCase().replace(/\s+/g, '-');
+
+  // Total items in a content-type collection (whole library)
+  eleventyConfig.addNunjucksFilter("typeCount", function(contentType) {
+    const c = this.ctx.collections;
+    const name = normalizeTypeName(contentType);
+    return (c && c[name]) ? c[name].length : 0;
+  });
+
+  // Items matching a discipline within a content-type collection (matrix cells)
+  eleventyConfig.addNunjucksFilter("disciplineTypeCount", function(discipline, contentType) {
+    const c = this.ctx.collections;
+    const name = normalizeTypeName(contentType);
+    if (!c || !c[name]) return 0;
+    const d = String(discipline).toLowerCase();
+    return c[name].filter(item =>
+      typeof item.data.discipline === 'string' && item.data.discipline.toLowerCase() === d
+    ).length;
+  });
+
+  // Sum of counts across a list of content types (hero "N resources")
+  eleventyConfig.addNunjucksFilter("sumTypeCounts", function(types) {
+    const c = this.ctx.collections;
+    if (!c) return 0;
+    return (types || []).reduce((sum, t) => {
+      const name = normalizeTypeName(t);
+      return sum + (c[name] ? c[name].length : 0);
+    }, 0);
+  });
+
+  // Disciplines with at least one item across the given types (hero "N disciplines")
+  eleventyConfig.addNunjucksFilter("activeDisciplineCount", function(disciplineList, typeList) {
+    const c = this.ctx.collections;
+    if (!c) return 0;
+    return (disciplineList || []).filter(d => {
+      const dl = String(d).toLowerCase();
+      return (typeList || []).some(t => {
+        const name = normalizeTypeName(t);
+        return c[name] && c[name].some(item =>
+          typeof item.data.discipline === 'string' && item.data.discipline.toLowerCase() === dl
+        );
+      });
+    }).length;
   });
 
   // Version validation: warn on invalid semver or incomplete version metadata

--- a/_includes/_lib-button.njk
+++ b/_includes/_lib-button.njk
@@ -1,0 +1,12 @@
+{#
+  Library Button — Framer "Library Button" (m6SKoROEH).
+  variant: "filled" (Framer dmpGepZk0) | "outline" (Framer e4iNiqO4b)
+  Usage: {% from "_lib-button.njk" import libButton %}
+         {{ libButton("GitHub", "https://…", "outline", true) }}
+#}
+{% macro libButton(label, href, variant="outline", newTab=false) %}
+<a class="rd-btn rd-btn--{{ variant }}" href="{{ href }}"{% if newTab %} target="_blank" rel="noopener noreferrer"{% endif %}>
+  <span class="rd-btn__label">{{ label }}</span>
+  <span class="rd-btn__arrow" aria-hidden="true">→</span>
+</a>
+{% endmacro %}

--- a/_includes/_resource-card.njk
+++ b/_includes/_resource-card.njk
@@ -1,0 +1,17 @@
+{#
+  Resource Card — Framer "Resource Card" (U4fILFY7M).
+  Usage: {% from "_resource-card.njk" import resourceCard %}
+         {{ resourceCard(title, description, typeTag, disciplineTag, status, href) }}
+#}
+{% macro resourceCard(title, description, typeTag, disciplineTag, status, href, newTab=false) %}
+<a class="rd-card rd-card--resource" href="{{ href }}"{% if newTab %} target="_blank" rel="noopener noreferrer"{% endif %}>
+  <div class="rd-card__tags">
+    {% if typeTag %}<span class="rd-tag">{{ typeTag }}</span>{% endif %}
+    {% if disciplineTag %}<span class="rd-tag">{{ disciplineTag }}</span>{% endif %}
+    {% if status %}<span class="rd-badge">{{ status }}</span>{% endif %}
+  </div>
+  <h3 class="rd-card__title">{{ title }}</h3>
+  <p class="rd-card__desc">{{ description }}</p>
+  <span class="rd-card__cta">View resource <span aria-hidden="true">→</span></span>
+</a>
+{% endmacro %}

--- a/_includes/_type-card.njk
+++ b/_includes/_type-card.njk
@@ -1,0 +1,14 @@
+{#
+  Type Card — Framer "Type Card" (zZ0bGFHll).
+  Usage: {% from "_type-card.njk" import typeCard %}
+         {{ typeCard("Prompts", 12, "Reusable starting points…", "/prompts/") }}
+#}
+{% macro typeCard(title, count, description, href, newTab=false) %}
+<a class="rd-card rd-card--type" href="{{ href }}"{% if newTab %} target="_blank" rel="noopener noreferrer"{% endif %}>
+  <div class="rd-card__type-head">
+    <h3 class="rd-card__title">{{ title }}</h3>
+    <span class="rd-count">{{ count }}</span>
+  </div>
+  <p class="rd-card__desc">{{ description }}</p>
+</a>
+{% endmacro %}

--- a/_layouts/base.njk
+++ b/_layouts/base.njk
@@ -6,48 +6,59 @@
     <meta name="base-url" content="{{ baseUrl }}">
     <title>{{ title }} - Prompt Library</title>
     <link rel="stylesheet" href="{{ baseUrl }}/assets/css/styles.css">
+    <link rel="stylesheet" href="{{ baseUrl }}/assets/css/redesign.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
+    {% if needsSwiper %}
+    <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css" />
     <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+    {% endif %}
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="{{ baseUrl }}/assets/js/theme.js"></script>
 </head>
-<body>
-    <header>
-        <nav>
-            <a href="{{ baseUrl }}/" class="home-link"><i class="fas fa-book-open"></i> Home</a>
-            <a href="{{ baseUrl }}/help" class="home-link"><i class="fas fa-question-circle"></i> Help</a>
-            <div class="search-container">
-                <form class="search-form" role="search">
-                    <label for="search-input" class="visually-hidden">Search</label>
-                    <input 
-                        type="search" 
-                        id="search-input" 
-                        class="search-input" 
-                        placeholder="Search prompts, rules, and configurations..."
-                        aria-label="Search content"
-                    >
-                    <button type="submit" class="search-button" aria-label="Search">
-                        <i class="fas fa-search"></i>
-                    </button>
-                </form>
-                <div id="search-results" class="search-results" hidden></div>
-            </div>
-            <a href="https://github.com/Lullabot/prompt_library" class="theme-toggle" aria-label="GitHub Repository" target="_blank" rel="noopener noreferrer">
-                <i class="fab fa-github"></i>
-            </a>
-            <button id="theme-toggle" class="theme-toggle" onclick="toggleTheme()" aria-label="Switch theme">
-                <i class="fas fa-moon"></i>
-            </button>
+<body class="{{ bodyClass }}">
+    <header class="rd-topbar">
+        <a class="rd-brand" href="{{ baseUrl }}/" aria-label="Prompt Library home">
+            <span class="rd-brand__mark" aria-hidden="true">
+                <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M5 6l5 6-5 6"/>
+                    <path d="M13 18h6"/>
+                </svg>
+            </span>
+            <span class="rd-brand__name">Prompt Library</span>
+        </a>
+        {% if not hideHeaderSearch %}
+        <div class="rd-topbar__search">
+            <form class="search-form" role="search">
+                <i class="fas fa-search rd-searchbar__icon" aria-hidden="true"></i>
+                <label for="search-input" class="visually-hidden">Search</label>
+                <input type="search" id="search-input" class="search-input"
+                       placeholder="Search prompts, rules, agents, skills…" aria-label="Search content">
+            </form>
+            <div id="search-results" class="search-results" hidden></div>
+        </div>
+        {% endif %}
+        <nav class="rd-topbar__links" aria-label="Primary">
+            <a href="{{ baseUrl }}/">Home</a>
+            <a href="{{ baseUrl }}/help">Help</a>
         </nav>
+        <div class="rd-topbar__actions">
+            <a class="rd-btn rd-btn--outline" href="https://github.com/Lullabot/prompt_library" target="_blank" rel="noopener noreferrer">GitHub <span class="rd-btn__arrow" aria-hidden="true">&rarr;</span></a>
+            <button id="theme-toggle" class="rd-theme-toggle" onclick="toggleTheme()" aria-label="Switch theme">
+                <i class="fas fa-moon" aria-hidden="true"></i>
+            </button>
+        </div>
     </header>
 
     <main>
         {{ content | safe }}
     </main>
 
-    <footer>
-        <p>&copy; {{ "now" | date("yyyy") }} Prompt Library</p>
+    <footer class="rd-footer">
+        <span class="rd-footer__copy">&copy; {{ "now" | date("yyyy") }} Prompt Library</span>
+        <div class="rd-footer__links">
+            <a href="https://github.com/Lullabot/prompt_library" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a href="{{ baseUrl }}/help">Help</a>
+        </div>
     </footer>
 
     <div id="markdown-modal" class="markdown-modal">

--- a/assets/css/redesign.css
+++ b/assets/css/redesign.css
@@ -1,0 +1,353 @@
+/* ===========================================================================
+   Prompt Library — Homepage redesign (Framer "Miraculous Motivation")
+   Component primitives only (buttons, cards, tags, badges). Section layout
+   CSS lands with the index.njk rewrite (Phase 3). Palette tokens (--rd-*)
+   live in styles.css under :root and :root.dark-theme.
+   All classes are namespaced .rd-* so interior pages are unaffected.
+   =========================================================================== */
+
+/* ---- Library Button ---------------------------------------------------- */
+.rd-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-family: var(--font-sans);
+  font-weight: 700;
+  font-size: 0.95rem;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: transform 0.15s ease, background-color 0.2s ease, border-color 0.2s ease;
+}
+.rd-btn:hover { transform: translateY(-1px); }
+.rd-btn:focus-visible { outline: 2px solid var(--rd-accent); outline-offset: 2px; }
+.rd-btn__arrow { transition: transform 0.15s ease; }
+.rd-btn:hover .rd-btn__arrow { transform: translateX(2px); }
+
+.rd-btn--filled {
+  background-color: var(--rd-accent);
+  color: var(--rd-on-accent);
+}
+.rd-btn--filled:hover { background-color: #d8431f; }
+
+.rd-btn--outline {
+  background-color: transparent;
+  color: var(--rd-ink);
+  border-color: var(--rd-border);
+}
+.rd-btn--outline:hover { border-color: var(--rd-accent); color: var(--rd-accent); }
+
+/* ---- Cards (shared) ---------------------------------------------------- */
+.rd-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border-radius: 18px;
+  background-color: var(--rd-surface);
+  border: 1px solid var(--rd-border);
+  text-decoration: none;
+  transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.rd-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--rd-accent);
+  box-shadow: 0 8px 24px rgba(16, 35, 49, 0.10);
+}
+.rd-card:focus-visible { outline: 2px solid var(--rd-accent); outline-offset: 2px; }
+
+.rd-card__title {
+  font-family: var(--font-heading);
+  font-weight: 800;
+  font-size: 1.15rem;
+  color: var(--rd-ink);
+  margin: 0;
+}
+.rd-card__desc {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--rd-muted);
+  margin: 0;
+  flex: 1;
+}
+.rd-card__cta {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--rd-accent);
+}
+
+/* ---- Resource card tags + status badge --------------------------------- */
+.rd-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+.rd-tag,
+.rd-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+.rd-tag {
+  background-color: var(--rd-chip);
+  color: var(--rd-chip-text);
+}
+.rd-badge {
+  background-color: var(--rd-accent-soft);
+  color: var(--rd-accent);
+  text-transform: uppercase;
+}
+
+/* ---- Type card --------------------------------------------------------- */
+.rd-card__type-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.rd-count {
+  font-family: var(--font-heading);
+  font-weight: 800;
+  font-size: 1.1rem;
+  color: var(--rd-accent);
+  background-color: var(--rd-accent-soft);
+  min-width: 2rem;
+  text-align: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+}
+
+/* ===========================================================================
+   Homepage sections (only rendered on body.rd-home / index.njk)
+   =========================================================================== */
+body.rd-home { background-color: var(--rd-bg); }
+.rd-page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 28px 40px;
+  color: var(--rd-text);
+  font-family: var(--font-sans);
+}
+.visually-hidden {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+}
+
+/* ---- Eyebrow ---- */
+.rd-eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 8px 12px; border-radius: 999px;
+  background-color: var(--rd-accent-soft); color: var(--rd-accent);
+  font-weight: 700; font-size: 0.78rem; letter-spacing: 0.02em; text-transform: uppercase;
+}
+.rd-eyebrow--plain { background: transparent; padding: 0; }
+
+/* ---- Top bar (full width) ---- */
+.rd-topbar {
+  display: flex; align-items: center; gap: 20px;
+  width: 100%; padding: 16px clamp(20px, 4vw, 48px);
+  background-color: var(--rd-nav-shell);
+  border-bottom: 1px solid var(--rd-border);
+  -webkit-backdrop-filter: blur(8px); backdrop-filter: blur(8px);
+}
+.rd-brand { display: inline-flex; align-items: center; gap: 10px; text-decoration: none; }
+.rd-brand__mark {
+  width: 26px; height: 26px; border-radius: 8px; background-color: var(--rd-accent);
+  color: #fff; display: inline-flex; align-items: center; justify-content: center;
+  font-weight: 900; font-size: 0.95rem;
+}
+.rd-brand__name { font-weight: 800; color: var(--rd-ink); font-size: 1rem; }
+/* push nav links + actions to the right edge */
+.rd-topbar__links { display: flex; gap: 4px; margin-left: auto; }
+.rd-topbar__links a {
+  padding: 8px 12px; border-radius: 999px; text-decoration: none;
+  color: var(--rd-text); font-weight: 600; font-size: 0.92rem;
+}
+.rd-topbar__links a:hover { color: var(--rd-ink); background-color: var(--rd-chip); }
+.rd-topbar__actions { display: flex; align-items: center; gap: 8px; }
+.rd-theme-toggle {
+  background: transparent; border: none; cursor: pointer; color: var(--rd-muted);
+  font-size: 1rem; padding: 8px; border-radius: 999px;
+}
+.rd-theme-toggle:hover { color: var(--rd-accent); }
+/* Topbar search (shown on interior pages; suppressed on the homepage hero) */
+.rd-topbar__search { position: relative; flex: 0 1 360px; }
+.rd-topbar__search .search-form {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--rd-chip); border: 1px solid var(--rd-border);
+  border-radius: 999px; padding: 8px 14px;
+}
+.rd-topbar__search .search-input {
+  flex: 1; min-width: 0; border: none; background: transparent; outline: none;
+  color: var(--rd-ink); font-family: var(--font-sans); font-size: 0.9rem;
+}
+.rd-topbar__search .search-input::placeholder { color: var(--rd-muted); }
+.rd-topbar__search .search-results { position: absolute; left: 0; right: 0; top: 48px; z-index: 30; }
+
+/* ---- Hero ---- */
+.rd-hero { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 18px; padding: 32px 0 36px; }
+.rd-hero__title {
+  font-family: var(--font-heading); font-weight: 800;
+  font-size: clamp(2.2rem, 5vw, 3.4rem); line-height: 1.05;
+  color: var(--rd-ink); max-width: 680px; margin: 0; text-wrap: balance;
+}
+.rd-hero__sub { font-size: 1.05rem; line-height: 1.55; color: var(--rd-muted); max-width: 640px; margin: 0; }
+
+/* ---- Search panel ---- */
+.rd-search {
+  width: 100%; max-width: 840px; margin: 0 auto; align-self: center; position: relative;
+  background-color: var(--rd-surface); border: 1px solid var(--rd-border);
+  border-radius: 28px; padding: 16px; display: flex; flex-direction: column; gap: 16px;
+}
+.rd-searchbar {
+  display: flex; align-items: center; gap: 12px; background-color: var(--rd-bg);
+  border: 1px solid var(--rd-border); border-radius: 18px; padding: 14px 16px;
+}
+.rd-searchbar__icon { color: var(--rd-muted); }
+.rd-searchbar__input {
+  flex: 1; border: none; background: transparent; outline: none;
+  font-family: var(--font-sans); font-size: 1rem; color: var(--rd-ink);
+}
+.rd-searchbar__input::placeholder { color: var(--rd-muted); }
+.rd-searchbar__btn { white-space: nowrap; }
+.rd-chips { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; }
+.rd-chip {
+  border: none; cursor: pointer; padding: 8px 14px; border-radius: 999px;
+  background-color: var(--rd-chip); color: var(--rd-chip-text);
+  font-family: var(--font-sans); font-weight: 700; font-size: 0.85rem;
+}
+.rd-chip.is-active { background-color: var(--rd-accent); color: var(--rd-on-accent); }
+.rd-chip:hover { filter: brightness(0.97); }
+.rd-search .search-results { position: absolute; left: 16px; right: 16px; top: 80px; z-index: 20; }
+
+/* ---- Stats ---- */
+.rd-stats { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px 20px; color: var(--rd-muted); font-size: 0.95rem; }
+.rd-stats strong { color: var(--rd-ink); font-weight: 800; }
+
+/* ---- Install callout ---- */
+.rd-install { padding: 18px 0 40px; }
+.rd-install__card {
+  display: flex; flex-wrap: wrap; background-color: var(--rd-surface);
+  border: 1px solid var(--rd-border); border-radius: 28px; overflow: clip;
+}
+.rd-install__copy { flex: 1 1 320px; padding: 34px; display: flex; flex-direction: column; gap: 12px; justify-content: center; }
+.rd-install__title { font-weight: 800; font-size: 1.6rem; color: var(--rd-ink); margin: 0; }
+.rd-install__desc { color: var(--rd-muted); margin: 0; line-height: 1.5; }
+.rd-terminal {
+  flex: 1 1 360px; background-color: var(--rd-terminal); color: var(--rd-terminal-text);
+  padding: 28px; display: flex; flex-direction: column; gap: 14px; align-items: flex-start;
+}
+.rd-terminal__dots { display: flex; gap: 6px; }
+.rd-dot { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
+.rd-dot--r { background: var(--rd-dot-red); }
+.rd-dot--y { background: var(--rd-dot-yellow); }
+.rd-dot--g { background: var(--rd-dot-green); }
+.rd-terminal__cmd {
+  font-family: var(--font-mono); font-size: 0.9rem; line-height: 1.5;
+  color: var(--rd-terminal-text); word-break: break-all;
+  background: transparent; padding: 0; border-radius: 0;
+}
+
+/* ---- Section heads ---- */
+.rd-section { padding: 48px 0; display: flex; flex-direction: column; gap: 26px; }
+.rd-section__head--split { display: flex; justify-content: space-between; align-items: flex-end; gap: 20px; flex-wrap: wrap; }
+.rd-section__head--center { text-align: center; max-width: 720px; margin: 0 auto; display: flex; flex-direction: column; gap: 10px; align-items: center; }
+.rd-section__heading { display: flex; flex-direction: column; gap: 10px; max-width: 640px; align-items: flex-start; }
+.rd-section__head--center .rd-section__title,
+.rd-section__head--center .rd-section__lead { max-width: 640px; }
+.rd-section__title { font-weight: 800; font-size: 1.9rem; color: var(--rd-ink); margin: 0; }
+.rd-section__lead { color: var(--rd-muted); margin: 0; line-height: 1.5; }
+
+/* ---- Grids ---- */
+.rd-grid { display: grid; gap: 16px; }
+.rd-grid--resources { grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); }
+.rd-grid--types { grid-template-columns: repeat(auto-fill, minmax(198px, 1fr)); }
+
+/* ---- Matrix ---- */
+.rd-matrix { background-color: var(--rd-surface); border: 1px solid var(--rd-border); border-radius: 26px; overflow: clip; }
+.rd-matrix__row { display: grid; grid-template-columns: 1.4fr repeat(5, 1fr); }
+.rd-matrix__row--head { background-color: var(--rd-matrix-head); }
+.rd-matrix__row + .rd-matrix__row { border-top: 1px solid var(--rd-border); }
+.rd-matrix__cell { padding: 16px 18px; font-weight: 800; color: var(--rd-ink); font-size: 0.9rem; }
+.rd-matrix__row--head .rd-matrix__cell { color: var(--rd-muted); font-weight: 700; }
+.rd-matrix__cell--label { text-align: left; }
+.rd-matrix__cell--label a { color: var(--rd-ink); text-decoration: none; font-weight: 800; }
+.rd-matrix__cell--label a:hover { color: var(--rd-accent); }
+.rd-matrix__cell a { color: var(--rd-ink); text-decoration: none; }
+.rd-matrix__cell a:hover { color: var(--rd-accent); text-decoration: underline; }
+.rd-matrix__dash { color: var(--rd-muted); opacity: 0.5; }
+
+/* ---- CTA band ---- */
+.rd-cta-wrap { padding: 48px 0 24px; }
+.rd-cta {
+  display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap;
+  background-color: var(--rd-accent); color: #fff; border-radius: 30px; padding: 34px;
+}
+.rd-cta__title { font-weight: 800; font-size: 1.6rem; margin: 0; color: #fff; }
+.rd-cta__desc { margin: 6px 0 0; max-width: 560px; color: rgba(255, 255, 255, 0.92); line-height: 1.5; }
+.rd-cta__actions { display: flex; gap: 10px; flex-wrap: wrap; }
+.rd-cta .rd-btn--filled,
+.rd-cta .rd-btn--outline { background-color: #16242e; color: #fff; border-color: transparent; }
+.rd-cta .rd-btn--filled:hover,
+.rd-cta .rd-btn--outline:hover { background-color: #0b1822; color: #fff; border-color: transparent; }
+
+/* ---- Footer ---- */
+.rd-footer {
+  display: flex; justify-content: space-between; align-items: center; gap: 16px;
+  max-width: 1120px; margin: 0 auto; padding: 24px 28px 40px; color: var(--rd-muted);
+  font-weight: 600; flex-wrap: wrap;
+  background: transparent; border-top: none; text-align: left;
+}
+.rd-footer__links { display: flex; gap: 16px; }
+.rd-footer__links a { color: var(--rd-ink); text-decoration: none; font-weight: 700; }
+.rd-footer__links a:hover { color: var(--rd-accent); }
+
+/* ---- Responsive ---- */
+@media (max-width: 760px) {
+  .rd-topbar__links { display: none; }
+  .rd-searchbar { flex-wrap: wrap; }
+  .rd-searchbar__btn { width: 100%; justify-content: center; }
+  .rd-section__head--split { flex-direction: column; align-items: flex-start; }
+  .rd-matrix { overflow-x: auto; }
+  .rd-matrix__row { grid-template-columns: 1.4fr repeat(5, minmax(64px, 1fr)); min-width: 560px; }
+  .rd-cta { flex-direction: column; align-items: flex-start; }
+}
+
+/* ---- Copy command button: right-aligned in terminal ---- */
+.rd-terminal .rd-copy { align-self: flex-end; }
+
+/* ---- Recently Added carousel (restored Swiper, themed to redesign) ---- */
+.rd-home .recently-added-swiper { width: 100%; position: relative; padding: 4px 0 48px; }
+.rd-home .swiper-slide { display: flex; justify-content: center; align-items: stretch; height: auto; transition: opacity 0.3s ease; }
+.rd-home .recent-item {
+  width: 100%; display: flex; flex-direction: column; gap: 8px;
+  background-color: var(--rd-surface); border: 1px solid var(--rd-border);
+  border-radius: 18px; padding: 20px;
+}
+.rd-home .recent-item h3 { font-size: 1.15rem; margin: 0; }
+.rd-home .recent-item h3 a { color: var(--rd-ink); text-decoration: none; font-weight: 800; }
+.rd-home .recent-item h3 a:hover { color: var(--rd-accent); }
+.rd-home .recent-meta { display: flex; flex-wrap: wrap; gap: 6px; margin: 2px 0; }
+.rd-home .recent-type,
+.rd-home .recent-discipline,
+.rd-home .recent-version {
+  background: var(--rd-chip); color: var(--rd-chip-text);
+  border-radius: 999px; padding: 4px 10px; font-size: 0.72rem; font-weight: 700;
+}
+.rd-home .recent-version { font-family: var(--font-mono); }
+.rd-home .recent-updated {
+  background-color: var(--rd-accent-soft); color: var(--rd-accent);
+  border-radius: 999px; padding: 4px 10px; font-size: 0.72rem; font-weight: 700; text-transform: uppercase;
+}
+.rd-home .recent-desc { color: var(--rd-muted); font-size: 0.95rem; line-height: 1.5; margin: 0; }
+.rd-home .swiper-pagination-bullet-active { background-color: var(--rd-accent); }
+.rd-home .swiper-button-next,
+.rd-home .swiper-button-prev { color: var(--rd-accent); --swiper-navigation-size: 26px; top: 45%; }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -36,6 +36,26 @@
     --font-sans: 'Inter', verdana, sans-serif;
     --font-mono: 'IBM Plex Mono', 'Consolas', 'Liberation Mono', monospace;
     --font-heading: 'Inter', verdana, sans-serif;
+
+    /* Homepage redesign tokens (Framer "Miraculous Motivation") — light. See docs/redesign-spec.md */
+    --rd-bg: #f7f4ef;
+    --rd-surface: #ffffff;
+    --rd-terminal: #0b1822;
+    --rd-terminal-text: #e6edf2;
+    --rd-ink: #16242e;
+    --rd-text: #2c3a44;
+    --rd-muted: #5c6b73;
+    --rd-accent: #f15a3b;
+    --rd-accent-soft: rgba(241, 90, 59, 0.12);
+    --rd-chip: #eceae4;
+    --rd-chip-text: #46535c;
+    --rd-border: rgba(16, 35, 49, 0.10);
+    --rd-nav-shell: rgba(255, 255, 255, 0.72);
+    --rd-matrix-head: #efede7;
+    --rd-on-accent: #ffffff;
+    --rd-dot-red: #ff6a57;
+    --rd-dot-yellow: #ffd15c;
+    --rd-dot-green: #5cdf7b;
 }
 
 /* Dark theme — Lullabot primary-dark palette */
@@ -63,6 +83,23 @@
     --inline-code-text: #e0e6eb;
     --card-hover-shadow: rgba(0, 0, 0, 0.4);
     --card-text: #edf0f2;
+
+    /* Homepage redesign tokens (Framer "Miraculous Motivation") — dark. See docs/redesign-spec.md */
+    --rd-bg: #102331;
+    --rd-surface: #17303e;
+    --rd-terminal: #0b1822;
+    --rd-terminal-text: #e6edf2;
+    --rd-ink: #ffffff;
+    --rd-text: #c7d6df;
+    --rd-muted: #7fa2b3;
+    --rd-accent: #f15a3b;
+    --rd-accent-soft: rgba(241, 90, 59, 0.12);
+    --rd-chip: rgba(178, 209, 223, 0.10);
+    --rd-chip-text: #b2d1df;
+    --rd-border: rgba(178, 209, 223, 0.12);
+    --rd-nav-shell: rgba(23, 48, 62, 0.78);
+    --rd-matrix-head: #0b1822;
+    --rd-on-accent: #ffffff;
 }
 
 /* ===========================

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -88,8 +88,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 const descriptionScore = description.toLowerCase().includes(queryLower) ? 2 : 0;
                 const contentScore = content.toLowerCase().includes(queryLower) ? 1 : 0;
                 const tagScore = tags.some(tag => tag.toLowerCase().includes(queryLower)) ? 2 : 0;
-                
-                const totalScore = titleScore + descriptionScore + contentScore + tagScore;
+
+                // Also match the discipline / content type, normalizing hyphens vs spaces
+                // so a "Content Strategy" filter chip finds content-strategy items.
+                const normalize = (s) => String(s || '').toLowerCase().replace(/[-_\s]+/g, ' ').trim();
+                const normQuery = normalize(query);
+                const disciplineScore = normQuery && normalize(item.discipline).includes(normQuery) ? 2 : 0;
+                const typeScore = normQuery && normalize(item.contentType).includes(normQuery) ? 2 : 0;
+
+                const totalScore = titleScore + descriptionScore + contentScore + tagScore + disciplineScore + typeScore;
                 
                 return {
                     ...item,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -76,6 +76,11 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         const queryLower = query.toLowerCase();
+        // Normalize hyphens vs spaces once per search so a "Content Strategy"
+        // filter chip matches content-strategy items.
+        const normalize = (s) => String(s || '').toLowerCase().replace(/[-_\s]+/g, ' ').trim();
+        const normQuery = normalize(query);
+
         const results = searchIndex
             .map(item => {
                 // Ensure all values are strings before calling toLowerCase()
@@ -89,10 +94,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const contentScore = content.toLowerCase().includes(queryLower) ? 1 : 0;
                 const tagScore = tags.some(tag => tag.toLowerCase().includes(queryLower)) ? 2 : 0;
 
-                // Also match the discipline / content type, normalizing hyphens vs spaces
-                // so a "Content Strategy" filter chip finds content-strategy items.
-                const normalize = (s) => String(s || '').toLowerCase().replace(/[-_\s]+/g, ' ').trim();
-                const normQuery = normalize(query);
+                // Also match the discipline / content type.
                 const disciplineScore = normQuery && normalize(item.discipline).includes(normQuery) ? 2 : 0;
                 const typeScore = normQuery && normalize(item.contentType).includes(normQuery) ? 2 : 0;
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -37,9 +37,13 @@ function toggleTheme() {
 
 // Initialize theme
 function initializeTheme() {
-    // Set initial theme
-    const theme = getColorPreference();
-    setTheme(theme);
+    // Non-persistent theme preview via ?theme=light|dark (handy for previews/screenshots)
+    const override = new URLSearchParams(window.location.search).get('theme');
+    if (override === 'light' || override === 'dark') {
+        reflectTheme(override);
+    } else {
+        setTheme(getColorPreference());
+    }
 
     // Watch for system theme changes
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', ({ matches }) => {

--- a/docs/framer-claude-code-evaluation.md
+++ b/docs/framer-claude-code-evaluation.md
@@ -1,0 +1,181 @@
+# Framer + AI Coding Agents: A Hands-On Evaluation
+
+*An experience report on using Claude Code with a Framer design to reimplement
+it in a real codebase.*
+
+## Executive Summary
+
+We connected an AI coding agent (Claude Code) to a [Framer](https://framer.com)
+redesign of our "Prompt Library" site and tried to read the design well enough
+to rebuild it in our own 11ty/Eleventy codebase. Connecting and authenticating
+was painless on both integration paths we tried, and reading a normal page was
+genuinely excellent — we extracted a complete, accurate design spec. But the
+two paths each had real gaps: Framer's official agent bridge is currently
+blocked by a rendering bug, and the third-party tool that *does* work is
+fragile in specific, predictable ways.
+
+**Bottom line: promising but early-stage. A "design in Framer → implement in
+code" handoff to an AI agent works today if you design with plain layers, model
+things as named components, and keep the right plugin open — but it is not yet
+turnkey.**
+
+### Terms used in this report
+
+- **AI coding agent** — a tool like Claude Code or Cursor that can read your
+  files and project context and write code. Here it reads the Framer design and
+  writes the implementation.
+- **MCP (Model Context Protocol)** — an open standard that lets an AI agent
+  call external tools (here, tools that read a Framer project). "MCP server"
+  means the program exposing those tools.
+- **Replica / variant** — Framer's mechanism for reusing one design across
+  states or screen sizes (e.g. a light-theme copy of a dark design, or a mobile
+  version of a desktop layout). This is where the tooling is weakest.
+
+## What We Were Trying to Do
+
+Take a finished Framer design (a homepage redesign) and have the agent read it
+faithfully — colors, layout, copy, links, component props — so we could rebuild
+it node-for-node in our static-site codebase. We were **not** trying to use
+Framer's own hosting; the goal was design-in-Framer, ship-in-our-stack.
+
+We succeeded. The extracted result lives in
+[`docs/redesign-spec.md`](./redesign-spec.md) — a full 8-section spec with exact
+palette tokens, layout, and component definitions, captured node-for-node. That
+file is the evidence this workflow *can* work. This report explains how we got
+there and where it broke.
+
+## Integration Paths We Tested
+
+We tried three ways to get the design out of Framer and into the agent.
+
+| Path | What it is | Result |
+|---|---|---|
+| **1. Official Framer bridge** (`@framer/agent` CLI + Claude Code skills) | Framer's own first-party tooling for connecting an agent to a project | **Blocked.** Setup and auth worked; every call that renders or serializes the canvas failed with a renderer bug |
+| **2. unframer MCP** (third-party, [open source](https://github.com/remorses/unframer)) | A community MCP server, installed as an in-Framer plugin that tunnels read/write tools to the agent | **Worked.** We read the whole page as XML and reconstructed it — with notable blind spots |
+| **3. Publishing route** (read the live site's HTML/CSS) | Skip the tooling; just read the published web page | **Not viable here.** The design lived on a Framer *design page*, which doesn't publish; staging/production URLs were null |
+
+### Path 1 — Official `@framer/agent` bridge (v0.0.33)
+
+Setup was the smooth part. Three commands and a browser approval:
+
+- `npx @framer/agent setup` — installs the Claude Code skills
+- `npx @framer/agent project auth <url>` — browser-based approval (clean)
+- `npx @framer/agent session new <id>` — starts a local relay server
+
+Lightweight calls worked: `getContext()` and `getNodesOfTypes()` returned node
+lists and counts. But **every call that has to render or serialize the canvas
+failed** with the same error:
+
+```
+Assertion Error: The importMap has to exist on the module
+```
+
+This killed `screenshot`, `serialize`, `getNode`, and even reading a single
+node's `.attributes` or `.text`. In other words, the bridge could enumerate the
+design but could not *read* it.
+
+We tried hard to clear it: destroy and recreate the session, restart the relay
+server, re-authorize, reload the skills/plugins, open the project in Framer's
+browser editor so its modules would load, and a brand-new agent session. **The
+bug persisted in every case.** Our conclusion is that this is a genuine
+renderer bug in `@framer/agent` 0.0.33 for this project — and the version
+number (`0.0.x`) tells you how early this tooling is. For now, the first-party
+bridge was effectively unusable for *reading* a design.
+
+### Path 2 — unframer MCP (the one that worked)
+
+The [unframer](https://github.com/remorses/unframer) MCP server (hosted at
+`mcp.unframer.co`) installs as an in-Framer plugin (Cmd-K → search "MCP"). The
+plugin exposes an HTTP tunnel URL, which we registered with the agent via
+`claude mcp add --transport http`.
+
+This succeeded where the official bridge failed. We read the entire page as XML
+(`getProjectXml`, `getNodeXml`) and reconstructed all 8 sections node-for-node:
+exact colors, layout, copy, links, and component props. Roughly 22 tools are
+available — read project/node/selected-node XML, read and write CMS content,
+read color and text styles, search fonts, create/update/delete/duplicate nodes
+via an XML DSL, and export React.
+
+The XML maps cleanly onto web concepts. Framer expresses layout with familiar,
+CSS-ish ideas — stack/grid layout, `gap`, `padding`, `backgroundColor`,
+`borderRadius` — so translating it into real HTML and CSS was straightforward.
+
+### Path 3 — Publishing route
+
+If the design had been on a publishable web page, we could have skipped the
+tooling and just read the rendered HTML/CSS. But this design lived on a Framer
+**design page** (a canvas surface), which does not publish, so there was no URL
+to read. Worth knowing as a fallback, but it did not apply here.
+
+## What Worked Well
+
+- **Connecting and authenticating** the agent to Framer was quick and painless
+  on *both* paths. No friction here.
+- **Reading a normal page** (plain frames and stacks) via unframer was better
+  than expected — accurate and complete. The extracted spec
+  ([`redesign-spec.md`](./redesign-spec.md)) is the proof.
+- **Components with named props translated beautifully.** Where the design used
+  components ("Resource Card", "Type Card", "Library Button"), each instance
+  exposed its props directly in the XML and mapped 1:1 to code — we turned them
+  into reusable Nunjucks macros. **This is the pattern to recommend.**
+- **Familiar layout model.** Because Framer's layout vocabulary mirrors CSS, an
+  agent that knows CSS can reason about it with little translation loss.
+
+## What Didn't Work
+
+| Issue | Impact |
+|---|---|
+| **Official bridge renderer bug** (`importMap`) | The first-party `@framer/agent` path can enumerate but not read a design. Effectively unusable for reads today |
+| **Tunnel is fragile** | Closing the unframer plugin panel in Framer drops the tunnel — every call then returns "Framer plugin not connected." You must keep the plugin open for the whole session |
+| **Replicas / variants are a blind spot** | `getNodeXml` and `getSelectedNodesXml` return replica/variant nodes self-closed (no children), and `duplicateNode` refuses them ("Cannot set parent of a replica node"). Our light-theme design was built as a replica, so it was *entirely unreadable* — we recovered its colors from an editor screenshot |
+| **Component *definitions* aren't readable** | Calling `getNodeXml` on a component's own node returned "Node is not a text node." We could still read each *instance's* props where it was used, which was enough — but you can't introspect the component itself |
+| **Clean React export is paywalled** | `exportReactComponents` (pitched as "the most interesting tool") returns "No active React Export subscription" and points to a pricing page. It also only exports component nodes, not whole pages |
+
+The replica/variant blind spot deserves emphasis: **variants and replicas are
+exactly how Framer handles responsive breakpoints *and* component states.** So
+the read tooling is weakest precisely where a real, production-grade design is
+richest. Plan around this.
+
+## If You Want to Try This
+
+A concrete setup checklist for a Framer → AI-agent handoff today:
+
+1. **Use the unframer MCP, not the first-party bridge.** Install the unframer
+   plugin in Framer (Cmd-K → "MCP"), then register its tunnel URL with your
+   agent (`claude mcp add --transport http <url>`).
+2. **Keep the unframer plugin panel open** in Framer for the entire session.
+   If you close it, the tunnel drops and every call fails until you reconnect.
+3. **Design with plain layers where you need a clean read.** Frames and stacks
+   read perfectly; replicas/variants do not.
+4. **Model reusable elements as components with clearly named props/controls.**
+   Named props are what survive the trip to code 1:1 — this is the single
+   biggest lever for a clean handoff.
+5. **Detach or flatten any replicas/variants you need read** before handoff —
+   or accept that you'll recover those from a screenshot. (Note the tension:
+   this conflicts with using variants for responsive breakpoints. Decide
+   per-element.)
+6. **Treat colors pulled from screenshots as "within a few shades."** Fine-tune
+   them against a real preview rather than trusting the sampled hex exactly.
+7. **Budget for the React Export subscription** if you want direct design→React
+   from unframer — or evaluate Framer's own native React export separately.
+8. **Report the `importMap` bug to Framer** so the first-party bridge becomes
+   viable.
+
+> **Security note.** The unframer tunnel URL embeds a personal session secret
+> (`?id=…&secret=…`). Treat it like a credential — don't commit it to a repo or
+> paste it into shared channels.
+
+## Readiness Verdict
+
+**Promising, but early-stage and not yet turnkey.**
+
+The first-party bridge is blocked by a real renderer bug. The reliable path is a
+third-party MCP that is tunnel-fragile, blind to replicas and variants, and
+paywalls the clean code export. None of that is a dealbreaker — we got a
+complete, accurate spec out of a real design — but it does mean the workflow
+rewards deliberate design choices rather than working out of the box.
+
+Usable **today** for "read a Framer design and reimplement it in code" *if* you:
+design with plain layers (or detach replicas before handoff), model things as
+named components, and keep the unframer plugin open. As Framer's own agent
+tooling matures past `0.0.x`, expect this to get meaningfully smoother.

--- a/docs/redesign-spec.md
+++ b/docs/redesign-spec.md
@@ -1,0 +1,171 @@
+# Prompt Library — Homepage Redesign Spec
+
+Source of truth for the homepage redesign. Extracted from the Framer project
+**"Miraculous Motivation"** (`8OZqoCrNXFsUHCrgmH3H`), page `/` (node `augiA20Il`),
+plus the design page **"Prompt Library Theme Comparison"** (light + dark versions).
+
+> **How this was captured.** The dark version was read node-for-node via the
+> [unframer](https://github.com/remorses/unframer) MCP (`getProjectXml` /
+> `getNodeXml`). The light version is a Framer *replica/variant* node, which the
+> MCP cannot traverse, so its palette was read from an editor screenshot. Framer's
+> first-party `@framer/agent` bridge could not be used for reads — it fails with
+> `Assertion Error: The importMap has to exist on the module` on every render-path
+> call (`screenshot`, `serialize`, node attributes). See
+> `docs/framer-claude-code-evaluation.md` for the full tooling write-up.
+
+## Goal
+
+Replace the current homepage (plain title + Swiper carousel + "By Type" pills +
+discipline grid) with the Framer redesign: a search-first hero, an install
+callout, a resource-card grid, a type-card grid, a discipline **matrix**, an
+orange contribution CTA, and a footer — all dual-theme (light + dark), keeping
+the existing `theme.js` toggle.
+
+Scope: **homepage only** (`index.njk`). Interior pages keep their current
+templates. Counts are computed **live** from collections (never hardcoded).
+
+## Palette (both themes)
+
+Implemented as `--rd-*` tokens scoped to `:root` (light) and `:root.dark-theme`
+(dark) so the redesign is self-contained and does not restyle interior pages.
+
+| Token | Role | Light | Dark |
+|---|---|---|---|
+| `--rd-bg` | page background | `#F7F4EF` (warm cream) | `#102331` |
+| `--rd-surface` | cards / panels | `#FFFFFF` | `#17303E` |
+| `--rd-terminal` | terminal card (dark in BOTH themes) | `#0B1822` | `#0B1822` |
+| `--rd-terminal-text` | terminal text | `#E6EDF2` | `#E6EDF2` |
+| `--rd-ink` | headings | `#16242E` | `#FFFFFF` |
+| `--rd-text` | body text | `#2C3A44` | `#C7D6DF` |
+| `--rd-muted` | muted / icons | `#5C6B73` | `#7FA2B3` (`rgb(127,162,179)`) |
+| `--rd-accent` | coral accent (same both) | `#F15A3B` | `#F15A3B` |
+| `--rd-accent-soft` | eyebrow / tint | `rgba(241,90,59,0.12)` | `rgba(241,90,59,0.12)` |
+| `--rd-chip` | inactive filter / tag chip | `#ECEAE4` | `rgba(178,209,223,0.10)` |
+| `--rd-chip-text` | chip text | `#46535C` | `#B2D1DF` |
+| `--rd-border` | hairline borders | `rgba(16,35,49,0.10)` | `rgba(178,209,223,0.12)` |
+| `--rd-nav-shell` | nav pill background | `rgba(255,255,255,0.72)` | `rgba(23,48,62,0.78)` |
+| `--rd-matrix-head` | matrix header row | `#EFEDE7` | `#0B1822` |
+| `--rd-on-accent` | text on coral | `#FFFFFF` | `#FFFFFF` |
+| dots | terminal traffic lights | `#FF6A57` / `#FFD15C` / `#5CDF7B` | same |
+
+Fonts: **Inter** (already the site font). Framer weights used: Black, ExtraBold,
+Bold, SemiBold, Medium, Regular.
+
+**Confidence:** dark values + page-bg + the "terminal stays dark / coral is shared"
+decisions are exact. Light ink/muted/chip/header values were read off a 32%-zoom
+screenshot and should be fine-tuned against the Tugboat preview.
+
+## Layout
+
+Single column, centered, `max-width: 1120px`, `28px` horizontal padding. Sections
+top → bottom:
+
+### 1. Navigation (pill)
+Rounded `999px` shell (`--rd-nav-shell`), `space-between`:
+- **Brand** — coral `#F15A3B` rounded square (`8px`) with white "P" (Inter Black) + "Prompt Library" wordmark (Inter ExtraBold).
+- **Links** — Home (`/`), Help (`/help`).
+- **Library Button** "GitHub" (outline) → `https://github.com/Lullabot/prompt_library`.
+
+### 2. Hero (`SearchFirstIntroduction`)
+Centered, `56px` top padding:
+- Eyebrow pill (`--rd-accent-soft`): sparkles icon + "AI workflows, ready to reuse".
+- H1 (Inter ExtraBold): **"Find the right prompt before the work starts."**
+- Subtitle (max 720px): "A searchable library of prompts, rules, agents, skills, and resources for practical AI workflows across project teams."
+- **Search panel** (`--rd-surface`, radius `28px`): search bar (icon + placeholder "Search prompts, rules, agents, skills…" + filled "Search" button → `/#search`) and **filter chips**: `Prompts` (active, coral) · `Skills` · `Agents` · `Development` · `Content Strategy`.
+- **Stats** (Inter ExtraBold): `{N} resources` · `5 content types` · `6 disciplines` — all live.
+
+### 3. Install callout (`InstallSkillsCallout`)
+Two-column card (`--rd-surface`, radius `28px`):
+- **Left** — eyebrow "Claude Code skills bundle", "Install all skills at once.", body "Clone the shared skill bundle into your project and let Claude Code pick up the workflows automatically."
+- **Right** — terminal card (`--rd-terminal`): red/yellow/green dots, `git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills`, "Copy command" button (clipboard).
+
+### 4. Recently Added (`RecentlyAdded`)
+Heading ("Recently Added" eyebrow / "New and updated workflows" / body) + "View all"
+button (→ `/skills/`). Then a **Resource Card grid** (`minmax(300px, 1fr)`), driven
+by `collections.recentlyAdded`. Framer mock cards:
+
+| Title | Type | Discipline | Status |
+|---|---|---|---|
+| Reviewing Skills | Skills | Development | Updated |
+| Broken Link Report | Skills | Quality Assurance | Updated |
+| Drupal Security Review | Skills | Development | Updated |
+| Content Inventory | Skills | Content Strategy | New |
+| Pencil Designer | Skills | Design | v1.0.0 |
+| SEO Expert | Skills | Sales Marketing | New |
+
+Status rule: `lastUpdated` within 30d → "Updated"; `version` set → `v{version}`;
+else if recently created → "New".
+
+### 5. Browse by Type (`BrowseByType`)
+Centered heading ("Browse by Type" / "Choose the shape of help you need" / body) +
+**Type Card grid** (`minmax(198px, 1fr)`). Cards (count = live):
+
+| Type | Mock count | Description |
+|---|---|---|
+| Prompts | 12 | Reusable starting points for repeatable AI tasks. |
+| Rules | 5 | Reusable standards for writing, code quality, and team conventions. |
+| Agents | 8 | Role-based assistants for structured project workflows. |
+| Skills | 19 | Installable workflows for Claude Code and project-specific tasks. |
+| Resources | 2 | Reference links, documentation, and learning material. |
+
+### 6. Browse by Discipline (`BrowseByDiscipline`)
+Heading ("Browse by Discipline" / "A library map for every team" / body) + a
+**6-column matrix** (`--rd-surface`, radius `26px`). Header row (`--rd-matrix-head`):
+`Discipline | Prompts | Rules | Agents | Skills | Resources`. Cells show counts or
+`—`. Framer mock rows (counts illustrative — implementation computes live):
+
+| Discipline | Prompts | Rules | Agents | Skills | Resources |
+|---|---|---|---|---|---|
+| Project Management | 3 | — | 1 | — | — |
+| Development | 5 | 3 | 4 | 9 | 2 |
+| Content Strategy | 1 | 1 | 2 | 5 | — |
+| Design | — | — | — | 2 | — |
+| Quality Assurance | 1 | — | 1 | 3 | — |
+
+> **⚠️ Fidelity note:** the Framer matrix omits **Sales Marketing** (5 rows, but the
+> stats say "6 disciplines" and SEO Expert is Sales Marketing). The implementation
+> **includes all 6 disciplines**.
+
+### 7. Share your knowledge (`ShareYourKnowledge`)
+Orange band (`--rd-accent`, radius `30px`), `space-between`:
+- Copy: "Share your best workflow." / "Submit a prompt, rule, agent, or skill and help the library become more useful for everyone."
+- Buttons: "Submit Prompt" (→ prompt issue template), "Contribute Guide" (→ `/contributing`).
+
+### 8. Footer
+`space-between`: "© {year} Prompt Library" + links GitHub, Help.
+
+## Components → Nunjucks macros
+
+| Framer component | id | Macro | Props |
+|---|---|---|---|
+| Library Button | `m6SKoROEH` | `_lib-button.njk` | label, href, variant (`filled`\|`outline`), newTab |
+| Resource Card | `U4fILFY7M` | `_resource-card.njk` | title, description, typeTag, disciplineTag, status, href |
+| Type Card | `zZ0bGFHll` | `_type-card.njk` | title, count, description, href |
+
+Button variants in Framer: filled = `dmpGepZk0`, outline = `e4iNiqO4b`.
+
+## Data layer (`.eleventy.js`)
+
+Added Nunjucks filters (live counts):
+- `typeCount(contentType)` → items in that content-type collection.
+- `disciplineTypeCount(discipline, contentType)` → items matching both (matrix cells).
+- `sumTypeCounts(types)` → total across a list of types (hero "N resources").
+- `activeDisciplineCount(disciplines, types)` → disciplines with ≥1 item (hero "N disciplines").
+
+Display types: `['prompts','rules','agents','skills','resources']`.
+Disciplines: `['development','project-management','sales-marketing','content-strategy','design','quality-assurance']`.
+
+## Implementation phases
+
+0. **Data layer** — filters above. ✅ (this change)
+1. **Palette + macros** — `--rd-*` tokens, 3 macros, `redesign.css` component styles. ✅ (this change)
+2. **Header/footer** — pill nav + footer links in `base.njk`; drop Swiper CDN.
+3. **Homepage rewrite** — `index.njk`: hero, install callout, resource grid, type grid, discipline matrix, CTA. Remove Swiper.
+4. **JS** — remove Swiper init; wire "Copy command" + filter chips → search (`main.js`).
+5. **Verify** — `npm run build` + `npm start`, both themes, responsive, Tugboat preview.
+
+## Open decisions (resolved)
+- Keep the light/dark toggle (dual-theme). ✅
+- Reuse existing search JS; chips pre-filter. ✅
+- Include all 6 disciplines in the matrix. ✅
+- Compute all counts live. ✅

--- a/index.njk
+++ b/index.njk
@@ -1,17 +1,101 @@
 ---
 title: "Prompt Library"
-description: "A collection of AI prompts, rules, project configurations, and resources organized by discipline."
+description: "A searchable library of prompts, rules, agents, skills, and resources for practical AI workflows across project teams."
 layout: "base.njk"
-hideSearch: false
+hideHeaderSearch: true
+bodyClass: "rd-home"
+needsSwiper: true
 ---
+{% from "_lib-button.njk" import libButton %}
+{% from "_resource-card.njk" import resourceCard %}
+{% from "_type-card.njk" import typeCard %}
 
-<div class="disciplines">
-  <h1 class="page-title"><i class="fas fa-book-open"></i> Prompt Library</h1>
-  <p class="page-description">Explore AI resources organized by discipline and content type.</p>
+{% set displayTypes = ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
+{% set allDisciplines = ['development', 'project-management', 'sales-marketing', 'content-strategy', 'design', 'quality-assurance'] %}
+{% set matrixDisciplines = [
+  { slug: 'project-management', label: 'Project Management' },
+  { slug: 'development', label: 'Development' },
+  { slug: 'content-strategy', label: 'Content Strategy' },
+  { slug: 'design', label: 'Design' },
+  { slug: 'quality-assurance', label: 'Quality Assurance' },
+  { slug: 'sales-marketing', label: 'Sales Marketing' }
+] %}
+{% set typeDescriptions = {
+  prompts: 'Reusable starting points for repeatable AI tasks.',
+  rules: 'Reusable standards for writing, code quality, and team conventions.',
+  agents: 'Role-based assistants for structured project workflows.',
+  skills: 'Installable workflows for Claude Code and project-specific tasks.',
+  resources: 'Reference links, documentation, and learning material.'
+} %}
+{% set totalResources = displayTypes | sumTypeCounts %}
+{% set disciplineCount = allDisciplines | activeDisciplineCount(displayTypes) %}
 
-  <div class="recently-added">
-    <h2 class="recently-added-title">Recently Added</h2>
-    <!-- Swiper -->
+<div class="rd-page">
+
+  {# 2. Hero #}
+  <section class="rd-hero">
+    <span class="rd-eyebrow"><i class="fas fa-wand-magic-sparkles" aria-hidden="true"></i> AI workflows, ready to reuse</span>
+    <h1 class="rd-hero__title">Find the right prompt before the work starts.</h1>
+    <p class="rd-hero__sub">A searchable library of prompts, rules, agents, skills, and resources for practical AI workflows across project teams.</p>
+
+    <div class="rd-search">
+      <form class="rd-searchbar search-form" role="search">
+        <i class="fas fa-search rd-searchbar__icon" aria-hidden="true"></i>
+        <label for="search-input" class="visually-hidden">Search</label>
+        <input type="search" id="search-input" class="search-input rd-searchbar__input"
+               placeholder="Search prompts, rules, agents, skills…" aria-label="Search content">
+        <button type="submit" class="rd-btn rd-btn--filled rd-searchbar__btn">Search <span aria-hidden="true">→</span></button>
+      </form>
+      <div class="rd-chips">
+        <button type="button" class="rd-chip is-active" data-query="prompt">Prompts</button>
+        <button type="button" class="rd-chip" data-query="skill">Skills</button>
+        <button type="button" class="rd-chip" data-query="agent">Agents</button>
+        <button type="button" class="rd-chip" data-query="development">Development</button>
+        <button type="button" class="rd-chip" data-query="content strategy">Content Strategy</button>
+      </div>
+      <div id="search-results" class="search-results" hidden></div>
+    </div>
+
+    <div class="rd-stats">
+      <span><strong>{{ totalResources }}</strong> resources</span>
+      <span><strong>{{ displayTypes | length }}</strong> content types</span>
+      <span><strong>{{ disciplineCount }}</strong> disciplines</span>
+    </div>
+  </section>
+
+  {# 3. Install callout #}
+  <section class="rd-install">
+    <div class="rd-install__card">
+      <div class="rd-install__copy">
+        <span class="rd-eyebrow rd-eyebrow--plain">Claude Code skills bundle</span>
+        <h2 class="rd-install__title">Install all skills at once.</h2>
+        <p class="rd-install__desc">Clone the shared skill bundle into your project and let Claude Code pick up the workflows automatically.</p>
+      </div>
+      <div class="rd-terminal">
+        <div class="rd-terminal__dots" aria-hidden="true">
+          <span class="rd-dot rd-dot--r"></span>
+          <span class="rd-dot rd-dot--y"></span>
+          <span class="rd-dot rd-dot--g"></span>
+        </div>
+        <code class="rd-terminal__cmd">git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills</code>
+        <button type="button" class="rd-btn rd-btn--filled rd-copy"
+                data-copy="git clone https://github.com/Lullabot/lullabot-skills.git .claude/skills">
+          <span class="rd-copy__label">Copy command</span> <span aria-hidden="true">→</span>
+        </button>
+      </div>
+    </div>
+  </section>
+
+  {# 4. Recently Added (carousel) #}
+  <section class="rd-section">
+    <div class="rd-section__head rd-section__head--split">
+      <div class="rd-section__heading">
+        <span class="rd-eyebrow rd-eyebrow--plain">Recently Added</span>
+        <h2 class="rd-section__title">New and updated workflows</h2>
+        <p class="rd-section__lead">The latest prompts, rules, agents, and skills added to the library.</p>
+      </div>
+      {{ libButton("View all", baseUrl + "/skills/", "outline") }}
+    </div>
     <div class="swiper-container recently-added-swiper">
       <div class="swiper-wrapper">
         {% for item in collections.recentlyAdded %}
@@ -19,493 +103,153 @@ hideSearch: false
             <article class="recent-item">
               <h3><a href="{{ item.url | fullUrl }}">{{ item.data.title }}</a></h3>
               <div class="recent-meta">
-                {% if item.data.contentType %}
-                  <span class="recent-type">{{ item.data.contentType | replace('-', ' ') | title }}</span>
-                {% endif %}
-                {% if item.data.discipline %}
-                  <span class="recent-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>
-                {% endif %}
-                {% if item.data.version %}
-                  <span class="recent-version">v{{ item.data.version }}</span>
-                {% endif %}
-                {% if item | isRecentlyUpdated %}
-                  <span class="recent-updated">Updated</span>
-                {% endif %}
+                {% if item.data.contentType %}<span class="recent-type">{{ item.data.contentType | replace('-', ' ') | title }}</span>{% endif %}
+                {% if item.data.discipline %}<span class="recent-discipline">{{ item.data.discipline | replace('-', ' ') | title }}</span>{% endif %}
+                {% if item.data.version %}<span class="recent-version">v{{ item.data.version }}</span>{% endif %}
+                {% if item | isRecentlyUpdated %}<span class="recent-updated">Updated</span>{% endif %}
               </div>
               <p class="recent-desc">{{ item.data.description }}</p>
             </article>
           </div>
         {% endfor %}
       </div>
-      <!-- Add Pagination -->
       <div class="swiper-pagination"></div>
-      <!-- Add Navigation -->
       <div class="swiper-button-next"></div>
       <div class="swiper-button-prev"></div>
     </div>
-  </div>
-  
-  <h2 class="recently-added-title">By Type</h2>
-  <div class="by-type-nav">
-    {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
-      {% set typeCount = collections[type] | length %}
-      {% if typeCount > 0 %}
-      <a href="{{ baseUrl }}/{{ type }}/" class="by-type-link">
-      {% else %}
-      <span class="by-type-link empty" aria-disabled="true">
-      {% endif %}
-        <span class="content-type-icon" aria-hidden="true">
-          {% if type === 'prompts' %}💡
-          {% elif type === 'rules' %}📋
-          {% elif type === 'agents' %}🤖
-          {% elif type === 'skills' %}🛠️
-          {% elif type === 'resources' %}🔗
-          {% endif %}
-        </span>
-        <span class="by-type-label">{{ type | replace('-', ' ') | title }}</span>
-        <span class="by-type-count">{{ typeCount }}</span>
-      {% if typeCount > 0 %}
-      </a>
-      {% else %}
-      </span>
-      {% endif %}
-    {% endfor %}
-  </div>
+  </section>
 
-  {% set compact = true %}
-  {% include "skills-bundle-banner.njk" %}
-
-  <h2 class="recently-added-title">By Discipline</h2>
-  <div class="discipline-grid">
-    
-    {% for discipline in ['project-management', 'development', 'sales-marketing', 'content-strategy', 'design', 'quality-assurance'] %}
-      {% set hasAnyDisciplineContent = false %}
-      {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
-        {% if discipline | hasContent(type) %}
-          {% set hasAnyDisciplineContent = true %}
-        {% endif %}
+  {# 5. Browse by Type #}
+  <section class="rd-section">
+    <div class="rd-section__head rd-section__head--center">
+      <span class="rd-eyebrow rd-eyebrow--plain">Browse by Type</span>
+      <h2 class="rd-section__title">Choose the shape of help you need</h2>
+      <p class="rd-section__lead">Each content type has a different job: starting points, standards, installable workflows, role-based assistants, and reference material.</p>
+    </div>
+    <div class="rd-grid rd-grid--types">
+      {% for t in displayTypes %}
+        {{ typeCard(t | replace('-', ' ') | title, t | typeCount, typeDescriptions[t], baseUrl + "/" + t + "/") }}
       {% endfor %}
+    </div>
+  </section>
 
-      <div class="discipline-card fade-up {% if not hasAnyDisciplineContent %}discipline-empty{% endif %}">
-        <h2>{{ discipline | replace('-', ' ') | title }}</h2>
-        <div class="content-types">
-          {% for type in ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
-            {% set hasTypeContent = discipline | hasContent(type) %}
-            <a href="{{ baseUrl }}/{{ discipline }}/{{ type }}" class="content-type-link {% if not hasTypeContent %}empty{% endif %}">
-              <span class="content-type-icon">
-                {% if type === 'prompts' %}💡
-                {% elif type === 'rules' %}📋
-                {% elif type === 'agents' %}🤖
-                {% elif type === 'skills' %}🛠️
-                {% elif type === 'resources' %}🔗
-                {% endif %}
-              </span>
-              <span class="content-type-label">{{ type | replace('-', ' ') | title }}</span>
-              <span class="content-indicator" aria-label="{% if hasTypeContent %}Contains content{% else %}No content{% endif %}"></span>
-            </a>
+  {# 6. Browse by Discipline (matrix) #}
+  <section class="rd-section">
+    <div class="rd-section__head rd-section__head--split">
+      <div class="rd-section__heading">
+        <span class="rd-eyebrow rd-eyebrow--plain">Browse by Discipline</span>
+        <h2 class="rd-section__title">A library map for every team</h2>
+        <p class="rd-section__lead">A compact matrix so people can scan across teams and resource types quickly.</p>
+      </div>
+    </div>
+    <div class="rd-matrix" role="table" aria-label="Resources by discipline and type">
+      <div class="rd-matrix__row rd-matrix__row--head" role="row">
+        <span class="rd-matrix__cell rd-matrix__cell--label" role="columnheader">Discipline</span>
+        {% for t in displayTypes %}
+          <span class="rd-matrix__cell" role="columnheader">{{ t | replace('-', ' ') | title }}</span>
+        {% endfor %}
+      </div>
+      {% for d in matrixDisciplines %}
+        <div class="rd-matrix__row" role="row">
+          <span class="rd-matrix__cell rd-matrix__cell--label" role="rowheader"><a href="{{ baseUrl }}/{{ d.slug }}/">{{ d.label }}</a></span>
+          {% for t in displayTypes %}
+            {% set n = d.slug | disciplineTypeCount(t) %}
+            <span class="rd-matrix__cell" role="cell">
+              {% if n > 0 %}<a href="{{ baseUrl }}/{{ d.slug }}/{{ t }}/">{{ n }}</a>{% else %}<span class="rd-matrix__dash">—</span>{% endif %}
+            </span>
           {% endfor %}
         </div>
-      </div>
-    {% endfor %}
-  </div>
-
-  <div class="contribute-cta">
-    <h2>Share Your Knowledge</h2>
-    <p>Have a great prompt, cursor rule, or workflow configuration to share? The Prompt Library thrives on community contributions.</p>
-    <div class="submit-links">
-      <a href="https://github.com/Lullabot/prompt_library/issues/new?template=prompt-submission.yml" class="cta-button">Submit a Prompt</a>
-      <a href="https://github.com/Lullabot/prompt_library/issues/new?template=rule-submission.yml" class="cta-button">Submit a Rule</a>
-      <a href="https://github.com/Lullabot/prompt_library/issues/new?template=agent-submission.yml" class="cta-button">Submit an Agent</a>
-      <a href="https://github.com/Lullabot/lullabot-skills/issues/new" class="cta-button">Submit a Skill</a>
+      {% endfor %}
     </div>
-    <a href="{{ baseUrl }}/contributing" class="cta-button secondary">Learn How to Contribute</a>
-  </div>
+  </section>
+
+  {# 7. Share your knowledge #}
+  <section class="rd-cta-wrap">
+    <div class="rd-cta">
+      <div class="rd-cta__copy">
+        <h2 class="rd-cta__title">Share your best workflow.</h2>
+        <p class="rd-cta__desc">Submit a prompt, rule, agent, or skill and help the library become more useful for everyone.</p>
+      </div>
+      <div class="rd-cta__actions">
+        {{ libButton("Submit Prompt", "https://github.com/Lullabot/prompt_library/issues/new?template=prompt-submission.yml", "filled", true) }}
+        {{ libButton("Contribution Guide", baseUrl + "/contributing", "outline") }}
+      </div>
+    </div>
+  </section>
+
 </div>
 
-<style>
-  .disciplines {
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
-  }
+<script>
+  (function () {
+    // Filter chips populate and trigger the search
+    var input = document.getElementById('search-input');
+    document.querySelectorAll('.rd-chip').forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        document.querySelectorAll('.rd-chip').forEach(function (c) { c.classList.remove('is-active'); });
+        chip.classList.add('is-active');
+        if (input) {
+          input.value = chip.dataset.query || chip.textContent.trim();
+          input.dispatchEvent(new Event('input', { bubbles: true }));
+          input.focus();
+        }
+      });
+    });
 
-  .page-title {
-    font-size: 2.5rem;
-    font-weight: 700;
-    color: var(--text-color);
-    margin-bottom: 0.5rem;
-    text-align: center;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.75rem;
-  }
-
-  .page-title i {
-    color: var(--primary-color);
-  }
-
-  .page-description {
-    font-size: 1.25rem;
-    color: var(--text-muted);
-    text-align: center;
-    margin-bottom: 3rem;
-  }
-
-  .by-type-nav {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-    margin-bottom: 3rem;
-  }
-
-  .by-type-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 1.2rem;
-    background-color: var(--card-background);
-    border: 1px solid var(--border-color);
-    border-radius: 2rem;
-    color: var(--text-color);
-    text-decoration: none;
-    font-weight: 500;
-    font-size: 0.95rem;
-    transition: all 0.2s;
-  }
-
-  a.by-type-link:hover,
-  a.by-type-link:focus-visible {
-    border-color: var(--primary-color);
-    background-color: var(--surface-color);
-    transform: translateY(-1px);
-  }
-
-  a.by-type-link:focus-visible {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
-  }
-
-  .by-type-link.empty {
-    opacity: 0.5;
-  }
-
-  .by-type-count {
-    background-color: var(--tag-background);
-    color: var(--text-muted);
-    font-size: 0.75rem;
-    padding: 0.15rem 0.5rem;
-    border-radius: 1rem;
-    font-weight: 600;
-  }
-
-  .discipline-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-    gap: 2rem;
-    margin-bottom: 3rem;
-  }
-
-  .discipline-card {
-    background-color: var(--card-background);
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    padding: 1.5rem;
-    transition: transform 0.2s, box-shadow 0.2s, var(--theme-transition);
-    border: 1px solid var(--border-color);
-  }
-
-  .discipline-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 6px var(--card-hover-shadow);
-  }
-
-  .discipline-card h2 {
-    font-size: 1.5rem;
-    color: var(--text-color);
-    margin-bottom: 1.5rem;
-    padding-bottom: 0.5rem;
-    border-bottom: 2px solid var(--border-color);
-  }
-
-  .content-types {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
-  }
-
-  .content-type-link {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.75rem;
-    background-color: var(--tag-background);
-    border-radius: 0.375rem;
-    color: var(--text-color);
-    text-decoration: none;
-    transition: background-color 0.2s, var(--theme-transition);
-  }
-
-  .content-type-link:hover {
-    background-color: var(--background-color);
-  }
-
-  .content-type-icon {
-    font-size: 1.25rem;
-  }
-
-  .content-type-label {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--text-color);
-  }
-
-  .contribute-cta {
-    background-color: var(--card-background);
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    padding: 2rem;
-    text-align: center;
-    margin-top: 3rem;
-    border: 1px solid var(--border-color);
-  }
-
-  .contribute-cta h2 {
-    font-size: 1.75rem;
-    color: var(--text-color);
-    margin-bottom: 1rem;
-  }
-
-  .contribute-cta p {
-    font-size: 1.1rem;
-    margin-bottom: 1.5rem;
-    max-width: 600px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .submit-links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
-    justify-content: center;
-    margin-bottom: 1.5rem;
-  }
-
-  .cta-button {
-    display: inline-block;
-    background-color: var(--primary-color);
-    color: white;
-    padding: 0.75rem 1.5rem;
-    border-radius: 0.375rem;
-    text-decoration: none;
-    font-weight: 600;
-    transition: background-color 0.2s;
-  }
-
-  .cta-button:hover {
-    background-color: var(--secondary-color);
-  }
-
-  .cta-button.secondary {
-    background: none;
-    color: var(--primary-color);
-    border: 1px solid var(--primary-color);
-  }
-
-  @media (max-width: 640px) {
-    .discipline-grid {
-      grid-template-columns: 1fr;
-    }
-
-    .content-types {
-      grid-template-columns: 1fr;
-    }
-  }
-
-  .recently-added {
-    max-width: 1200px;
-    margin: 0 auto 2rem auto;
-    padding: 2rem 1rem 0 1rem;
-  }
-  .recently-added-title {
-    font-size: 2rem;
-    font-weight: 600;
-    color: var(--primary-color);
-    margin-bottom: 1.5rem;
-    text-align: center;
-  }
-  .recently-added-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-  }
-  .recent-item {
-    background-color: var(--card-background);
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-    padding: 1.25rem 1rem;
-    border: 1px solid var(--border-color);
-    transition: box-shadow 0.2s;
-  }
-  .recent-item h3 {
-    font-size: 1.15rem;
-    margin-bottom: 0.5rem;
-    color: var(--text-color);
-  }
-  .recent-item h3 a {
-    color: inherit;
-    text-decoration: none;
-  }
-  .recent-item h3 a:hover {
-    color: var(--primary-color);
-  }
-  .recent-meta {
-    font-size: 0.9rem;
-    color: var(--text-color);
-    opacity: 0.7;
-    margin-bottom: 0.5rem;
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-  .recent-type, .recent-discipline, .recent-date, .recent-version, .recent-updated {
-    background: var(--tag-background);
-    border-radius: 0.25rem;
-    padding: 0.1rem 0.5rem;
-    margin-right: 0.25rem;
-    font-weight: 500;
-  }
-  .recent-version {
-    font-family: var(--font-mono);
-    font-size: 0.8rem;
-  }
-  .recent-updated {
-    background-color: var(--accent-color);
-    color: #12212b;
-    font-weight: 600;
-    text-transform: uppercase;
-    font-size: 0.7rem;
-    letter-spacing: 0.02em;
-  }
-  .recent-desc {
-    color: var(--text-color);
-    opacity: 0.85;
-    font-size: 1rem;
-    margin-bottom: 0;
-  }
-
-  /* Swiper Styles */
-  .recently-added-swiper {
-    width: 100%;
-    position: relative; /* Ensure positioning context for arrows */
-    padding-top: 20px; /* Space for pagination */
-    padding-bottom: 50px; /* Space for pagination and nav buttons */
-  }
-  .swiper-slide {
-    display: flex;
-    justify-content: center;
-    align-items: stretch; /* Make slides same height */
-    height: auto; /* Allow slides to determine height based on content */
-    transition: opacity 0.3s ease; /* For smooth fading */
-  }
-  .swiper-slide .recent-item {
-    width: 100%; /* Make recent-item fill the slide */
-    display: flex;
-    flex-direction: column; /* Ensure content within card stacks vertically */
-    justify-content: flex-start; /* Align content to top */
-  }
-  .swiper-pagination-bullet-active {
-    background-color: var(--primary-color);
-  }
-  .swiper-button-next, .swiper-button-prev {
-    color: var(--primary-color);
-    --swiper-navigation-size: 30px;
-    --swiper-navigation-sides-offset: 0px;
-    top: 50%;
-    transform: translateY(-50%);
-  }
-  .swiper-button-prev {
-    left: -20px !important;
-  }
-  .swiper-button-next {
-    right: -20px !important;
-  }
-  .swiper-button-next:after, .swiper-button-prev:after {
-    font-size: var(--swiper-navigation-size);
-  }
-</style>
+    // Copy command button
+    document.querySelectorAll('.rd-copy').forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var text = btn.getAttribute('data-copy') || '';
+        var label = btn.querySelector('.rd-copy__label');
+        var prev = label ? label.textContent : '';
+        var done = function () {
+          if (label) { label.textContent = 'Copied'; }
+          btn.classList.add('is-copied');
+          setTimeout(function () { if (label) { label.textContent = prev; } btn.classList.remove('is-copied'); }, 1600);
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(text).then(done).catch(function () {});
+        }
+      });
+    });
+  })();
+</script>
 
 <script>
-  function initRecentlyAddedSwiper() {
-    var swiper = new Swiper('.recently-added-swiper', {
-      watchSlidesProgress: true, // Needed for progress-based effects
-      slidesPerView: 1, // Base: 1 slide for small screens
-      spaceBetween: 20,
-      centeredSlides: true, // Center single slide on small screens
-      loop: true, // Optional: enable continuous loop
-      pagination: {
-        el: '.swiper-pagination',
-        clickable: true,
-      },
-      navigation: {
-        nextEl: '.swiper-button-next',
-        prevEl: '.swiper-button-prev',
-      },
-      breakpoints: {
-        640: {
-          slidesPerView: 2,
-          spaceBetween: 20,
-          centeredSlides: false 
-        },
-        960: {
-          slidesPerView: 3,
-          spaceBetween: 30,
-          centeredSlides: true 
+  // Recently Added carousel (Swiper) — waits until the Swiper lib has loaded
+  (function () {
+    var IDLE_MS = 30000; // resume autoplay after this long without interaction
+    function initRecentlyAddedSwiper() {
+      var idleTimer = null;
+      var swiper = new Swiper('.recently-added-swiper', {
+        slidesPerView: 1,
+        spaceBetween: 20,
+        loop: true,
+        loopAdditionalSlides: 5,
+        watchSlidesProgress: true,
+        autoplay: { delay: 5000, disableOnInteraction: false },
+        pagination: { el: '.swiper-pagination', clickable: true, dynamicBullets: true },
+        navigation: { nextEl: '.swiper-button-next', prevEl: '.swiper-button-prev' },
+        breakpoints: {
+          640: { slidesPerView: 2, spaceBetween: 20 },
+          960: { slidesPerView: 3, spaceBetween: 24 }
         }
-      },
-      on: {
-        progress: function (swiperInstance) {
-          const slides = swiperInstance.slides;
-          const slidesPerView = swiperInstance.params.slidesPerView;
-          // Threshold for fading: beyond half the number of visible slides from the center
-          // For 3 slides, center is 0, edges are approx +/-1. Anything beyond +/-1.5 (approx) should fade.
-          // A simpler way for centered slides: progress absolute value > (slidesPerView -1) / 2 roughly
-          // Let's use a threshold like 1.2 for 3 slides, 0.7 for 2 slides, 0.2 for 1 slide
-          let fadeThreshold = 0.2; // For 1 slide view
-          if (slidesPerView === 2) fadeThreshold = 0.7;
-          if (slidesPerView >= 3) fadeThreshold = 1.2; 
+      });
 
-          for (let i = 0; i < slides.length; i++) {
-            const slideProgress = slides[i].progress;
-            const absProgress = Math.abs(slideProgress);
-            if (absProgress > fadeThreshold) {
-              slides[i].style.opacity = 0.3; // Faded
-            } else {
-              slides[i].style.opacity = 1; // Fully visible
-            }
-          }
-        },
-        transitionEnd: function(swiperInstance){
-          // Trigger progress update to re-apply opacities after transition
-          swiperInstance.emit('progress', swiperInstance.progress);
-        },
-        // Also call on init to set initial opacities
-        init: function(swiperInstance){
-            swiperInstance.emit('progress', swiperInstance.progress);
-        }
+      // Pause autoplay on any interaction; resume after 30s of inactivity.
+      function onInteract() {
+        if (swiper.autoplay) { swiper.autoplay.stop(); }
+        if (idleTimer) { clearTimeout(idleTimer); }
+        idleTimer = setTimeout(function () {
+          if (swiper.autoplay) { swiper.autoplay.start(); }
+        }, IDLE_MS);
       }
-    });
-  }
-
-  function checkSwiperAndInit() {
-    if (typeof Swiper !== 'undefined') {
-      initRecentlyAddedSwiper();
-    } else {
-      requestAnimationFrame(checkSwiperAndInit);
+      swiper.el.addEventListener('pointerdown', onInteract, { passive: true });
+      swiper.el.addEventListener('keydown', onInteract);
     }
-  }
-  requestAnimationFrame(checkSwiperAndInit);
-</script> 
+    function checkSwiperAndInit() {
+      if (typeof Swiper !== 'undefined') { initRecentlyAddedSwiper(); }
+      else { requestAnimationFrame(checkSwiperAndInit); }
+    }
+    requestAnimationFrame(checkSwiperAndInit);
+  })();
+</script>

--- a/index.njk
+++ b/index.njk
@@ -7,7 +7,6 @@ bodyClass: "rd-home"
 needsSwiper: true
 ---
 {% from "_lib-button.njk" import libButton %}
-{% from "_resource-card.njk" import resourceCard %}
 {% from "_type-card.njk" import typeCard %}
 
 {% set displayTypes = ['prompts', 'rules', 'agents', 'skills', 'resources'] %}
@@ -18,7 +17,7 @@ needsSwiper: true
   { slug: 'content-strategy', label: 'Content Strategy' },
   { slug: 'design', label: 'Design' },
   { slug: 'quality-assurance', label: 'Quality Assurance' },
-  { slug: 'sales-marketing', label: 'Sales Marketing' }
+  { slug: 'sales-marketing', label: 'Sales & Marketing' }
 ] %}
 {% set typeDescriptions = {
   prompts: 'Reusable starting points for repeatable AI tasks.',
@@ -206,8 +205,33 @@ needsSwiper: true
           btn.classList.add('is-copied');
           setTimeout(function () { if (label) { label.textContent = prev; } btn.classList.remove('is-copied'); }, 1600);
         };
+        var fail = function () {
+          if (label) { label.textContent = 'Copy failed'; }
+          btn.classList.add('is-copy-failed');
+          setTimeout(function () { if (label) { label.textContent = prev; } btn.classList.remove('is-copy-failed'); }, 1600);
+        };
+        var fallbackCopy = function () {
+          try {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'absolute';
+            ta.style.left = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            var ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            return ok;
+          } catch (e) { return false; }
+        };
         if (navigator.clipboard && navigator.clipboard.writeText) {
-          navigator.clipboard.writeText(text).then(done).catch(function () {});
+          navigator.clipboard.writeText(text).then(done).catch(function () {
+            if (fallbackCopy()) { done(); } else { fail(); }
+          });
+        } else if (fallbackCopy()) {
+          done();
+        } else {
+          fail();
         }
       });
     });

--- a/quality-assurance/index.njk
+++ b/quality-assurance/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Quality Assurance"
+description: "Resources and tools for quality assurance and testing, including AI prompts, rules, agents, and skills."
+layout: "discipline.njk"
+---
+
+<p><a href="/quality-assurance/skills/">Browse Quality Assurance Resources &rarr;</a></p>

--- a/quality-assurance/index.njk
+++ b/quality-assurance/index.njk
@@ -4,4 +4,4 @@ description: "Resources and tools for quality assurance and testing, including A
 layout: "discipline.njk"
 ---
 
-<p><a href="/quality-assurance/skills/">Browse Quality Assurance Resources &rarr;</a></p>
+<p><a href="{{ baseUrl }}/quality-assurance/skills/">Browse Quality Assurance Resources &rarr;</a></p>


### PR DESCRIPTION
Implements the Framer **"Miraculous Motivation"** redesign of the homepage, extracted from the Framer canvas via the [unframer](https://github.com/remorses/unframer) MCP. Full spec in `docs/redesign-spec.md`.

## Homepage (`index.njk`)
- **Search-first hero** — eyebrow, headline, centered search panel with live filter chips and **live stats** (resources / content types / disciplines)
- **Install callout** — dark terminal card + working "Copy command"
- **Recently Added carousel** — Swiper; autoplay every 5s, pauses on interaction, resumes after 30s idle; seamless infinite loop + dynamic pagination
- **Browse by Type** cards (live counts) and a **clickable discipline matrix**
- Orange **contribution CTA** + footer

## Chrome (`_layouts/base.njk`)
- Universal full-width **top bar** across all templates: new terminal-prompt logo, search on interior pages (hero search on home), GitHub button, theme toggle
- Content-aligned **footer**

## Theming
- Redesign palette as `--rd-*` tokens scoped to light (`:root`) and dark (`:root.dark-theme`); keeps the existing light/dark toggle
- Adds a non-persistent `?theme=light|dark` preview override

## Data (`.eleventy.js`)
- `typeCount` / `disciplineTypeCount` / `sumTypeCounts` / `activeDisciplineCount` filters for live counts
- `recentlyAdded` now excludes untitled skill-resource files

## Also
- Created the missing `/quality-assurance/` landing page
- Search now matches discipline/content-type so the category chips work
- `docs/` adds the design spec and a Framer + Claude Code tooling evaluation (for the design team)

## Notes
- Scope is the **homepage + shared chrome**; interior page *content* still uses existing styling (a larger follow-up if desired).
- Light palette values were read from a screenshot of the Framer light version; fine-tune against the Tugboat preview if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)