### PR TITLE
Fix broken discipline nav paths + add link regression tests

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -185,6 +185,20 @@ module.exports = function(eleventyConfig) {
     return parts.length > 1 ? parts[1] : '';
   });
 
+  // Extract discipline from URL path (e.g. /development/resources/ -> development)
+  // Strips baseUrl prefix first so it works on GitHub Pages (/prompt_library/...).
+  // Used as a defensive fallback in discipline.njk when the page omits the
+  // `discipline` frontmatter (which otherwise yields broken `//` nav links).
+  eleventyConfig.addFilter("disciplineFromUrl", function(url) {
+    if (!url || typeof url !== 'string') return '';
+    let normalizedUrl = url;
+    if (baseUrl && normalizedUrl.startsWith(baseUrl)) {
+      normalizedUrl = normalizedUrl.slice(baseUrl.length);
+    }
+    const parts = normalizedUrl.replace(/^\//, '').split('/').filter(Boolean);
+    return parts.length > 0 ? parts[0] : '';
+  });
+
   // Add URL filter that includes base URL
   eleventyConfig.addFilter("fullUrl", function(url) {
     if (url.startsWith(baseUrl)) {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # Runs unit tests + the end-to-end link checks (scripts/links.test.js),
+      # which build the site with the production baseUrl and fail on broken
+      # paths (double slashes, missing /prompt_library prefix, dead links).
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build
 

--- a/_layouts/discipline.njk
+++ b/_layouts/discipline.njk
@@ -2,13 +2,16 @@
 layout: base.njk
 ---
 
+{# Fall back to deriving the discipline from the URL so a page that forgets the
+   `discipline` frontmatter doesn't produce broken `//<type>` nav links. #}
+{% set disc = discipline or (page.url | disciplineFromUrl) %}
 <nav class="discipline-nav">
-    <span class="discipline-name">{{ discipline | replace("-", " ") | title }} : </span>
-    <a href="{{ baseUrl }}/{{ discipline }}/prompts">Prompts</a>
-    <a href="{{ baseUrl }}/{{ discipline }}/rules">Rules</a>
-    <a href="{{ baseUrl }}/{{ discipline }}/project-configs">Project Configs</a>
-    <a href="{{ baseUrl }}/{{ discipline }}/resources">Resources</a>
-    <a href="{{ baseUrl }}/{{ discipline }}/agents">Agents</a>
+    <span class="discipline-name">{{ disc | replace("-", " ") | title }} : </span>
+    <a href="{{ baseUrl }}/{{ disc }}/prompts">Prompts</a>
+    <a href="{{ baseUrl }}/{{ disc }}/rules">Rules</a>
+    <a href="{{ baseUrl }}/{{ disc }}/project-configs">Project Configs</a>
+    <a href="{{ baseUrl }}/{{ disc }}/resources">Resources</a>
+    <a href="{{ baseUrl }}/{{ disc }}/agents">Agents</a>
 </nav>
 
 {{ content | safe }} 

--- a/content-strategy/index.njk
+++ b/content-strategy/index.njk
@@ -2,4 +2,5 @@
 title: "Content Strategy"
 description: "Resources and tools for content strategy, including AI prompts, rules, project configurations, and workflow states."
 layout: "discipline.njk"
+discipline: "content-strategy"
 --- 

--- a/content-strategy/resources/index.njk
+++ b/content-strategy/resources/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Content Strategy Resources"
+description: "Curated external resources, guides, and documentation for content strategy."
+layout: "content-type.njk"
+discipline: "content-strategy"
+contentType: "resources"
+---

--- a/design/index.njk
+++ b/design/index.njk
@@ -2,4 +2,5 @@
 title: "Design"
 description: "Resources and tools for design, including AI prompts, rules, project configurations, and workflow states."
 layout: "discipline.njk"
+discipline: "design"
 --- 

--- a/design/resources/index.njk
+++ b/design/resources/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Design Resources"
+description: "Curated external resources, guides, and documentation for design."
+layout: "content-type.njk"
+discipline: "design"
+contentType: "resources"
+---

--- a/development/index.njk
+++ b/development/index.njk
@@ -2,6 +2,7 @@
 title: "Development"
 description: "Resources and tools for software development, including AI prompts, rules, project configurations, and workflow states."
 layout: "discipline.njk"
+discipline: "development"
 ---
 
-<p><a href="/development/resources/">Browse Development Resources &rarr;</a></p> 
+<p><a href="{{ baseUrl }}/development/resources/">Browse Development Resources &rarr;</a></p> 

--- a/project-management/index.njk
+++ b/project-management/index.njk
@@ -2,4 +2,5 @@
 title: "Project Management"
 description: "Resources and tools for project management, including AI prompts, rules, project configurations, and workflow states."
 layout: "discipline.njk"
+discipline: "project-management"
 --- 

--- a/project-management/resources/index.njk
+++ b/project-management/resources/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Project Management Resources"
+description: "Curated external resources, guides, and documentation for project management."
+layout: "content-type.njk"
+discipline: "project-management"
+contentType: "resources"
+---

--- a/quality-assurance/index.njk
+++ b/quality-assurance/index.njk
@@ -2,6 +2,7 @@
 title: "Quality Assurance"
 description: "Resources and tools for quality assurance and testing, including AI prompts, rules, agents, and skills."
 layout: "discipline.njk"
+discipline: "quality-assurance"
 ---
 
 <p><a href="{{ baseUrl }}/quality-assurance/skills/">Browse Quality Assurance Resources &rarr;</a></p>

--- a/quality-assurance/resources/index.njk
+++ b/quality-assurance/resources/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Quality Assurance Resources"
+description: "Curated external resources, guides, and documentation for quality assurance and testing."
+layout: "content-type.njk"
+discipline: "quality-assurance"
+contentType: "resources"
+---

--- a/sales-marketing/index.njk
+++ b/sales-marketing/index.njk
@@ -2,4 +2,5 @@
 title: "Sales & Marketing"
 description: "Resources and tools for sales and marketing, including AI prompts, rules, project configurations, and workflow states."
 layout: "discipline.njk"
+discipline: "sales-marketing"
 --- 

--- a/sales-marketing/resources/index.njk
+++ b/sales-marketing/resources/index.njk
@@ -1,0 +1,7 @@
+---
+title: "Sales & Marketing Resources"
+description: "Curated external resources, guides, and documentation for sales and marketing."
+layout: "content-type.njk"
+discipline: "sales-marketing"
+contentType: "resources"
+---

--- a/scripts/generate-skill-pages.test.js
+++ b/scripts/generate-skill-pages.test.js
@@ -18,8 +18,9 @@ function vendorAvailable() {
   return fs.existsSync(path.join(VENDOR_DIR, 'cloudflare-tunnel', 'SKILL.md'));
 }
 
-test('VALID_DISCIPLINES contains the six disciplines', () => {
-  assert.equal(VALID_DISCIPLINES.size, 6);
+test('VALID_DISCIPLINES contains the seven disciplines', () => {
+  assert.equal(VALID_DISCIPLINES.size, 7);
+  assert.ok(VALID_DISCIPLINES.has('admin'));
   assert.ok(VALID_DISCIPLINES.has('development'));
   assert.ok(VALID_DISCIPLINES.has('content-strategy'));
   assert.ok(VALID_DISCIPLINES.has('design'));
@@ -136,12 +137,12 @@ test('readSkill resolves the first supported discipline in declared order', () =
 test('readSkill rejects a list with no supported discipline', () => {
   const { vendorDir, cleanup } = makeFixture({
     'SKILL.md': '---\nname: bad-skill\ndescription: x\n---\n# x\n',
-    'meta.yml': 'title: Bad\ndiscipline:\n  - security\n  - admin\ndate: "2025-01-01"\n',
+    'meta.yml': 'title: Bad\ndiscipline:\n  - security\n  - ops\ndate: "2025-01-01"\n',
   });
   try {
     assert.throws(
       () => readSkill('bad-skill', vendorDir),
-      (err) => err instanceof GenerateSkillsError && /No supported discipline.*"security", "admin"/.test(err.message)
+      (err) => err instanceof GenerateSkillsError && /No supported discipline.*"security", "ops"/.test(err.message)
     );
   } finally {
     cleanup();

--- a/scripts/links.test.js
+++ b/scripts/links.test.js
@@ -23,21 +23,35 @@ const BASE_URL = '/prompt_library';
 let built = false;
 let buildError = null;
 
+// npm is `npm.cmd` on Windows; pick the right executable so `npm test` works cross-platform.
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
 function build() {
   if (built) return;
   try {
     // Start from a clean output so stale artifacts from removed pages (Eleventy
     // does not prune _site between builds) can't mask or fake link results.
     fs.rmSync(SITE, { recursive: true, force: true });
-    execFileSync('npm', ['run', 'build'], {
+    execFileSync(NPM, ['run', 'build'], {
       cwd: ROOT,
       env: { ...process.env, GITHUB_ACTIONS: '1' },
       stdio: 'pipe',
     });
     built = true;
   } catch (e) {
-    buildError = e;
+    // With stdio:'pipe' the build output is captured on the error — surface it so
+    // CI failures are actionable instead of just "Command failed".
+    const details = [e.message, e.stdout && e.stdout.toString(), e.stderr && e.stderr.toString()]
+      .filter(Boolean).join('\n');
+    buildError = new Error(details);
   }
+}
+
+// Guard used by every link test: fail fast with the build error instead of
+// letting collectLinks() throw confusing secondary errors on a missing _site.
+function ensureBuilt() {
+  build();
+  assert.equal(buildError, null, `Eleventy build failed:\n${buildError && buildError.message}`);
 }
 
 function htmlFiles(dir) {
@@ -78,13 +92,12 @@ function collectLinks() {
 }
 
 test('site builds for link checking', () => {
-  build();
-  assert.equal(buildError, null, `Eleventy build failed: ${buildError && buildError.message}`);
+  ensureBuilt();
   assert.ok(fs.existsSync(path.join(SITE, 'index.html')), '_site/index.html should exist after build');
 });
 
 test('no internal link contains a double slash', () => {
-  build();
+  ensureBuilt();
   const offenders = collectLinks().filter(({ value }) =>
     value.startsWith('/') && !value.startsWith('//') && value.includes('//')
   );
@@ -95,7 +108,7 @@ test('no internal link contains a double slash', () => {
 });
 
 test('internal links that resolve to a real page carry the baseUrl prefix', () => {
-  build();
+  ensureBuilt();
   // A root-relative link that does NOT start with baseUrl but DOES resolve to a
   // built file is a missing-prefix bug. Content examples (e.g. /category) don't
   // resolve, so they're correctly ignored.
@@ -113,7 +126,7 @@ test('internal links that resolve to a real page carry the baseUrl prefix', () =
 });
 
 test('baseUrl-prefixed internal links point at real files (no dead links)', () => {
-  build();
+  ensureBuilt();
   const offenders = collectLinks().filter(({ value }) => {
     if (!value.startsWith(BASE_URL + '/') && value !== BASE_URL) return false;
     const sitePath = value.slice(BASE_URL.length) || '/';

--- a/scripts/links.test.js
+++ b/scripts/links.test.js
@@ -1,0 +1,126 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+// End-to-end link checks over the BUILT site. These guard against the broken
+// paths reported in production:
+//   - double-slash links  (e.g. /prompt_library//project-configs)
+//   - internal links missing the GitHub Pages baseUrl prefix
+//     (e.g. /development/resources/ instead of /prompt_library/development/resources/)
+//   - links that point at pages/files that don't exist (dead internal links)
+//
+// The site is built with GITHUB_ACTIONS=1 (so baseUrl = /prompt_library), which
+// mirrors the deployed environment where these bugs appear. We build into the
+// real `_site` output because the zip + search-index after-hooks write there
+// directly (they don't honor a custom --output), so everything stays co-located.
+
+const ROOT = path.resolve(__dirname, '..');
+const SITE = path.join(ROOT, '_site');
+const BASE_URL = '/prompt_library';
+
+let built = false;
+let buildError = null;
+
+function build() {
+  if (built) return;
+  try {
+    // Start from a clean output so stale artifacts from removed pages (Eleventy
+    // does not prune _site between builds) can't mask or fake link results.
+    fs.rmSync(SITE, { recursive: true, force: true });
+    execFileSync('npm', ['run', 'build'], {
+      cwd: ROOT,
+      env: { ...process.env, GITHUB_ACTIONS: '1' },
+      stdio: 'pipe',
+    });
+    built = true;
+  } catch (e) {
+    buildError = e;
+  }
+}
+
+function htmlFiles(dir) {
+  const out = [];
+  (function walk(d) {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) walk(full);
+      else if (e.name.endsWith('.html')) out.push(full);
+    }
+  })(dir);
+  return out;
+}
+
+// Resolve a site-absolute path (baseUrl already stripped) to a file in _site.
+function resolvesToFile(sitePath) {
+  const clean = sitePath.split('#')[0].split('?')[0];
+  let candidates;
+  if (clean.endsWith('/')) candidates = [clean + 'index.html'];
+  else if (path.extname(clean)) candidates = [clean];
+  else candidates = [clean + '.html', clean + '/index.html'];
+  return candidates.some((c) => fs.existsSync(path.join(SITE, '.' + c)));
+}
+
+let _links = null;
+function collectLinks() {
+  if (_links) return _links;
+  const linkRe = /(?:href|src)="([^"]*)"/g;
+  const links = [];
+  for (const file of htmlFiles(SITE)) {
+    const rel = path.relative(SITE, file);
+    const html = fs.readFileSync(file, 'utf8');
+    let m;
+    while ((m = linkRe.exec(html)) !== null) links.push({ file: rel, value: m[1] });
+  }
+  _links = links;
+  return links;
+}
+
+test('site builds for link checking', () => {
+  build();
+  assert.equal(buildError, null, `Eleventy build failed: ${buildError && buildError.message}`);
+  assert.ok(fs.existsSync(path.join(SITE, 'index.html')), '_site/index.html should exist after build');
+});
+
+test('no internal link contains a double slash', () => {
+  build();
+  const offenders = collectLinks().filter(({ value }) =>
+    value.startsWith('/') && !value.startsWith('//') && value.includes('//')
+  );
+  assert.deepEqual(
+    offenders, [],
+    `Double-slash links found:\n${offenders.map((o) => `  ${o.file}: ${o.value}`).join('\n')}`
+  );
+});
+
+test('internal links that resolve to a real page carry the baseUrl prefix', () => {
+  build();
+  // A root-relative link that does NOT start with baseUrl but DOES resolve to a
+  // built file is a missing-prefix bug. Content examples (e.g. /category) don't
+  // resolve, so they're correctly ignored.
+  const offenders = collectLinks().filter(({ value }) =>
+    value.startsWith('/') &&
+    !value.startsWith('//') &&
+    !value.startsWith(BASE_URL + '/') &&
+    value !== BASE_URL &&
+    resolvesToFile(value)
+  );
+  assert.deepEqual(
+    offenders, [],
+    `Internal links missing the "${BASE_URL}" prefix:\n${offenders.map((o) => `  ${o.file}: ${o.value}`).join('\n')}`
+  );
+});
+
+test('baseUrl-prefixed internal links point at real files (no dead links)', () => {
+  build();
+  const offenders = collectLinks().filter(({ value }) => {
+    if (!value.startsWith(BASE_URL + '/') && value !== BASE_URL) return false;
+    const sitePath = value.slice(BASE_URL.length) || '/';
+    return !resolvesToFile(sitePath);
+  });
+  assert.deepEqual(
+    offenders, [],
+    `Dead internal links (target not found in build):\n${offenders.map((o) => `  ${o.file}: ${o.value}`).join('\n')}`
+  );
+});


### PR DESCRIPTION
Fixes the broken paths David reported:
- `https://lullabot.github.io/prompt_library//project-configs` (double slash)
- `https://lullabot.github.io/development/resources/` (missing `/prompt_library` prefix)

## Root causes
1. **Double slash** — the 6 discipline index pages set `layout: discipline.njk` but never set a `discipline` frontmatter value, so `discipline.njk` rendered `{{ baseUrl }}//<type>` for every nav link.
2. **Missing baseUrl prefix** — `development/index.njk` hard-coded `href="/development/resources/"` without `{{ baseUrl }}`.
3. **Dead nav links (found while investigating)** — the discipline nav links to a *Resources* page for every discipline, but `resources/index.njk` only existed for `development`. The other 5 disciplines' "Resources" link 404'd.

## Fixes
- Added explicit `discipline:` frontmatter to all 6 discipline index pages.
- Added a **defensive fallback** in `discipline.njk`: it now derives the discipline from the page URL (new `disciplineFromUrl` filter) if frontmatter is missing — so this can't silently regress.
- `development/index.njk` now uses `{{ baseUrl }}`.
- Created the 5 missing `<discipline>/resources/index.njk` pages.

## Tests + CI (the "make sure we remediate" part)
- **New `scripts/links.test.js`** — builds the site with the production baseUrl (`GITHUB_ACTIONS=1`) and asserts:
  - no internal link contains a double slash,
  - any internal link that resolves to a real page carries the `/prompt_library` prefix,
  - every baseUrl-prefixed link points at a real file (no dead links).
  These fail on all three bug classes above.
- **`deploy.yml` now runs `npm test` before build/deploy**, so broken paths fail the pipeline instead of shipping. (CI previously only ran install → build.)
- Fixed two stale `generate-skill-pages` test assertions (unrelated pre-existing red: `VALID_DISCIPLINES` gained `admin` → now 7; the "unsupported discipline" fixture used `admin`, switched to `ops`).

All tests pass locally (`npm test`, exit 0). Verified the built output has zero double-slash and zero unprefixed internal links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)